### PR TITLE
Tune the help messages for govuk-docker a bit

### DIFF
--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -6,22 +6,24 @@ require_relative "./commands/prune"
 require_relative "./commands/run_this"
 
 class GovukDockerCLI < Thor
-  desc "build-this", "build the current service"
+  package_name "govuk-docker"
+
+  desc "build-this", "Build the service in the current directory"
   def build_this
     Commands::BuildThis.new.call
   end
 
-  desc "compose ARGS", "passes ARGS to docker-compose"
+  desc "compose ARGS", "Run `docker-compose` with ARGS"
   def compose(*args)
     Commands::Compose.new.call(*args)
   end
 
-  desc "prune", "remove all docker containers, volumes and images"
+  desc "prune", "Remove all docker containers, volumes and images"
   def prune
     Commands::Prune.new.call
   end
 
-  desc "run-this STACK [ARGS]", "run the current service in the stack with optional args"
+  desc "run-this STACK [ARGS]", "Run the service in the current directory with the specified stack (for example `govuk-docker run-this backend`)"
   def run_this(stack, *args)
     Commands::RunThis.new(stack, args).call
   end


### PR DESCRIPTION
Example output:

```
@tijmen ~/govuk/govuk-docker on current-service $ bin/govuk-docker
govuk-docker commands:
govuk-docker build-this             # Build the service in the current directory
govuk-docker compose ARGS           # Run `docker-compose` with ARGS
govuk-docker help [COMMAND]         # Describe available commands or one specific command
govuk-docker prune                  # Remove all docker containers, volumes and images
govuk-docker run-this STACK [ARGS]  # Run the service in the current directory with the specified stack (for example `govuk-docker run-this backend`)
```