### PR TITLE
Add link-checker-api

### DIFF
--- a/link-checker-api/Dockerfile
+++ b/link-checker-api/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.6.3
+
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
+
+RUN useradd -m build
+USER build
+
+ENV EDITOR=vim

--- a/link-checker-api/Makefile
+++ b/link-checker-api/Makefile
@@ -1,0 +1,3 @@
+link-checker-api: ../link-checker-api
+	bin/govuk-docker run link-checker-api-default bundle
+	bin/govuk-docker run link-checker-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/link-checker-api/docker-compose.yml
+++ b/link-checker-api/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.7'
+
+x-link-checker-api: &link-checker-api
+  build:
+    context: .
+    dockerfile: link-checker-api/Dockerfile
+  image: link-checker-api
+  volumes:
+    - ..:/govuk:delegated
+    - bundle:/usr/local/bundle
+    - home:/home/build
+  working_dir: /govuk/link-checker-api
+
+services:
+  link-checker-api-default:
+    <<: *link-checker-api
+    privileged: true
+    depends_on:
+      - postgres
+      - redis
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres/link-checker-api"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres/link-checker-api-test"
+      REDIS_URL: redis://redis
+
+  link-checker-api-backend: &link-checker-api-backend
+    <<: *link-checker-api
+    depends_on:
+      - link-checker-api-worker
+      - nginx-proxy
+      - postgres
+      - redis
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres/link-checker-api"
+      REDIS_URL: redis://redis
+      VIRTUAL_HOST: link-checker-api.dev.gov.uk
+      HOST: 0.0.0.0
+    ports:
+      - "3000"
+    command: bin/rails s -P /tmp/rails.pid
+
+  link-checker-api-worker:
+    <<: *link-checker-api
+    depends_on:
+      - postgres
+      - redis
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres/link-checker-api"
+      REDIS_URL: redis://redis
+    command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
<img width="440" alt="Screenshot 2019-07-02 10 22 59" src="https://user-images.githubusercontent.com/773037/60501172-7c4cd580-9cb3-11e9-8d08-6bcc41fcc2e5.png">

This also adds the link checker api worker as a dependency of the backend app which seems to work
pretty well.

running:

 `curl -s http://link-checker-api.dev.gov.uk/check\?uri\=https%3A%2F%2Fwww.gov.uk%2F`

gives an initial response of:

> {"uri":"https://www.gov.uk/","status":"pending","checked":null,"problem_summary":null,"errors":[],"warnings":[],"suggested_fix":null}%

once the worker has run, repeating the request gives the response:

> {"uri":"https://www.gov.uk/","status":"ok","checked":"2019-07-02T10:04:44Z","problem_summary":null,"errors":[],"warnings":[],"suggested_fix":null}%

We don't think we need an e2e option right now.
https://trello.com/c/CrqFTwwu/35-set-up-link-checker-api