### PR TITLE
Add smart-answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ The following apps are supported by govuk-docker to some extent.
    - ✅ router
    - ✅ router-api
    - ✅ signon
+   - ✅ smart-answers
    - ✅ specialist-publisher
    - ⚠ static
       * JavaScript 404 errors when previewing pages, possibly [related to analytics](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/init.js.erb#L28)

--- a/services/nginx-proxy/docker-compose.yml
+++ b/services/nginx-proxy/docker-compose.yml
@@ -28,6 +28,7 @@ services:
           - router-api.dev.gov.uk
           - router.dev.gov.uk
           - signon.dev.gov.uk
+          - smart-answers.dev.gov.uk
           - specialist-publisher.dev.gov.uk
           - static.dev.gov.uk
           - support.dev.gov.uk

--- a/services/smart-answers/Dockerfile
+++ b/services/smart-answers/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:2.6.3
+
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
+
+# Dependencies required for Google Chrome
+RUN apt-get install -y qt5-default libnss3-dev libxss1 libappindicator1 libindicator7
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && apt install -y ./google-chrome*.deb
+
+RUN wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 2>&1
+RUN tar -xf phantomjs-2.1.1-linux-x86_64.tar.bz2
+RUN cp phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN apt-get update -qq && apt-get install -y nodejs
+
+RUN useradd -m build
+USER build
+
+ENV EDITOR=vim

--- a/services/smart-answers/Makefile
+++ b/services/smart-answers/Makefile
@@ -1,0 +1,2 @@
+smart-answers: $(GOVUK_ROOT_DIR)/smart-answers asset-manager publishing-api static
+	$(COMPOSE_RUN) smart-answers-lite bundle

--- a/services/smart-answers/docker-compose.yml
+++ b/services/smart-answers/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.7'
+
+x-smart-answers: &smart-answers
+  build:
+    context: .
+    dockerfile: services/smart-answers/Dockerfile
+  image: smart-answers
+  volumes:
+    - ..:/govuk:delegated
+    - bundle:/usr/local/bundle
+    - home:/home/build
+  working_dir: /govuk/smart-answers
+
+services:
+  smart-answers-lite:
+    <<: *smart-answers
+    privileged: true
+
+  smart-answers-app:
+    <<: *smart-answers
+    depends_on:
+      - nginx-proxy
+      - publishing-api-app
+      - asset-manager-app
+      - static-app
+      - content-store-app
+    environment:
+      VIRTUAL_HOST: smart-answers.dev.gov.uk
+      HOST: 0.0.0.0
+    ports:
+      - "3000"
+    command: bin/rails s -P /tmp/rails.pid


### PR DESCRIPTION
Trello: https://trello.com/c/tQL1TvP8

It seems that smart-answer needs both Google Chrome and PhantomJS to run it's tests:
https://github.com/alphagov/smart-answers/blob/b63316766b31064e7ccfa78fbcffcfcb90c6f72d/doc/smart-answers-app-development/testing.md#external-dependencies

# Publishing smart-answers

Run:  `govuk-docker run rake publishing_api:publish`

# Rendering smart-answers

Run:  `govuk-docker startup`

http://smart-answers.dev.gov.uk/pay-leave-for-parents/y

![Screen Shot 2019-07-04 at 12 57 16](https://user-images.githubusercontent.com/5793815/60666208-6c252980-9e5e-11e9-8b0f-7e683c1037a2.png)

