### PR TITLE
Remove build-essential everywhere

### DIFF
--- a/asset-manager/Dockerfile
+++ b/asset-manager/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential clamav vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y clamav vim
 RUN freshclam
 RUN ln -sf /usr/bin/clamscan /usr/bin/govuk_clamscan
 

--- a/content-data-admin/Dockerfile
+++ b/content-data-admin/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6.3
 
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 RUN apt-get install -y libxss1 libappindicator1 libindicator7
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && apt install -y ./google-chrome*.deb
 

--- a/content-publisher/Dockerfile
+++ b/content-publisher/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6.3
 
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 RUN apt-get install -y libxss1 libappindicator1 libindicator7
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && apt install -y ./google-chrome*.deb
 

--- a/content-store/Dockerfile
+++ b/content-store/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6.3
 
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential && apt-get clean vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
 
 RUN useradd -m build
 USER build

--- a/content-tagger/Dockerfile
+++ b/content-tagger/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6.3
 
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 RUN apt-get install -y libxss1 libappindicator1 libindicator7
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && apt install -y ./google-chrome*.deb
 

--- a/government-frontend/Dockerfile
+++ b/government-frontend/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && apt install -y ./google-chrome*.deb
 
 RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2

--- a/govspeak/Dockerfile
+++ b/govspeak/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
 
 RUN useradd -m build
 USER build

--- a/govuk-developer-docs/Dockerfile
+++ b/govuk-developer-docs/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs

--- a/govuk-lint/Dockerfile
+++ b/govuk-lint/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
 
 RUN useradd -m build
 USER build

--- a/govuk_app_config/Dockerfile
+++ b/govuk_app_config/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
 
 RUN useradd -m build
 USER build

--- a/govuk_publishing_components/Dockerfile
+++ b/govuk_publishing_components/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 RUN apt-get install -y libxss1 libappindicator1 libindicator7
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && apt install -y ./google-chrome*.deb
 

--- a/miller-columns-element/Dockerfile
+++ b/miller-columns-element/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 RUN apt-get install -y libxss1 libappindicator1 libindicator7
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && apt install -y ./google-chrome*.deb
 

--- a/plek/Dockerfile
+++ b/plek/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
 
 RUN useradd -m build
 USER build

--- a/publishing-api/Dockerfile
+++ b/publishing-api/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential libpq-dev libxml2-dev libxslt1-dev vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
 
 RUN useradd -m build
 USER build

--- a/router-api/Dockerfile
+++ b/router-api/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
 
 RUN useradd -m build
 USER build

--- a/signon/Dockerfile
+++ b/signon/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6.3
 
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 
 RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2
 RUN tar -xf phantomjs-2.1.1-linux-x86_64.tar.bz2

--- a/static/Dockerfile
+++ b/static/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && apt install -y ./google-chrome*.deb
 
 RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2

--- a/support-api/Dockerfile
+++ b/support-api/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential libpq-dev libxml2-dev libxslt1-dev vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y libpq-dev libxml2-dev libxslt1-dev vim
 RUN apt-get install -y postgresql-client
 RUN apt-get clean
 

--- a/support/Dockerfile
+++ b/support/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6.3
 
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 RUN apt-get install -y libxss1 libappindicator1 libindicator7
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && apt install -y ./google-chrome*.deb
 

--- a/whitehall/Dockerfile
+++ b/whitehall/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential vim
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 RUN apt-get install -y libxss1 libappindicator1 libindicator7
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && apt install -y ./google-chrome*.deb
 


### PR DESCRIPTION
https://trello.com/c/2XWgdfo7/5-%F0%9F%92%A5-make-setup-super-fast-and-easy

    Previously we installed the build-essential package for all images,
    which is an artefact from the approach in the E2E tests. This removes
    the package, since the utilities it provides (make, gcc, etc.) are
    included as part of the ruby:* images.
    
    This also removes an unnecessary set of lib* packages for publishing-api
    which are again an artefact from copying the E2E test Dockerfiles.

In order to update all your images to match, you'll need to do a `govuk-docker build` command. This isn't actually necessary, since the before/after should behave the same.