### PR TITLE
Allow specifying which repos to clone/pull

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
 GOVUK_ROOT_DIR="${HOME}/govuk"
 
+REPOS ?= $(shell ls */Makefile | xargs -L 1 dirname)
+
 default: clone build setup clean
 
 clone:
-	for repo in $(shell ls */Makefile | xargs -L 1 dirname); do \
+	for repo in $(REPOS); do \
 		if [ ! -d "${GOVUK_ROOT_DIR}/$$repo" ]; then \
 			echo $$repo && git clone git@github.com:alphagov/$$repo.git ${GOVUK_ROOT_DIR}/$$repo; \
 		fi \
 	done
 
 pull:
-	for repo in $(shell ls */Makefile | xargs -L 1 dirname); do \
+	for repo in $(REPOS); do \
 		if [ -d "${GOVUK_ROOT_DIR}/$$repo" ]; then \
 			(cd ${GOVUK_ROOT_DIR}/$$repo && echo $$repo && git pull origin master:master); \
 		fi \
@@ -20,7 +22,7 @@ build:
 	govuk-docker build
 
 setup:
-	for repo in $(shell ls */Makefile | xargs -L 1 dirname); do \
+	for repo in $(REPOS); do \
 		make -f $$repo/Makefile; \
 	done
 	govuk-docker run whitehall-e2e rake taxonomy:populate_end_to_end_test_data


### PR DESCRIPTION
Variables can be specified on the command line like so:

    make clone REPOS=email-alert-api

And that will only clone email-alert-api.  Multiple values can be
specified with spaces:

    make clone REPOS="email-alert-api content-publisher"