### PR TITLE
Make stack a keyword argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ publish a document end-to-end e.g.
 
 ```
 # Run whitehall rake plus any required dependencies (DBs)
-whitehall$ govuk-docker run-this default rake
+whitehall$ govuk-docker run-this rake
 
 # Start content-tagger rails plus a minimal backend stack
-content-tagger$ govuk-docker run-this backend
+content-tagger$ govuk-docker run-this --stack backend
 
 # Start content-publisher rails plus an end-to-end stack
-content-publisher$ govuk-docker run-this e2e
+content-publisher$ govuk-docker run-this --stack e2e
 ```
 
 In the last two commands, the app will be available in your browser at *app-name.dev.gov.uk*.
@@ -152,7 +152,7 @@ govuk-docker logs -f
 docker ps -a
 
 # get a terminal inside a service
-govuk-docker run-this default bash
+govuk-docker run-this bash
 ```
 
 ### How to: add a new service

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -23,8 +23,9 @@ class GovukDockerCLI < Thor
     Commands::Prune.new.call
   end
 
-  desc "run-this STACK [ARGS]", "Run the service in the current directory with the specified stack (for example `govuk-docker run-this backend`)"
-  def run_this(stack, *args)
-    Commands::RunThis.new(stack, args).call
+  desc "run-this [ARGS]", "Run the service in the current directory with the specified stack (for example `govuk-docker run-this --stack backend`)"
+  option :stack, default: "default"
+  def run_this(*args)
+    Commands::RunThis.new(options[:stack], args).call
   end
 end

--- a/spec/govuk_docker_cli_spec.rb
+++ b/spec/govuk_docker_cli_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+require_relative "../lib/govuk_docker_cli"
+
+describe GovukDockerCLI do
+  let(:command) { nil }
+  let(:args) { [] }
+  subject { described_class.start([command] + args) }
+  let(:command_double) { double }
+  before { allow(command_double).to receive(:call) }
+
+  describe "run-this" do
+    let(:command) { "run-this" }
+
+    context "without a stack argument" do
+      it "runs in the default stack" do
+        expect(Commands::RunThis)
+          .to receive(:new).with("default", [])
+          .and_return(command_double)
+        subject
+      end
+    end
+
+    context "with a stack argument" do
+      let(:args) { ["--stack", "backend"] }
+
+      it "runs in the specified stack" do
+        expect(Commands::RunThis)
+          .to receive(:new).with("backend", [])
+          .and_return(command_double)
+        subject
+      end
+    end
+
+    context "with additional arguments" do
+      let(:args) { ["bundle", "exec", "rspec"] }
+
+      it "runs the command with additinal arguments" do
+        expect(Commands::RunThis)
+          .to receive(:new).with("default", ["bundle", "exec", "rspec"])
+          .and_return(command_double)
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
By default the stack will be 'default' and for other stacks you can pass in the `--stack` argument.

This makes it clearer what the argument means rather than an anonymous positional argument as it is currently.

[Trello Card](https://trello.com/c/akpi3nt3/2-%F0%9F%92%AA-optimise-day-to-day-development)