### PR TITLE
Improve pulling of git repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,7 @@ default:
 clone: $(addprefix ../,$(APPS))
 
 pull:
-	for repo in $(APPS); do \
-		if [ -d "${GOVUK_ROOT_DIR}/$$repo" ]; then \
-			(cd ${GOVUK_ROOT_DIR}/$$repo && echo $$repo && git pull origin master:master); \
-		fi \
-	done
+	echo $(APPS) | cut -d/ -f3 | xargs -P8 -n1 ./bin/update-git-repo.sh
 
 clean:
 	bin/govuk-docker stop

--- a/bin/update-git-repo.sh
+++ b/bin/update-git-repo.sh
@@ -64,7 +64,12 @@ cd "$(dirname "$0")"
 
 REPO="$1"
 
-cd "../../$REPO"
+if [ -d "../../$REPO" ]; then
+  cd "../../$REPO"
+else
+  warn "directory not found"
+  exit
+fi
 
 BRANCH=$(git symbolic-ref HEAD | sed 's|^refs/heads/||')
 

--- a/bin/update-git-repo.sh
+++ b/bin/update-git-repo.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+
+set -e
+
+
+ANSI_GREEN="\033[32m"
+ANSI_RED="\033[31m"
+ANSI_YELLOW="\033[33m"
+ANSI_RESET="\033[0m"
+ANSI_BOLD="\033[1m"
+
+truncate () {
+  local len="$1"
+  local str="$2"
+  if [ "${#str}" -gt "$len" ]; then
+    printf "$str" | awk "{ s=substr(\$0, 1, $len-3); print s \"...\"; }"
+  else
+    printf "$str"
+  fi
+}
+
+catch_errors () {
+  out=$(mktemp -t update-git.XXXXXX)
+  trap "rm -f '$out'" EXIT
+
+  if ! "$@" >"$out" 2>&1; then
+    error "FAILED, with output:"
+    cat "$out"
+    exit 1
+  fi
+
+  rm -f "$out"
+}
+
+start () {
+  local repo="$1"
+  local branch="$2"
+  repo=$(truncate 25 "$repo")
+  branch=$(truncate 15 "$branch")
+  printf "${ANSI_BOLD}%-25s${ANSI_RESET} %-15s " "$repo" "$branch" >&2
+}
+
+ok () {
+  start "$REPO" "$BRANCH"
+  echo "${ANSI_GREEN}${@}${ANSI_RESET}" >&2
+}
+
+warn () {
+  start "$REPO" "$BRANCH"
+  echo "${ANSI_YELLOW}${@}${ANSI_RESET}" >&2
+}
+
+error () {
+  start "$REPO" "$BRANCH"
+  echo "${ANSI_RED}${@}${ANSI_RESET}" >&2
+}
+
+if [ "$#" -ne "1" ]; then
+  echo "Usage: $(basename "$0") <reponame>"
+  exit 1
+fi
+
+cd "$(dirname "$0")"
+
+REPO="$1"
+
+cd "../../$REPO"
+
+BRANCH=$(git symbolic-ref HEAD | sed 's|^refs/heads/||')
+
+if [ -f lock ]; then
+  warn "skipped: 'lock' file exists"
+elif [ "$BRANCH" != "master" ]; then
+  warn "skipped: on non-master branch"
+elif ! git diff --quiet --ignore-submodules --no-ext-diff; then
+  warn "skipped: uncommitted local changes"
+else
+  catch_errors git fetch origin
+  if ! git merge --ff-only origin/master >/dev/null 2>&1; then
+    warn "skipped: unpushed local commits"
+  else
+    catch_errors git clean -df
+    ok "ok"
+  fi
+fi


### PR DESCRIPTION
This code is completely stolen from [update-git in the development-vm][1].

It will look through the apps, and pull master only if there aren't any local changes. It does so quickly (in parallel) and has fairly fancy output.

<img width="1552" alt="Screen Shot 2019-07-02 at 17 13 01 1" src="https://user-images.githubusercontent.com/233676/60528757-18df9980-9ced-11e9-8bbf-368d50f169c7.png">

https://trello.com/c/iuV63U6m

[1]: https://github.com/alphagov/govuk-puppet/blob/c8771e21b391bbccbcfeea19157f03ff24eff36c/development-vm/update-git.sh