### PR TITLE
Add stack for dummy government-frontend

### DIFF
--- a/services/government-frontend/docker-compose.yml
+++ b/services/government-frontend/docker-compose.yml
@@ -44,3 +44,17 @@ services:
       VIRTUAL_HOST: draft-government-frontend.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"
       HOST: 0.0.0.0
+
+  government-frontend-app-live:
+    <<: *government-frontend
+    depends_on:
+      - nginx-proxy
+    environment:
+      GOVUK_WEBSITE_ROOT: https://www.gov.uk
+      PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
+      PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
+      VIRTUAL_HOST: government-frontend.dev.gov.uk
+      HOST: 0.0.0.0
+    ports:
+      - "3000"
+    command: bin/rails s -P /tmp/rails.pid


### PR DESCRIPTION
https://trello.com/c/akpi3nt3/2-%F0%9F%92%AA-optimise-day-to-day-development

This adds a 'dummy' stack to the government-frontend service to make it
use external content items - in this case, from the Heroku sample app.

Emulates some of the current behaviour in https://github.com/alphagov/government-frontend/blob/master/startup.sh