### PR TITLE
Add instruction to backup and restore vagrant dns settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,15 @@ cd govuk-docker
 make
 ```
 
-Then create or append to the following and restart dnsmasq.
+If you have been using the vagrant based dev vm, take a backup
+of  `/etc/resolver/dev.gov.uk`.
+
+```
+cp /etc/resolver/dev.gov.uk ~/dev.gov.uk
+```
+
+Then create or append to the following and restart dnsmasq. If you've been using
+the vagrant based dev vm, you'll need to replace `/etc/resolver/dev.gov.uk`..
 
 ```
 # /etc/resolver/dev.gov.uk


### PR DESCRIPTION
We want to replace /etc/resolver/dev.gov.uk so we have nice web
addresses during docker based development. However, some users might
want or need to use vagrant while we polish the docker based development
environment.

These instructions help by making a backup of the vagrant based dns
settings.

[Trello](https://trello.com/c/wyd77Pfc/18-document-how-to-switch-back-devgovuk-to-vm-or-use-another-domain-for-container)