### PR TITLE
Test docker-compose files on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: minimal
+
+env:
+  - DOCKER_COMPOSE_VERSION=1.23.2
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+script:
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -19,14 +19,15 @@ pull:
 	done
 
 build:
-	govuk-docker build
+	bin/govuk-docker build
 
 setup:
 	for repo in $(REPOS); do \
 		make -f $$repo/Makefile; \
 	done
-	govuk-docker run whitehall-e2e rake taxonomy:populate_end_to_end_test_data
+	bin/govuk-docker run whitehall-e2e rake taxonomy:populate_end_to_end_test_data
 
 clean:
-	govuk-docker stop
-	govuk-docker prune
+	bin/govuk-docker stop
+	bin/govuk-docker prune
+

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,7 @@ clean:
 	bin/govuk-docker stop
 	bin/govuk-docker prune
 
+test:
+	# Test that the docker-compose config is valid. This will error if there are errors
+	# in the YAML files, or incompatible features are used.
+	bin/govuk-docker config


### PR DESCRIPTION
This adds a travis config file and test task to the Makefile. This allows us to run tests for every pull request.

I wanted to run this on our own CI, but we're using an old version of docker/docker-compose that won't accept our newer docker-compose syntax.

https://trello.com/c/B0TSiqy5
