### PR TITLE
Use specific rake rails

### DIFF
--- a/services/asset-manager/Makefile
+++ b/services/asset-manager/Makefile
@@ -1,4 +1,4 @@
 asset-manager: $(GOVUK_ROOT_DIR)/asset-manager
 	$(COMPOSE_RUN) asset-manager-default bundle
-	$(COMPOSE_RUN) asset-manager-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	$(COMPOSE_RUN) asset-manager-default rails runner 'User.first || User.create'
+	$(COMPOSE_RUN) asset-manager-default sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(COMPOSE_RUN) asset-manager-default bin/rails runner 'User.first || User.create'

--- a/services/content-data-admin/Makefile
+++ b/services/content-data-admin/Makefile
@@ -1,3 +1,3 @@
 content-data-admin: $(GOVUK_ROOT_DIR)/content-data-admin
 	$(COMPOSE_RUN) content-data-admin-default bundle
-	$(COMPOSE_RUN) content-data-admin-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(COMPOSE_RUN) content-data-admin-default sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/content-publisher/Makefile
+++ b/services/content-publisher/Makefile
@@ -1,4 +1,4 @@
 content-publisher: $(GOVUK_ROOT_DIR)/content-publisher asset-manager publishing-api
 	$(COMPOSE_RUN) content-publisher-default bundle
-	$(COMPOSE_RUN) content-publisher-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(COMPOSE_RUN) content-publisher-default sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
 	$(COMPOSE_RUN) content-publisher-default yarn

--- a/services/content-store/Makefile
+++ b/services/content-store/Makefile
@@ -1,6 +1,6 @@
 content-store: $(GOVUK_ROOT_DIR)/content-store router-api govuk-content-schemas
 	$(COMPOSE_RUN) content-store-default bundle
-	$(COMPOSE_RUN) content-store-default rake db:create
-	$(COMPOSE_RUN) content-store-default rails runner 'User.first || User.create'
-	$(COMPOSE_RUN) content-store-draft rake db:create
-	$(COMPOSE_RUN) content-store-draft rails runner 'User.first || User.create'
+	$(COMPOSE_RUN) content-store-default bin/rake db:create
+	$(COMPOSE_RUN) content-store-default bin/rails runner 'User.first || User.create'
+	$(COMPOSE_RUN) content-store-draft bin/rake db:create
+	$(COMPOSE_RUN) content-store-draft bin/rails runner 'User.first || User.create'

--- a/services/content-tagger/Makefile
+++ b/services/content-tagger/Makefile
@@ -1,3 +1,3 @@
 content-tagger: $(GOVUK_ROOT_DIR)/content-tagger publishing-api
 	$(COMPOSE_RUN) content-tagger-default bundle
-	$(COMPOSE_RUN) content-tagger-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(COMPOSE_RUN) content-tagger-default sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/email-alert-api/Makefile
+++ b/services/email-alert-api/Makefile
@@ -1,3 +1,3 @@
 email-alert-api: $(GOVUK_ROOT_DIR)/email-alert-api
 	$(COMPOSE_RUN) email-alert-api-default bundle
-	$(COMPOSE_RUN) email-alert-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(COMPOSE_RUN) email-alert-api-default sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/email-alert-api/docker-compose.yml
+++ b/services/email-alert-api/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 x-email-alert-api: &email-alert-api
   build:
     context: .
-    dockerfile: email-alert-api/Dockerfile
+    dockerfile: services/email-alert-api/Dockerfile
   image: email-alert-api
   volumes:
     - ..:/govuk:delegated

--- a/services/link-checker-api/Makefile
+++ b/services/link-checker-api/Makefile
@@ -1,3 +1,3 @@
 link-checker-api: $(GOVUK_ROOT_DIR)/link-checker-api
 	$(COMPOSE_RUN) link-checker-api-default bundle
-	$(COMPOSE_RUN) link-checker-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(COMPOSE_RUN) link-checker-api-default sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/publishing-api/Makefile
+++ b/services/publishing-api/Makefile
@@ -1,5 +1,5 @@
 publishing-api: $(GOVUK_ROOT_DIR)/publishing-api content-store govuk-content-schemas
 	$(COMPOSE_RUN) publishing-api-default bundle
-	$(COMPOSE_RUN) publishing-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	$(COMPOSE_RUN) publishing-api-default rails runner 'User.first || User.create'
-	$(COMPOSE_RUN) publishing-api-default rake setup_exchange
+	$(COMPOSE_RUN) publishing-api-default sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(COMPOSE_RUN) publishing-api-default bin/rails runner 'User.first || User.create'
+	$(COMPOSE_RUN) publishing-api-default bin/rake setup_exchange

--- a/services/signon/Makefile
+++ b/services/signon/Makefile
@@ -1,3 +1,3 @@
 signon: $(GOVUK_ROOT_DIR)/signon
 	$(COMPOSE_RUN) signon-default bundle
-	$(COMPOSE_RUN) signon-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(COMPOSE_RUN) signon-default sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/support-api/Makefile
+++ b/services/support-api/Makefile
@@ -1,3 +1,3 @@
 support-api: $(GOVUK_ROOT_DIR)/support-api
 	$(COMPOSE_RUN) support-api-default bundle
-	$(COMPOSE_RUN) support-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(COMPOSE_RUN) support-api-default sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/travel-advice-publisher/Makefile
+++ b/services/travel-advice-publisher/Makefile
@@ -1,3 +1,3 @@
 travel-advice-publisher: $(GOVUK_ROOT_DIR)/travel-advice-publisher asset-manager content-store publishing-api
 	$(COMPOSE_RUN) travel-advice-publisher-default bundle
-	$(COMPOSE_RUN) travel-advice-publisher-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(COMPOSE_RUN) travel-advice-publisher-default sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/whitehall/Makefile
+++ b/services/whitehall/Makefile
@@ -1,5 +1,5 @@
 whitehall: $(GOVUK_ROOT_DIR)/whitehall asset-manager publishing-api static
 	$(COMPOSE_RUN) whitehall-default bundle
-	$(COMPOSE_RUN) whitehall-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	$(COMPOSE_RUN) whitehall-default rake shared_mustache:compile
-	$(COMPOSE_RUN) whitehall-e2e rake taxonomy:populate_end_to_end_test_data
+	$(COMPOSE_RUN) whitehall-default sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(COMPOSE_RUN) whitehall-default bin/rake shared_mustache:compile
+	$(COMPOSE_RUN) whitehall-e2e bin/rake taxonomy:populate_end_to_end_test_data


### PR DESCRIPTION
https://trello.com/c/yj0PUGVS/20-asset-manager-rake-error

This ensures we run 'rake' and 'rails' in the context of the local bundle for each service. Not doing this has caused intermittent errors for people running `make app-name` tasks.

It's also a piece of left-over debt from this decision: https://trello.com/c/yj0PUGVS/20-asset-manager-rake-error.