### PR TITLE
Add Email Alert API

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The following apps are supported by govuk-docker to some extent.
    - ✅ content-publisher
    - ✅ content-store
    - ✅ content-tagger
+   - ✅ email-alert-api
    - ✅ government-frontend
    - ✅ govspeak
    - ✅ govuk-developer-docs

--- a/services/email-alert-api/Dockerfile
+++ b/services/email-alert-api/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.6.3
+
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
+
+RUN useradd -m build
+USER build
+
+ENV EDITOR=vim

--- a/services/email-alert-api/Makefile
+++ b/services/email-alert-api/Makefile
@@ -1,0 +1,3 @@
+email-alert-api: ../email-alert-api
+	bin/govuk-docker run email-alert-api-default bundle
+	bin/govuk-docker run email-alert-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/services/email-alert-api/docker-compose.yml
+++ b/services/email-alert-api/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.7'
+
+x-email-alert-api: &email-alert-api
+  build:
+    context: .
+    dockerfile: email-alert-api/Dockerfile
+  image: email-alert-api
+  volumes:
+    - ..:/govuk:delegated
+    - bundle:/usr/local/bundle
+  working_dir: /govuk/email-alert-api
+
+services:
+  email-alert-api-default:
+    <<: *email-alert-api
+    depends_on:
+      - postgres
+      - redis
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres/email-alert-api"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres/email-alert-api-test"
+      REDIS_URL: redis://redis
+
+  email-alert-api-backend: &email-alert-api-backend
+    <<: *email-alert-api
+    depends_on:
+      - postgres
+      - redis
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres/email-alert-api"
+      REDIS_URL: redis://redis
+      VIRTUAL_HOST: email-alert-api.dev.gov.uk
+      HOST: 0.0.0.0
+    ports:
+      - "3000"
+    command: bin/rails s -P /tmp/rails.pid
+
+  email-alert-api-worker:
+    <<: *email-alert-api
+    depends_on:
+      - postgres
+      - redis
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres/email-alert-api"
+      REDIS_URL: redis://redis
+    command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
This PR adds the Email Alert API as a Docker image and runnable via docker-compose.

<img width="1060" alt="Screen Shot 2019-07-02 at 10 36 56" src="https://user-images.githubusercontent.com/5422487/60503311-532e4400-9cb7-11e9-8496-40169a90e7d9.png">

<img width="648" alt="Screen Shot 2019-07-02 at 10 37 13" src="https://user-images.githubusercontent.com/5422487/60503316-56c1cb00-9cb7-11e9-8bc8-bdff6a578aba.png">

