### PR TITLE
Create draft content store db and seed

### DIFF
--- a/services/content-store/Makefile
+++ b/services/content-store/Makefile
@@ -2,3 +2,5 @@ content-store: ../content-store router-api govuk-content-schemas
 	bin/govuk-docker run content-store-default bundle
 	bin/govuk-docker run content-store-default rake db:create
 	bin/govuk-docker run content-store-default rails runner 'User.first || User.create'
+	bin/govuk-docker run content-store-draft rake db:create
+	bin/govuk-docker run content-store-draft rails runner 'User.first || User.create'


### PR DESCRIPTION
This also seeds the db with a user which is required to use the draft
content store.

While setting up calendars we ran into an issue due to there being no
user existing in the draft-content-store. The calendar publishing rake
task
(https://github.com/alphagov/calendars/blob/master/lib/tasks/publishing_api.rake)
was failing and the draft content store wasn't being populated with the
calendars. This commit adds a user for the draft-content-stores db when
running `make` for content-store.

Trello:
https://trello.com/c/sm2rw3Nr/27-set-up-calendars