### PR TITLE
Remove chromedriver version for government-frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ The following apps are supported by govuk-docker to some extent.
    - ✅ content-store
    - ⚠ content-tagger
       * [chromedriver-helper](https://github.com/alphagov/govuk-docker/blob/master/content-tagger/docker-compose.yml#L13) version lock is manually added
-   - ⚠ government-frontend
-      * [chromedriver-helper](https://github.com/alphagov/govuk-docker/blob/master/content-tagger/docker-compose.yml#L13) version lock is manually added
+   - ✅ government-frontend
    - ✅ govspeak
    - ✅ govuk-developer-docs
    - ✅ govuk-lint

--- a/services/government-frontend/Dockerfile
+++ b/services/government-frontend/Dockerfile
@@ -14,6 +14,4 @@ RUN apt-get update -qq && apt-get install -y nodejs
 RUN useradd -m build
 USER build
 
-RUN mkdir /home/build/.chromedriver-helper
-
 ENV EDITOR=vim

--- a/services/government-frontend/docker-compose.yml
+++ b/services/government-frontend/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     volumes:
       - ..:/govuk:delegated
       - bundle:/usr/local/bundle
-      - ./government-frontend/chromedriver-version:/home/build/.chromedriver-helper/.chromedriver-version
 
   government-frontend-live: &government-frontend-live
     <<: *government-frontend


### PR DESCRIPTION
Trello: https://trello.com/c/hwMoAOau/3-%F0%9F%90%B3-get-all-apps-working-on-docker

This depends on: https://github.com/alphagov/government-frontend/pull/1402

With government-frontend adopting govuk_test in
https://github.com/alphagov/government-frontend/pull/1402 we no longer
need to bundle a chromedriver-helper file.