### PR TITLE
Set up calendars with docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ app.dev.gov.uk.		0	IN	A	127.0.0.1
 The following apps are supported by govuk-docker to some extent.
 
    - ✅ asset-manager
+   - ✅ calendars
    - ⚠ content-data-admin
       * **TODO: Missing support for a webserver stack**
    - ✅ content-publisher

--- a/services/calendars/Dockerfile
+++ b/services/calendars/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.6.3
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
+RUN apt-get install -y nodejs
+
+RUN useradd -m build
+USER build
+
+ENV EDITOR=vim

--- a/services/calendars/Makefile
+++ b/services/calendars/Makefile
@@ -1,2 +1,2 @@
-calendars: ../calendars
-	bin/govuk-docker run calendars-default bundle
+calendars: $(GOVUK_ROOT_DIR)/calendars
+	$(COMPOSE_RUN) calendars-default bundle

--- a/services/calendars/Makefile
+++ b/services/calendars/Makefile
@@ -1,0 +1,2 @@
+calendars: ../calendars
+	bin/govuk-docker run calendars-default bundle

--- a/services/calendars/docker-compose.yml
+++ b/services/calendars/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '3.7'
+
+x-calendars: &calendars
+  build:
+    context: .
+    dockerfile: calendars/Dockerfile
+  image: calendars
+  volumes:
+    - ..:/govuk:delegated
+    - bundle:/usr/local/bundle
+  working_dir: /govuk/calendars
+
+services:
+  calendars-default:
+    <<: *calendars
+    volumes:
+      - ..:/govuk:delegated
+      - bundle:/usr/local/bundle
+
+  calendars-live: &calendars-live
+    <<: *calendars
+    depends_on:
+      - router-live
+      - content-store-live
+      - static-live
+    environment:
+      GOVUK_ASSET_ROOT: calendars.dev.gov.uk
+      VIRTUAL_HOST: calendars.dev.gov.uk
+      HOST: 0.0.0.0
+    ports:
+      - "3000"
+    command: bin/rails s -P /tmp/rails.pid
+
+  calendars-draft:
+    <<: *calendars-live
+    depends_on:
+      - router-draft
+      - content-store-draft
+      - static-draft
+    environment:
+      GOVUK_ASSET_ROOT: draft-calendars.dev.gov.uk
+      VIRTUAL_HOST: draft-calendars.dev.gov.uk
+      PLEK_HOSTNAME_PREFIX: "draft-"
+      HOST: 0.0.0.0
+
+  calendars-setup:
+    <<: *calendars
+    depends_on:
+      - publishing-api-e2e

--- a/services/calendars/docker-compose.yml
+++ b/services/calendars/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 x-calendars: &calendars
   build:
     context: .
-    dockerfile: calendars/Dockerfile
+    dockerfile: services/calendars/Dockerfile
   image: calendars
   volumes:
     - ..:/govuk:delegated


### PR DESCRIPTION
To populate content-store and draft-content-store with calendars, this
rake task needs to be run using the setup service -
https://github.com/alphagov/calendars/blob/master/lib/tasks/publishing_api.rake.

`govuk-docker run-this setup rake publishing_api:publish`

## Running the tests
<img width="1440" alt="Screen Shot 2019-07-02 at 18 09 05" src="https://user-images.githubusercontent.com/24479188/60532240-c99d6700-9cf4-11e9-8dd7-eaaf535d0793.png">

## Draft stack
<img width="1358" alt="Screen Shot 2019-07-02 at 18 08 38" src="https://user-images.githubusercontent.com/24479188/60532248-cefab180-9cf4-11e9-9098-28279be440a0.png">

## Live stack
<img width="1331" alt="Screen Shot 2019-07-02 at 18 07 17" src="https://user-images.githubusercontent.com/24479188/60532259-d326cf00-9cf4-11e9-89a4-d77423771942.png">

Trello:
https://trello.com/c/sm2rw3Nr/27-set-up-calendars