### PR TITLE
Add govuk-content-schemas

### DIFF
--- a/content-store/Makefile
+++ b/content-store/Makefile
@@ -1,4 +1,4 @@
-content-store: ../content-store router-api
+content-store: ../content-store router-api govuk-content-schemas
 	bin/govuk-docker run content-store-default bundle
 	bin/govuk-docker run content-store-default rake db:create
 	bin/govuk-docker run content-store-default rails runner 'User.first || User.create'

--- a/government-frontend/Makefile
+++ b/government-frontend/Makefile
@@ -1,2 +1,2 @@
-government-frontend: ../government-frontend content-store router static
+government-frontend: ../government-frontend content-store router static govuk-content-schemas
 	bin/govuk-docker run government-frontend-default bundle

--- a/govuk-content-schemas/Dockerfile
+++ b/govuk-content-schemas/Dockerfile
@@ -1,0 +1,7 @@
+FROM ruby:2.6.3
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
+
+RUN useradd -m build
+USER build
+
+ENV EDITOR=vim

--- a/govuk-content-schemas/Makefile
+++ b/govuk-content-schemas/Makefile
@@ -1,0 +1,2 @@
+govuk-content-schemas: ../govuk-content-schemas
+	bin/govuk-docker run govuk-content-schemas-default bundle

--- a/govuk-content-schemas/docker-compose.yml
+++ b/govuk-content-schemas/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.7'
+
+x-govuk-content-schemas: &govuk-content-schemas
+  build:
+    context: .
+    dockerfile: govuk-content-schemas/Dockerfile
+  image: govuk-content-schemas
+  volumes:
+    - ..:/govuk:delegated
+    - bundle:/usr/local/bundle
+    - home:/home/build
+  working_dir: /govuk/govuk-content-schemas
+
+services:
+  govuk-content-schemas-default:
+    <<: *govuk-content-schemas

--- a/publishing-api/Makefile
+++ b/publishing-api/Makefile
@@ -1,4 +1,4 @@
-publishing-api: ../publishing-api content-store
+publishing-api: ../publishing-api content-store govuk-content-schemas
 	bin/govuk-docker run publishing-api-default bundle
 	bin/govuk-docker run publishing-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
 	bin/govuk-docker run publishing-api-default rails runner 'User.first || User.create'


### PR DESCRIPTION
Some apps require govuk-content-schemas for their tests. These apps need to clone the govuk-content-schemas repo when you run, for example, `make government-frontend`