### PR TITLE
Add support for custom apps home directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOVUK_ROOT_DIR="${HOME}/govuk"
+GOVUK_ROOT_DIR ?= "${HOME}/govuk"
 
 .PHONY: clone pull build clean test $(shell ls */Makefile | xargs -L 1 dirname)
 


### PR DESCRIPTION
This allows users with a different root dir to override the standard path