### PR TITLE
Stop running apt-get clean

### DIFF
--- a/services/content-data-admin/Dockerfile
+++ b/services/content-data-admin/Dockerfile
@@ -7,8 +7,6 @@ RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.d
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs
 
-RUN apt-get clean
-
 RUN useradd -m build
 USER build
 

--- a/services/content-publisher/Dockerfile
+++ b/services/content-publisher/Dockerfile
@@ -9,8 +9,6 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y yarn nodejs
 
-RUN apt-get clean
-
 RUN useradd -m build
 USER build
 

--- a/services/content-store/Dockerfile
+++ b/services/content-store/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6.3
 
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 
 RUN useradd -m build
 USER build

--- a/services/content-tagger/Dockerfile
+++ b/services/content-tagger/Dockerfile
@@ -7,8 +7,6 @@ RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.d
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs
 
-RUN apt-get clean
-
 RUN useradd -m build
 USER build
 

--- a/services/government-frontend/Dockerfile
+++ b/services/government-frontend/Dockerfile
@@ -9,8 +9,6 @@ RUN cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs
 
-RUN apt-get clean
-
 RUN useradd -m build
 USER build
 

--- a/services/govspeak/Dockerfile
+++ b/services/govspeak/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 
 RUN useradd -m build
 USER build

--- a/services/govuk-content-schemas/Dockerfile
+++ b/services/govuk-content-schemas/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 
 RUN useradd -m build
 USER build

--- a/services/govuk-developer-docs/Dockerfile
+++ b/services/govuk-developer-docs/Dockerfile
@@ -4,8 +4,6 @@ RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs
 
-RUN apt-get clean
-
 RUN useradd -m build
 USER build
 

--- a/services/govuk-lint/Dockerfile
+++ b/services/govuk-lint/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 
 RUN useradd -m build
 USER build

--- a/services/govuk_app_config/Dockerfile
+++ b/services/govuk_app_config/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 
 RUN useradd -m build
 USER build

--- a/services/govuk_publishing_components/Dockerfile
+++ b/services/govuk_publishing_components/Dockerfile
@@ -6,8 +6,6 @@ RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.d
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs
 
-RUN apt-get clean
-
 RUN useradd -m build
 USER build
 

--- a/services/link-checker-api/Dockerfile
+++ b/services/link-checker-api/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6.3
 
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 
 RUN useradd -m build
 USER build

--- a/services/miller-columns-element/Dockerfile
+++ b/services/miller-columns-element/Dockerfile
@@ -6,8 +6,6 @@ RUN wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd6
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs
 
-RUN apt-get clean
-
 RUN useradd -m build
 USER build
 

--- a/services/plek/Dockerfile
+++ b/services/plek/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 
 RUN useradd -m build
 USER build

--- a/services/publishing-api/Dockerfile
+++ b/services/publishing-api/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 
 RUN useradd -m build
 USER build

--- a/services/router-api/Dockerfile
+++ b/services/router-api/Dockerfile
@@ -1,5 +1,5 @@
 FROM ruby:2.6.3
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 
 RUN useradd -m build
 USER build

--- a/services/signon/Dockerfile
+++ b/services/signon/Dockerfile
@@ -9,8 +9,6 @@ RUN cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs
 
-RUN apt-get clean
-
 RUN useradd -m build
 USER build
 

--- a/services/static/Dockerfile
+++ b/services/static/Dockerfile
@@ -9,8 +9,6 @@ RUN cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs
 
-RUN apt-get clean
-
 RUN useradd -m build
 USER build
 

--- a/services/support-api/Dockerfile
+++ b/services/support-api/Dockerfile
@@ -1,7 +1,6 @@
 FROM ruby:2.6.3
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y libpq-dev libxml2-dev libxslt1-dev vim
 RUN apt-get install -y postgresql-client
-RUN apt-get clean
 
 RUN useradd -m build
 USER build

--- a/services/support/Dockerfile
+++ b/services/support/Dockerfile
@@ -11,8 +11,6 @@ RUN cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs
 
-RUN apt-get clean
-
 RUN useradd -m build
 USER build
 

--- a/services/travel-advice-publisher/Dockerfile
+++ b/services/travel-advice-publisher/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.6.3
 
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim && apt-get clean
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>&1 && apt install -y ./google-chrome*.deb
 # for capybara-webkit
 RUN apt-get update -qq && apt-get install -y libqtwebkit4 libqt4-dev xvfb
@@ -12,8 +12,6 @@ RUN apt-get update -qq && apt-get install -y nodejs
 RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 2>&1
 RUN tar -xf phantomjs-2.1.1-linux-x86_64.tar.bz2
 RUN cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
-
-RUN apt-get clean
 
 RUN useradd -m build
 USER build

--- a/services/whitehall/Dockerfile
+++ b/services/whitehall/Dockerfile
@@ -6,8 +6,6 @@ RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.d
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs
 
-RUN apt-get clean
-
 RUN useradd -m build
 USER build
 


### PR DESCRIPTION
The ruby:2.6.3 image currently is Debian, and includes some additional
configuration for Apt [1] that deletes downloaded packages
automatically.

This means that running apt-get clean in the Dockerfile is redundant.

1: /etc/apt/apt.conf.d/docker-clean