### PR TITLE
Allow running setup task for individual apps and their dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ GOVUK_ROOT_DIR="${HOME}/govuk"
 
 APPS ?= $(shell ls */Makefile | xargs -L 1 dirname)
 
-default: clone build setup clean
+default: build setup clean
 
 clone: $(addprefix ../,$(APPS))
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 GOVUK_ROOT_DIR="${HOME}/govuk"
 
+.PHONY: clone pull build setup clean $(shell ls */Makefile | xargs -L 1 dirname)
+
 APPS ?= $(shell ls */Makefile | xargs -L 1 dirname)
 
 default: build setup clean
@@ -16,7 +18,7 @@ pull:
 build:
 	bin/govuk-docker build
 
-setup: $(addsuffix _setup,$(APPS))
+setup: $(APPS)
 
 clean:
 	bin/govuk-docker stop
@@ -27,9 +29,9 @@ test:
 	# in the YAML files, or incompatible features are used.
 	bin/govuk-docker config
 
-../%: % %/Makefile
-	if [ ! -d "${GOVUK_ROOT_DIR}/$<" ]; then \
-		echo "$<" && git clone "git@github.com:alphagov/$<.git" "${GOVUK_ROOT_DIR}/$<"; \
+../%: %/Makefile
+	if [ ! -d "${GOVUK_ROOT_DIR}/$(subst /Makefile,,$<)" ]; then \
+		echo "$(subst /Makefile,,$<)" && git clone "git@github.com:alphagov/$(subst /Makefile,,$<).git" "${GOVUK_ROOT_DIR}/$(subst /Makefile,,$<)"; \
 	fi
 
 include $(shell ls */Makefile)

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 GOVUK_ROOT_DIR="${HOME}/govuk"
 
-.PHONY: clone pull build setup clean $(shell ls */Makefile | xargs -L 1 dirname)
+.PHONY: clone pull build clean test $(shell ls */Makefile | xargs -L 1 dirname)
 
 APPS ?= $(shell ls */Makefile | xargs -L 1 dirname)
 
-default: build setup clean
+default:
+	@echo "Run 'make build' to bootstrap govuk-docker"
+	@echo "Or 'make APP-NAME' to set up an app"
 
 clone: $(addprefix ../,$(APPS))
 
@@ -17,8 +19,6 @@ pull:
 
 build:
 	bin/govuk-docker build
-
-setup: $(APPS)
 
 clean:
 	bin/govuk-docker stop

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ build:
 	bin/govuk-docker build
 
 setup: $(addsuffix _setup,$(APPS))
-	bin/govuk-docker run whitehall-e2e rake taxonomy:populate_end_to_end_test_data
 
 clean:
 	bin/govuk-docker stop

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,18 @@
 GOVUK_ROOT_DIR="${HOME}/govuk"
 
-REPOS ?= $(shell ls */Makefile | xargs -L 1 dirname)
+APPS ?= $(shell ls */Makefile | xargs -L 1 dirname)
 
 default: clone build setup clean
 
 clone:
-	for repo in $(REPOS); do \
+	for repo in $(APPS); do \
 		if [ ! -d "${GOVUK_ROOT_DIR}/$$repo" ]; then \
 			echo $$repo && git clone git@github.com:alphagov/$$repo.git ${GOVUK_ROOT_DIR}/$$repo; \
 		fi \
 	done
 
 pull:
-	for repo in $(REPOS); do \
+	for repo in $(APPS); do \
 		if [ -d "${GOVUK_ROOT_DIR}/$$repo" ]; then \
 			(cd ${GOVUK_ROOT_DIR}/$$repo && echo $$repo && git pull origin master:master); \
 		fi \
@@ -21,7 +21,7 @@ pull:
 build:
 	bin/govuk-docker build
 
-setup: $(addsuffix _setup,$(REPOS))
+setup: $(addsuffix _setup,$(APPS))
 	bin/govuk-docker run whitehall-e2e rake taxonomy:populate_end_to_end_test_data
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,11 @@ pull:
 build:
 	bin/govuk-docker build
 
-setup:
-	for repo in $(REPOS); do \
-		make -f $$repo/Makefile; \
-	done
+setup: asset-manager_setup content-data-admin_setup content-publisher_setup content-store_setup \
+	content-tagger_setup government-frontend_setup govspeak_setup govuk-developer-docs_setup \
+	govuk-lint_setup govuk_app_config_setup govuk_publishing_components_setup \
+	miller-columns-element_setup plek_setup publishing-api_setup router_setup router-api_setup \
+	signon_setup static_setup support_setup support-api_setup whitehall_setup
 	bin/govuk-docker run whitehall-e2e rake taxonomy:populate_end_to_end_test_data
 
 clean:
@@ -35,3 +36,5 @@ test:
 	# Test that the docker-compose config is valid. This will error if there are errors
 	# in the YAML files, or incompatible features are used.
 	bin/govuk-docker config
+
+include $(shell ls */Makefile)

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,7 @@ pull:
 build:
 	bin/govuk-docker build
 
-setup: asset-manager_setup content-data-admin_setup content-publisher_setup content-store_setup \
-	content-tagger_setup government-frontend_setup govspeak_setup govuk-developer-docs_setup \
-	govuk-lint_setup govuk_app_config_setup govuk_publishing_components_setup \
-	miller-columns-element_setup plek_setup publishing-api_setup router_setup router-api_setup \
-	signon_setup static_setup support_setup support-api_setup whitehall_setup
+setup: $(addsuffix _setup,$(REPOS))
 	bin/govuk-docker run whitehall-e2e rake taxonomy:populate_end_to_end_test_data
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,7 @@ APPS ?= $(shell ls */Makefile | xargs -L 1 dirname)
 
 default: clone build setup clean
 
-clone:
-	for repo in $(APPS); do \
-		if [ ! -d "${GOVUK_ROOT_DIR}/$$repo" ]; then \
-			echo $$repo && git clone git@github.com:alphagov/$$repo.git ${GOVUK_ROOT_DIR}/$$repo; \
-		fi \
-	done
+clone: $(addprefix ../,$(APPS))
 
 pull:
 	for repo in $(APPS); do \
@@ -31,5 +26,10 @@ test:
 	# Test that the docker-compose config is valid. This will error if there are errors
 	# in the YAML files, or incompatible features are used.
 	bin/govuk-docker config
+
+../%: % %/Makefile
+	if [ ! -d "${GOVUK_ROOT_DIR}/$<" ]; then \
+		echo "$<" && git clone "git@github.com:alphagov/$<.git" "${GOVUK_ROOT_DIR}/$<"; \
+	fi
 
 include $(shell ls */Makefile)

--- a/README.md
+++ b/README.md
@@ -58,19 +58,14 @@ Now in the `govuk` directory, run the following commands.
 ```
 git clone git@github.com:alphagov/govuk-docker.git
 cd govuk-docker
+make build
 ```
 
-You can now either clone and build all of the apps like this:
+You can now clone and setup the apps you need with `make APP-NAME`,
+for example:
 
 ```
-# expect this to take a while
-make
-```
-
-Or only an app and its transitive dependencies like this:
-
-```
-make APPS="content-publisher government-frontend"
+make content-publisher government-frontend
 ```
 
 If you have been using the vagrant based dev vm, take a backup
@@ -169,11 +164,11 @@ This will usually involve editing a `Dockerfile`, for things like system package
 
 ### How to: setup a specific service
 
-If a new service has been added to govuk-docker, first pull the latest version to get the changes. Then use `make APPS=app-name` to clone (if necessary) and set up just that app and its dependencies.
+If a new service has been added to govuk-docker, first pull the latest version to get the changes. Then use `make app-name` to clone (if necessary) and set up just that app and its dependencies.
 
 ### How to: update everything!
 
-Sometimes it's useful to get all changes for all repos e.g. to support finding things with a govuk-wide grep. This can be done by running `make pull`, followed by `make setup` to ensure all services continue to run as expected.
+Sometimes it's useful to get all changes for all repos e.g. to support finding things with a govuk-wide grep. This can be done by running `make pull`.
 
 
 ## Licence

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ content-tagger$ govuk-docker run-this backend
 content-publisher$ govuk-docker run-this e2e
 ```
 
-The above examples make use of an alias to reduce the amount of typing; the full form is `govuk-docker run-this`. In the last two commands, the app will be available in your browser at *app-name.dev.gov.uk*.
+In the last two commands, the app will be available in your browser at *app-name.dev.gov.uk*.
 
 ## User Needs
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,19 @@ Now in the `govuk` directory, run the following commands.
 ```
 git clone git@github.com:alphagov/govuk-docker.git
 cd govuk-docker
+```
 
-# Expect this to take some time (around 20 minutes)
+You can now either clone and build all of the apps like this:
+
+```
+# expect this to take a while
 make
+```
+
+Or only an app and its transitive dependencies like this:
+
+```
+make APPS="content-publisher government-frontend"
 ```
 
 If you have been using the vagrant based dev vm, take a backup
@@ -159,15 +169,7 @@ This will usually involve editing a `Dockerfile`, for things like system package
 
 ### How to: setup a specific service
 
-If a new service has been added to govuk-docker, first pull the latest version to get the changes. One way to setup the new service would be to run `make`, but this goes through every service and might take a while. A faster way is to do this:
-
-```
-# auto-clone any new services
-make clone
-
-# setup the specific service(s)
-make -f my_service/Makefile
-```
+If a new service has been added to govuk-docker, first pull the latest version to get the changes. Then use `make APPS=app-name` to clone (if necessary) and set up just that app and its dependencies.
 
 ### How to: update everything!
 

--- a/asset-manager/Makefile
+++ b/asset-manager/Makefile
@@ -1,4 +1,4 @@
-asset-manager_setup:
+asset-manager_setup: ../asset-manager
 	govuk-docker run asset-manager-default bundle
 	govuk-docker run asset-manager-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
 	govuk-docker run asset-manager-default rails runner 'User.first || User.create'

--- a/asset-manager/Makefile
+++ b/asset-manager/Makefile
@@ -1,4 +1,4 @@
 asset-manager: ../asset-manager
-	govuk-docker run asset-manager-default bundle
-	govuk-docker run asset-manager-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	govuk-docker run asset-manager-default rails runner 'User.first || User.create'
+	bin/govuk-docker run asset-manager-default bundle
+	bin/govuk-docker run asset-manager-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	bin/govuk-docker run asset-manager-default rails runner 'User.first || User.create'

--- a/asset-manager/Makefile
+++ b/asset-manager/Makefile
@@ -1,6 +1,4 @@
-GOVUK_DOCKER_RUN=govuk-docker run asset-manager-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
-	${GOVUK_DOCKER_RUN} sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	${GOVUK_DOCKER_RUN} rails runner 'User.first || User.create'
+asset-manager_setup:
+	govuk-docker run asset-manager-default bundle
+	govuk-docker run asset-manager-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	govuk-docker run asset-manager-default rails runner 'User.first || User.create'

--- a/asset-manager/Makefile
+++ b/asset-manager/Makefile
@@ -1,4 +1,4 @@
-asset-manager_setup: ../asset-manager
+asset-manager: ../asset-manager
 	govuk-docker run asset-manager-default bundle
 	govuk-docker run asset-manager-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
 	govuk-docker run asset-manager-default rails runner 'User.first || User.create'

--- a/content-data-admin/Makefile
+++ b/content-data-admin/Makefile
@@ -1,3 +1,3 @@
-content-data-admin_setup:
+content-data-admin_setup: ../content-data-admin
 	govuk-docker run content-data-admin-default bundle
 	govuk-docker run content-data-admin-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/content-data-admin/Makefile
+++ b/content-data-admin/Makefile
@@ -1,5 +1,3 @@
-GOVUK_DOCKER_RUN=govuk-docker run content-data-admin-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
-	${GOVUK_DOCKER_RUN} sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+content-data-admin_setup:
+	govuk-docker run content-data-admin-default bundle
+	govuk-docker run content-data-admin-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/content-data-admin/Makefile
+++ b/content-data-admin/Makefile
@@ -1,3 +1,3 @@
 content-data-admin: ../content-data-admin
-	govuk-docker run content-data-admin-default bundle
-	govuk-docker run content-data-admin-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	bin/govuk-docker run content-data-admin-default bundle
+	bin/govuk-docker run content-data-admin-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/content-data-admin/Makefile
+++ b/content-data-admin/Makefile
@@ -1,3 +1,3 @@
-content-data-admin_setup: ../content-data-admin
+content-data-admin: ../content-data-admin
 	govuk-docker run content-data-admin-default bundle
 	govuk-docker run content-data-admin-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/content-publisher/Makefile
+++ b/content-publisher/Makefile
@@ -1,4 +1,4 @@
-content-publisher_setup:
+content-publisher_setup: asset-manager_setup publishing-api_setup
 	govuk-docker run content-publisher-default bundle
 	govuk-docker run content-publisher-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
 	govuk-docker run content-publisher-default yarn

--- a/content-publisher/Makefile
+++ b/content-publisher/Makefile
@@ -1,4 +1,4 @@
-content-publisher_setup: asset-manager_setup publishing-api_setup
+content-publisher_setup: ../content-publisher asset-manager_setup publishing-api_setup
 	govuk-docker run content-publisher-default bundle
 	govuk-docker run content-publisher-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
 	govuk-docker run content-publisher-default yarn

--- a/content-publisher/Makefile
+++ b/content-publisher/Makefile
@@ -1,4 +1,4 @@
-content-publisher_setup: ../content-publisher asset-manager_setup publishing-api_setup
+content-publisher: ../content-publisher asset-manager publishing-api
 	govuk-docker run content-publisher-default bundle
 	govuk-docker run content-publisher-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
 	govuk-docker run content-publisher-default yarn

--- a/content-publisher/Makefile
+++ b/content-publisher/Makefile
@@ -1,6 +1,4 @@
-GOVUK_DOCKER_RUN=govuk-docker run content-publisher-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
-	${GOVUK_DOCKER_RUN} sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	${GOVUK_DOCKER_RUN} yarn
+content-publisher_setup:
+	govuk-docker run content-publisher-default bundle
+	govuk-docker run content-publisher-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	govuk-docker run content-publisher-default yarn

--- a/content-publisher/Makefile
+++ b/content-publisher/Makefile
@@ -1,4 +1,4 @@
 content-publisher: ../content-publisher asset-manager publishing-api
-	govuk-docker run content-publisher-default bundle
-	govuk-docker run content-publisher-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	govuk-docker run content-publisher-default yarn
+	bin/govuk-docker run content-publisher-default bundle
+	bin/govuk-docker run content-publisher-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	bin/govuk-docker run content-publisher-default yarn

--- a/content-store/Makefile
+++ b/content-store/Makefile
@@ -1,4 +1,4 @@
-content-store_setup: ../content-store router-api_setup
+content-store: ../content-store router-api
 	govuk-docker run content-store-default bundle
 	govuk-docker run content-store-default rake db:create
 	govuk-docker run content-store-default rails runner 'User.first || User.create'

--- a/content-store/Makefile
+++ b/content-store/Makefile
@@ -1,6 +1,4 @@
-GOVUK_DOCKER_RUN=govuk-docker run content-store-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
-	${GOVUK_DOCKER_RUN} rake db:create
-	${GOVUK_DOCKER_RUN} rails runner 'User.first || User.create'
+content-store_setup:
+	govuk-docker run content-store-default bundle
+	govuk-docker run content-store-default rake db:create
+	govuk-docker run content-store-default rails runner 'User.first || User.create'

--- a/content-store/Makefile
+++ b/content-store/Makefile
@@ -1,4 +1,4 @@
 content-store: ../content-store router-api
-	govuk-docker run content-store-default bundle
-	govuk-docker run content-store-default rake db:create
-	govuk-docker run content-store-default rails runner 'User.first || User.create'
+	bin/govuk-docker run content-store-default bundle
+	bin/govuk-docker run content-store-default rake db:create
+	bin/govuk-docker run content-store-default rails runner 'User.first || User.create'

--- a/content-store/Makefile
+++ b/content-store/Makefile
@@ -1,4 +1,4 @@
-content-store_setup: router-api_setup
+content-store_setup: ../content-store router-api_setup
 	govuk-docker run content-store-default bundle
 	govuk-docker run content-store-default rake db:create
 	govuk-docker run content-store-default rails runner 'User.first || User.create'

--- a/content-store/Makefile
+++ b/content-store/Makefile
@@ -1,4 +1,4 @@
-content-store_setup:
+content-store_setup: router-api_setup
 	govuk-docker run content-store-default bundle
 	govuk-docker run content-store-default rake db:create
 	govuk-docker run content-store-default rails runner 'User.first || User.create'

--- a/content-tagger/Makefile
+++ b/content-tagger/Makefile
@@ -1,3 +1,3 @@
-content-tagger_setup:
+content-tagger_setup: publishing-api_setup
 	govuk-docker run content-tagger-default bundle
 	govuk-docker run content-tagger-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/content-tagger/Makefile
+++ b/content-tagger/Makefile
@@ -1,3 +1,3 @@
-content-tagger_setup: ../content-tagger publishing-api_setup
+content-tagger: ../content-tagger publishing-api
 	govuk-docker run content-tagger-default bundle
 	govuk-docker run content-tagger-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/content-tagger/Makefile
+++ b/content-tagger/Makefile
@@ -1,5 +1,3 @@
-GOVUK_DOCKER_RUN=govuk-docker run content-tagger-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
-	${GOVUK_DOCKER_RUN} sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+content-tagger_setup:
+	govuk-docker run content-tagger-default bundle
+	govuk-docker run content-tagger-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/content-tagger/Makefile
+++ b/content-tagger/Makefile
@@ -1,3 +1,3 @@
-content-tagger_setup: publishing-api_setup
+content-tagger_setup: ../content-tagger publishing-api_setup
 	govuk-docker run content-tagger-default bundle
 	govuk-docker run content-tagger-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/content-tagger/Makefile
+++ b/content-tagger/Makefile
@@ -1,3 +1,3 @@
 content-tagger: ../content-tagger publishing-api
-	govuk-docker run content-tagger-default bundle
-	govuk-docker run content-tagger-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	bin/govuk-docker run content-tagger-default bundle
+	bin/govuk-docker run content-tagger-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/government-frontend/Makefile
+++ b/government-frontend/Makefile
@@ -1,2 +1,2 @@
-government-frontend_setup:
+government-frontend_setup: content-store_setup router_setup static_setup
 	govuk-docker run government-frontend-default bundle

--- a/government-frontend/Makefile
+++ b/government-frontend/Makefile
@@ -1,2 +1,2 @@
 government-frontend: ../government-frontend content-store router static
-	govuk-docker run government-frontend-default bundle
+	bin/govuk-docker run government-frontend-default bundle

--- a/government-frontend/Makefile
+++ b/government-frontend/Makefile
@@ -1,4 +1,2 @@
-GOVUK_DOCKER_RUN=govuk-docker run government-frontend-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
+government-frontend_setup:
+	govuk-docker run government-frontend-default bundle

--- a/government-frontend/Makefile
+++ b/government-frontend/Makefile
@@ -1,2 +1,2 @@
-government-frontend_setup: content-store_setup router_setup static_setup
+government-frontend_setup: ../government-frontend content-store_setup router_setup static_setup
 	govuk-docker run government-frontend-default bundle

--- a/government-frontend/Makefile
+++ b/government-frontend/Makefile
@@ -1,2 +1,2 @@
-government-frontend_setup: ../government-frontend content-store_setup router_setup static_setup
+government-frontend: ../government-frontend content-store router static
 	govuk-docker run government-frontend-default bundle

--- a/govspeak/Makefile
+++ b/govspeak/Makefile
@@ -1,4 +1,2 @@
-GOVUK_DOCKER_RUN=govuk-docker run govspeak-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
+govspeak_setup:
+	govuk-docker run govspeak-default bundle

--- a/govspeak/Makefile
+++ b/govspeak/Makefile
@@ -1,2 +1,2 @@
-govspeak_setup: ../govspeak
+govspeak: ../govspeak
 	govuk-docker run govspeak-default bundle

--- a/govspeak/Makefile
+++ b/govspeak/Makefile
@@ -1,2 +1,2 @@
-govspeak_setup:
+govspeak_setup: ../govspeak
 	govuk-docker run govspeak-default bundle

--- a/govspeak/Makefile
+++ b/govspeak/Makefile
@@ -1,2 +1,2 @@
 govspeak: ../govspeak
-	govuk-docker run govspeak-default bundle
+	bin/govuk-docker run govspeak-default bundle

--- a/govuk-developer-docs/Makefile
+++ b/govuk-developer-docs/Makefile
@@ -1,2 +1,2 @@
 govuk-developer-docs: ../govuk-developer-docs
-	govuk-docker run govuk-developer-docs-default bundle
+	bin/govuk-docker run govuk-developer-docs-default bundle

--- a/govuk-developer-docs/Makefile
+++ b/govuk-developer-docs/Makefile
@@ -1,4 +1,2 @@
-GOVUK_DOCKER_RUN=govuk-docker run govuk-developer-docs-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
+govuk-developer-docs_setup:
+	govuk-docker run govuk-developer-docs-default bundle

--- a/govuk-developer-docs/Makefile
+++ b/govuk-developer-docs/Makefile
@@ -1,2 +1,2 @@
-govuk-developer-docs_setup:
+govuk-developer-docs_setup: ../govuk-developer-docs
 	govuk-docker run govuk-developer-docs-default bundle

--- a/govuk-developer-docs/Makefile
+++ b/govuk-developer-docs/Makefile
@@ -1,2 +1,2 @@
-govuk-developer-docs_setup: ../govuk-developer-docs
+govuk-developer-docs: ../govuk-developer-docs
 	govuk-docker run govuk-developer-docs-default bundle

--- a/govuk-lint/Makefile
+++ b/govuk-lint/Makefile
@@ -1,4 +1,2 @@
-GOVUK_DOCKER_RUN=govuk-docker run govuk-lint-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
+govuk-lint_setup:
+	govuk-docker run govuk-lint-default bundle

--- a/govuk-lint/Makefile
+++ b/govuk-lint/Makefile
@@ -1,2 +1,2 @@
 govuk-lint: ../govuk-lint
-	govuk-docker run govuk-lint-default bundle
+	bin/govuk-docker run govuk-lint-default bundle

--- a/govuk-lint/Makefile
+++ b/govuk-lint/Makefile
@@ -1,2 +1,2 @@
-govuk-lint_setup:
+govuk-lint_setup: ../govuk-lint
 	govuk-docker run govuk-lint-default bundle

--- a/govuk-lint/Makefile
+++ b/govuk-lint/Makefile
@@ -1,2 +1,2 @@
-govuk-lint_setup: ../govuk-lint
+govuk-lint: ../govuk-lint
 	govuk-docker run govuk-lint-default bundle

--- a/govuk_app_config/Makefile
+++ b/govuk_app_config/Makefile
@@ -1,4 +1,2 @@
-GOVUK_DOCKER_RUN=govuk-docker run govuk_app_config-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
+govuk_app_config_setup:
+	govuk-docker run govuk_app_config-default bundle

--- a/govuk_app_config/Makefile
+++ b/govuk_app_config/Makefile
@@ -1,2 +1,2 @@
-govuk_app_config_setup: ../govuk_app_config
+govuk_app_config: ../govuk_app_config
 	govuk-docker run govuk_app_config-default bundle

--- a/govuk_app_config/Makefile
+++ b/govuk_app_config/Makefile
@@ -1,2 +1,2 @@
-govuk_app_config_setup:
+govuk_app_config_setup: ../govuk_app_config
 	govuk-docker run govuk_app_config-default bundle

--- a/govuk_app_config/Makefile
+++ b/govuk_app_config/Makefile
@@ -1,2 +1,2 @@
 govuk_app_config: ../govuk_app_config
-	govuk-docker run govuk_app_config-default bundle
+	bin/govuk-docker run govuk_app_config-default bundle

--- a/govuk_publishing_components/Makefile
+++ b/govuk_publishing_components/Makefile
@@ -1,2 +1,2 @@
-govuk_publishing_components_setup:
+govuk_publishing_components_setup: ../govuk_publishing_components
 	govuk-docker run govuk_publishing_components-default bundle

--- a/govuk_publishing_components/Makefile
+++ b/govuk_publishing_components/Makefile
@@ -1,2 +1,2 @@
-govuk_publishing_components_setup: ../govuk_publishing_components
+govuk_publishing_components: ../govuk_publishing_components
 	govuk-docker run govuk_publishing_components-default bundle

--- a/govuk_publishing_components/Makefile
+++ b/govuk_publishing_components/Makefile
@@ -1,4 +1,2 @@
-GOVUK_DOCKER_RUN=govuk-docker run govuk_publishing_components-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
+govuk_publishing_components_setup:
+	govuk-docker run govuk_publishing_components-default bundle

--- a/govuk_publishing_components/Makefile
+++ b/govuk_publishing_components/Makefile
@@ -1,2 +1,2 @@
 govuk_publishing_components: ../govuk_publishing_components
-	govuk-docker run govuk_publishing_components-default bundle
+	bin/govuk-docker run govuk_publishing_components-default bundle

--- a/miller-columns-element/Makefile
+++ b/miller-columns-element/Makefile
@@ -1,2 +1,2 @@
-miller-columns-element_setup: ../miller-columns-element
+miller-columns-element: ../miller-columns-element
 	govuk-docker run miller-columns-element-default npm install

--- a/miller-columns-element/Makefile
+++ b/miller-columns-element/Makefile
@@ -1,4 +1,2 @@
-GOVUK_DOCKER_RUN=govuk-docker run miller-columns-element-default
-
-default:
-	${GOVUK_DOCKER_RUN} npm install
+miller-columns-element_setup:
+	govuk-docker run miller-columns-element-default npm install

--- a/miller-columns-element/Makefile
+++ b/miller-columns-element/Makefile
@@ -1,2 +1,2 @@
-miller-columns-element_setup:
+miller-columns-element_setup: ../miller-columns-element
 	govuk-docker run miller-columns-element-default npm install

--- a/miller-columns-element/Makefile
+++ b/miller-columns-element/Makefile
@@ -1,2 +1,2 @@
 miller-columns-element: ../miller-columns-element
-	govuk-docker run miller-columns-element-default npm install
+	bin/govuk-docker run miller-columns-element-default npm install

--- a/plek/Makefile
+++ b/plek/Makefile
@@ -1,2 +1,2 @@
-plek_setup: ../plek
+plek: ../plek
 	govuk-docker run plek-default bundle

--- a/plek/Makefile
+++ b/plek/Makefile
@@ -1,2 +1,2 @@
-plek_setup:
+plek_setup: ../plek
 	govuk-docker run plek-default bundle

--- a/plek/Makefile
+++ b/plek/Makefile
@@ -1,4 +1,2 @@
-GOVUK_DOCKER_RUN=govuk-docker run plek-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
+plek_setup:
+	govuk-docker run plek-default bundle

--- a/plek/Makefile
+++ b/plek/Makefile
@@ -1,2 +1,2 @@
 plek: ../plek
-	govuk-docker run plek-default bundle
+	bin/govuk-docker run plek-default bundle

--- a/publishing-api/Makefile
+++ b/publishing-api/Makefile
@@ -1,5 +1,5 @@
 publishing-api: ../publishing-api content-store
-	govuk-docker run publishing-api-default bundle
-	govuk-docker run publishing-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	govuk-docker run publishing-api-default rails runner 'User.first || User.create'
-	govuk-docker run publishing-api-default rake setup_exchange
+	bin/govuk-docker run publishing-api-default bundle
+	bin/govuk-docker run publishing-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	bin/govuk-docker run publishing-api-default rails runner 'User.first || User.create'
+	bin/govuk-docker run publishing-api-default rake setup_exchange

--- a/publishing-api/Makefile
+++ b/publishing-api/Makefile
@@ -1,7 +1,5 @@
-GOVUK_DOCKER_RUN=govuk-docker run publishing-api-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
-	${GOVUK_DOCKER_RUN} sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	${GOVUK_DOCKER_RUN} rails runner 'User.first || User.create'
-	${GOVUK_DOCKER_RUN} rake setup_exchange
+publishing-api_setup:
+	govuk-docker run publishing-api-default bundle
+	govuk-docker run publishing-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	govuk-docker run publishing-api-default rails runner 'User.first || User.create'
+	govuk-docker run publishing-api-default rake setup_exchange

--- a/publishing-api/Makefile
+++ b/publishing-api/Makefile
@@ -1,4 +1,4 @@
-publishing-api_setup: ../publishing-api content-store_setup
+publishing-api: ../publishing-api content-store
 	govuk-docker run publishing-api-default bundle
 	govuk-docker run publishing-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
 	govuk-docker run publishing-api-default rails runner 'User.first || User.create'

--- a/publishing-api/Makefile
+++ b/publishing-api/Makefile
@@ -1,4 +1,4 @@
-publishing-api_setup:
+publishing-api_setup: content-store_setup
 	govuk-docker run publishing-api-default bundle
 	govuk-docker run publishing-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
 	govuk-docker run publishing-api-default rails runner 'User.first || User.create'

--- a/publishing-api/Makefile
+++ b/publishing-api/Makefile
@@ -1,4 +1,4 @@
-publishing-api_setup: content-store_setup
+publishing-api_setup: ../publishing-api content-store_setup
 	govuk-docker run publishing-api-default bundle
 	govuk-docker run publishing-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
 	govuk-docker run publishing-api-default rails runner 'User.first || User.create'

--- a/router-api/Makefile
+++ b/router-api/Makefile
@@ -1,2 +1,2 @@
-router-api_setup: ../router-api router_setup
+router-api: ../router-api router
 	govuk-docker run router-api-default bundle

--- a/router-api/Makefile
+++ b/router-api/Makefile
@@ -1,2 +1,2 @@
-router-api_setup:
+router-api_setup: router_setup
 	govuk-docker run router-api-default bundle

--- a/router-api/Makefile
+++ b/router-api/Makefile
@@ -1,2 +1,2 @@
-router-api_setup: router_setup
+router-api_setup: ../router-api router_setup
 	govuk-docker run router-api-default bundle

--- a/router-api/Makefile
+++ b/router-api/Makefile
@@ -1,2 +1,2 @@
 router-api: ../router-api router
-	govuk-docker run router-api-default bundle
+	bin/govuk-docker run router-api-default bundle

--- a/router-api/Makefile
+++ b/router-api/Makefile
@@ -1,4 +1,2 @@
-GOVUK_DOCKER_RUN=govuk-docker run router-api-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
+router-api_setup:
+	govuk-docker run router-api-default bundle

--- a/router/Makefile
+++ b/router/Makefile
@@ -1,2 +1,2 @@
 router: ../router
-	govuk-docker run router-default sh -c "BINARY=router make build"
+	bin/govuk-docker run router-default sh -c "BINARY=router make build"

--- a/router/Makefile
+++ b/router/Makefile
@@ -1,2 +1,2 @@
-router_setup: ../router
+router: ../router
 	govuk-docker run router-default sh -c "BINARY=router make build"

--- a/router/Makefile
+++ b/router/Makefile
@@ -1,4 +1,2 @@
-GOVUK_DOCKER_RUN=govuk-docker run router-default
-
-default:
-	${GOVUK_DOCKER_RUN} sh -c "BINARY=router make build"
+router_setup:
+	govuk-docker run router-default sh -c "BINARY=router make build"

--- a/router/Makefile
+++ b/router/Makefile
@@ -1,2 +1,2 @@
-router_setup:
+router_setup: ../router
 	govuk-docker run router-default sh -c "BINARY=router make build"

--- a/signon/Makefile
+++ b/signon/Makefile
@@ -1,3 +1,3 @@
-signon_setup:
+signon_setup: ../signon
 	govuk-docker run signon-default bundle
 	govuk-docker run signon-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/signon/Makefile
+++ b/signon/Makefile
@@ -1,3 +1,3 @@
 signon: ../signon
-	govuk-docker run signon-default bundle
-	govuk-docker run signon-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	bin/govuk-docker run signon-default bundle
+	bin/govuk-docker run signon-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/signon/Makefile
+++ b/signon/Makefile
@@ -1,3 +1,3 @@
-signon_setup: ../signon
+signon: ../signon
 	govuk-docker run signon-default bundle
 	govuk-docker run signon-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/signon/Makefile
+++ b/signon/Makefile
@@ -1,5 +1,3 @@
-GOVUK_DOCKER_RUN=govuk-docker run signon-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
-	${GOVUK_DOCKER_RUN} sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+signon_setup:
+	govuk-docker run signon-default bundle
+	govuk-docker run signon-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/static/Makefile
+++ b/static/Makefile
@@ -1,2 +1,2 @@
-static_setup:
+static_setup: ../static
 	govuk-docker run static-default bundle

--- a/static/Makefile
+++ b/static/Makefile
@@ -1,4 +1,2 @@
-GOVUK_DOCKER_RUN=govuk-docker run static-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
+static_setup:
+	govuk-docker run static-default bundle

--- a/static/Makefile
+++ b/static/Makefile
@@ -1,2 +1,2 @@
 static: ../static
-	govuk-docker run static-default bundle
+	bin/govuk-docker run static-default bundle

--- a/static/Makefile
+++ b/static/Makefile
@@ -1,2 +1,2 @@
-static_setup: ../static
+static: ../static
 	govuk-docker run static-default bundle

--- a/support-api/Makefile
+++ b/support-api/Makefile
@@ -1,5 +1,3 @@
-GOVUK_DOCKER_RUN=govuk-docker run support-api-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
-	${GOVUK_DOCKER_RUN} sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+support-api_setup:
+	govuk-docker run support-api-default bundle
+	govuk-docker run support-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/support-api/Makefile
+++ b/support-api/Makefile
@@ -1,3 +1,3 @@
-support-api_setup: ../support-api
+support-api: ../support-api
 	govuk-docker run support-api-default bundle
 	govuk-docker run support-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/support-api/Makefile
+++ b/support-api/Makefile
@@ -1,3 +1,3 @@
 support-api: ../support-api
-	govuk-docker run support-api-default bundle
-	govuk-docker run support-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	bin/govuk-docker run support-api-default bundle
+	bin/govuk-docker run support-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/support-api/Makefile
+++ b/support-api/Makefile
@@ -1,3 +1,3 @@
-support-api_setup:
+support-api_setup: ../support-api
 	govuk-docker run support-api-default bundle
 	govuk-docker run support-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/support/Makefile
+++ b/support/Makefile
@@ -1,2 +1,2 @@
-support_setup:
+support_setup: support-api_setup
 	govuk-docker run support-default bundle

--- a/support/Makefile
+++ b/support/Makefile
@@ -1,4 +1,2 @@
-GOVUK_DOCKER_RUN=govuk-docker run support-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
+support_setup:
+	govuk-docker run support-default bundle

--- a/support/Makefile
+++ b/support/Makefile
@@ -1,2 +1,2 @@
 support: ../support support-api
-	govuk-docker run support-default bundle
+	bin/govuk-docker run support-default bundle

--- a/support/Makefile
+++ b/support/Makefile
@@ -1,2 +1,2 @@
-support_setup: ../support support-api_setup
+support: ../support support-api
 	govuk-docker run support-default bundle

--- a/support/Makefile
+++ b/support/Makefile
@@ -1,2 +1,2 @@
-support_setup: support-api_setup
+support_setup: ../support support-api_setup
 	govuk-docker run support-default bundle

--- a/whitehall/Makefile
+++ b/whitehall/Makefile
@@ -1,5 +1,5 @@
 whitehall: ../whitehall asset-manager publishing-api static
-	govuk-docker run whitehall-default bundle
-	govuk-docker run whitehall-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	govuk-docker run whitehall-default rake shared_mustache:compile
-	govuk-docker run whitehall-e2e rake taxonomy:populate_end_to_end_test_data
+	bin/govuk-docker run whitehall-default bundle
+	bin/govuk-docker run whitehall-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	bin/govuk-docker run whitehall-default rake shared_mustache:compile
+	bin/govuk-docker run whitehall-e2e rake taxonomy:populate_end_to_end_test_data

--- a/whitehall/Makefile
+++ b/whitehall/Makefile
@@ -1,4 +1,4 @@
-whitehall_setup: asset-manager_setup publishing-api_setup static_setup
+whitehall_setup: ../whitehall asset-manager_setup publishing-api_setup static_setup
 	govuk-docker run whitehall-default bundle
 	govuk-docker run whitehall-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
 	govuk-docker run whitehall-default rake shared_mustache:compile

--- a/whitehall/Makefile
+++ b/whitehall/Makefile
@@ -1,6 +1,4 @@
-GOVUK_DOCKER_RUN=govuk-docker run whitehall-default
-
-default:
-	${GOVUK_DOCKER_RUN} bundle
-	${GOVUK_DOCKER_RUN} sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	${GOVUK_DOCKER_RUN} rake shared_mustache:compile
+whitehall_setup:
+	govuk-docker run whitehall-default bundle
+	govuk-docker run whitehall-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	govuk-docker run whitehall-default rake shared_mustache:compile

--- a/whitehall/Makefile
+++ b/whitehall/Makefile
@@ -1,4 +1,4 @@
-whitehall_setup:
+whitehall_setup: asset-manager_setup publishing-api_setup static_setup
 	govuk-docker run whitehall-default bundle
 	govuk-docker run whitehall-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
 	govuk-docker run whitehall-default rake shared_mustache:compile

--- a/whitehall/Makefile
+++ b/whitehall/Makefile
@@ -2,3 +2,4 @@ whitehall_setup: asset-manager_setup publishing-api_setup static_setup
 	govuk-docker run whitehall-default bundle
 	govuk-docker run whitehall-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
 	govuk-docker run whitehall-default rake shared_mustache:compile
+	govuk-docker run whitehall-e2e rake taxonomy:populate_end_to_end_test_data

--- a/whitehall/Makefile
+++ b/whitehall/Makefile
@@ -1,4 +1,4 @@
-whitehall_setup: ../whitehall asset-manager_setup publishing-api_setup static_setup
+whitehall: ../whitehall asset-manager publishing-api static
 	govuk-docker run whitehall-default bundle
 	govuk-docker run whitehall-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
 	govuk-docker run whitehall-default rake shared_mustache:compile


### PR DESCRIPTION
Setting up all the apps is slow, so we want to be able to just set up some of them.  It's also good to be able to set up all the dependent apps, so if you set up content-publisher and then start it, it doesn't immediately stop working because you haven't installed gems for the publishing-api (eg).

So now to get everything you need for content-publisher, and nothing else, you can run

    make APPS=content-publisher

This makes a fairly substantial change to the way the project makefiles are structured, pulling them all into the top-level makefile.