### PR TITLE
Trial a few simple build tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,10 @@ test:
 	# Test that the docker-compose config is valid. This will error if there are errors
 	# in the YAML files, or incompatible features are used.
 	bin/govuk-docker config
+
+	# Test that some builds work from scratch for services with different kinds of Dockerfile.
+	# This will error if a build fails for some reason.
+	bin/govuk-docker build --no-cache --parallel \
+		asset-manager-default \
+		content-publisher-default \
+		signon-default


### PR DESCRIPTION
https://trello.com/c/akpi3nt3/2-%F0%9F%92%AA-optimise-day-to-day-development

This adds a few no-cache (from-scratch) build commands for services with
different Dockerfiles, to test the builds continue to work over time as
external sources change; it should also help to double-check any global
changes made across the Dockerfiles.

Running from-scratch builds can take some time. One way to mitigate this
is be to use the '--parallel' flag, which runs the builds in parallel at
the expense of making the output jumbled - this seems like an OK
compromise as we expect the commands to be successful most of the time.

Currently takes around 2 mins using the 'time' command, and around 3.2
mins without the '--parallel' flag.