### PR TITLE
Remove 'fleshclam' command from Dockerfile

### DIFF
--- a/asset-manager/Dockerfile
+++ b/asset-manager/Dockerfile
@@ -1,6 +1,5 @@
 FROM ruby:2.6.3
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y clamav vim
-RUN freshclam
 RUN ln -sf /usr/bin/clamscan /usr/bin/govuk_clamscan
 
 RUN useradd -m build


### PR DESCRIPTION
https://trello.com/c/2XWgdfo7/5-%F0%9F%92%A5-make-setup-super-fast-and-easy

Previously we ran 'freshclam' to update virus definitions for Asset
Manager, but this takes a while a doesn't seem to have any impact on
the day-to-day tasks. This removes the command from the Dockerfile -
we may want to support updating virus definitions more regularly and
easily if this is a day-to-day concern.