### PR TITLE
Remove redundant yarn install from Whitehall

### DIFF
--- a/whitehall/Dockerfile
+++ b/whitehall/Dockerfile
@@ -4,9 +4,7 @@ RUN apt-get install -y libxss1 libappindicator1 libindicator7
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && apt install -y ./google-chrome*.deb
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update -qq && apt-get install -y yarn nodejs
+RUN apt-get update -qq && apt-get install -y nodejs
 
 RUN apt-get clean
 


### PR DESCRIPTION
https://trello.com/c/2XWgdfo7/5-%F0%9F%92%A5-make-setup-super-fast-and-easy

This removes the yarn package manager from the Whitehall image, since
it's not used as part of the Makefile and Whitehall doesn't seem to
require any JS package manager.