### PR TITLE
Change how PhantomJS is handled in Dockerfiles

### DIFF
--- a/services/government-frontend/Dockerfile
+++ b/services/government-frontend/Dockerfile
@@ -4,9 +4,11 @@ RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.d
     apt install -y ./google-chrome*.deb && \
     rm ./google-chrome*.deb
 
-RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 2>&1
-RUN tar -xf phantomjs-2.1.1-linux-x86_64.tar.bz2
-RUN cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
+RUN export VERSION=2.1.1 && \
+    wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$VERSION-linux-x86_64.tar.bz2 2>&1 && \
+    tar -vxf phantomjs-$VERSION-linux-x86_64.tar.bz2 && \
+    cp -v phantomjs-$VERSION-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs && \
+    rm -vr phantomjs-$VERSION-linux-x86_64
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs

--- a/services/signon/Dockerfile
+++ b/services/signon/Dockerfile
@@ -2,9 +2,11 @@ FROM ruby:2.6.3
 
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
 
-RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 2>&1
-RUN tar -xf phantomjs-2.1.1-linux-x86_64.tar.bz2
-RUN cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
+RUN export VERSION=2.1.1 && \
+    wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$VERSION-linux-x86_64.tar.bz2 2>&1 && \
+    tar -vxf phantomjs-$VERSION-linux-x86_64.tar.bz2 && \
+    cp -v phantomjs-$VERSION-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs && \
+    rm -vr phantomjs-$VERSION-linux-x86_64
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs

--- a/services/static/Dockerfile
+++ b/services/static/Dockerfile
@@ -4,9 +4,11 @@ RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.d
     apt install -y ./google-chrome*.deb && \
     rm ./google-chrome*.deb
 
-RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 2>&1
-RUN tar -xf phantomjs-2.1.1-linux-x86_64.tar.bz2
-RUN cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
+RUN export VERSION=2.1.1 && \
+    wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$VERSION-linux-x86_64.tar.bz2 2>&1 && \
+    tar -vxf phantomjs-$VERSION-linux-x86_64.tar.bz2 && \
+    cp -v phantomjs-$VERSION-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs && \
+    rm -vr phantomjs-$VERSION-linux-x86_64
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs

--- a/services/support/Dockerfile
+++ b/services/support/Dockerfile
@@ -6,9 +6,11 @@ RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.d
     apt install -y ./google-chrome*.deb && \
     rm ./google-chrome*.deb
 
-RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 2>&1
-RUN tar -xf phantomjs-2.1.1-linux-x86_64.tar.bz2
-RUN cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
+RUN export VERSION=2.1.1 && \
+    wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$VERSION-linux-x86_64.tar.bz2 2>&1 && \
+    tar -vxf phantomjs-$VERSION-linux-x86_64.tar.bz2 && \
+    cp -v phantomjs-$VERSION-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs && \
+    rm -vr phantomjs-$VERSION-linux-x86_64
 
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs

--- a/services/travel-advice-publisher/Dockerfile
+++ b/services/travel-advice-publisher/Dockerfile
@@ -11,9 +11,11 @@ RUN gem install foreman
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN apt-get update -qq && apt-get install -y nodejs
 
-RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 2>&1
-RUN tar -xf phantomjs-2.1.1-linux-x86_64.tar.bz2
-RUN cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
+RUN export VERSION=2.1.1 && \
+    wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$VERSION-linux-x86_64.tar.bz2 2>&1 && \
+    tar -vxf phantomjs-$VERSION-linux-x86_64.tar.bz2 && \
+    cp -v phantomjs-$VERSION-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs && \
+    rm -vr phantomjs-$VERSION-linux-x86_64
 
 RUN useradd -m build
 USER build


### PR DESCRIPTION
Extract the version in to a variable, to reduce duplication. Make the
tar and cp output verbose, so what's going on is more visible. Remove
the extraneous downloaded files for neatness at the end.