### PR TITLE
Add govuk-docker doctor

### DIFF
--- a/lib/doctor/dnsmasq.rb
+++ b/lib/doctor/dnsmasq.rb
@@ -1,0 +1,56 @@
+module Doctor
+  class Dnsmasq
+    def initialize
+      @message = []
+    end
+
+    def call
+      get_dnsmasq_install_state
+      get_dnsmasq_run_state
+
+      message.join("\r\n")
+    end
+
+    private
+    attr_reader :message
+
+    DNSMASQ_INSTALLED = "✅ Dnsmasq is installed".freeze
+    INSTALL_DNSMASQ = <<~HEREDOC.freeze
+      ❌ Dnsmasq not found.
+      You should install it with `brew install dnsmasq`.
+      For a manual installation, visit http://www.thekelleys.org.uk/dnsmasq/doc.html
+    HEREDOC
+
+    DNSMASQ_RUNNING = "✅ Dnsmasq is running".freeze
+    START_DNSMASQ = <<~HEREDOC.freeze
+      ❌ Dnsmasq is not running.
+      Dnsmasq needs to run as root.
+      You should start it with `sudo brew services start dnsmasq`.
+    HEREDOC
+
+    def get_dnsmasq_install_state
+      if dnsmasq_installed?
+        message << DNSMASQ_INSTALLED
+      else
+        message << INSTALL_DNSMASQ
+      end
+    end
+
+    def dnsmasq_installed?
+      system "which dnsmasq 1>/dev/null"
+    end
+
+    def get_dnsmasq_run_state
+      return unless dnsmasq_installed?
+      if dnsmasq_running?
+        message << DNSMASQ_RUNNING
+      else
+        message << START_DNSMASQ
+      end
+    end
+
+    def dnsmasq_running?
+      system "pgrep dnsmasq 1>/dev/null"
+    end
+  end
+end

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -4,6 +4,7 @@ require_relative "./commands/build_this"
 require_relative "./commands/compose"
 require_relative "./commands/prune"
 require_relative "./commands/run_this"
+require_relative "./doctor/dnsmasq"
 
 class GovukDockerCLI < Thor
   package_name "govuk-docker"
@@ -16,6 +17,12 @@ class GovukDockerCLI < Thor
   desc "compose ARGS", "Run `docker-compose` with ARGS"
   def compose(*args)
     Commands::Compose.new.call(*args)
+  end
+
+  desc "doctor", "Various tests to help diagnose issues when running govuk-docker"
+  def doctor
+    puts "Checking dnsmasq"
+    puts Doctor::Dnsmasq.new.call
   end
 
   desc "prune", "Remove all docker containers, volumes and images"

--- a/spec/doctor/dnsmasq_spec.rb
+++ b/spec/doctor/dnsmasq_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require "./lib/doctor/dnsmasq"
+
+describe Doctor::Dnsmasq do
+  subject { described_class.new }
+
+  context "when dnsmasq is not installed" do
+    it "should tell me to install dnsmasq if it is not yet installed" do
+      allow(subject).to receive(:system).with("which dnsmasq 1>/dev/null").and_return(false)
+      expect(subject.call).to include("Dnsmasq not found")
+    end
+  end
+
+  context "when dnsmasq is installed" do
+    it "should report that dnsmasq is installed if it is" do
+      allow(subject).to receive(:system).with("which dnsmasq 1>/dev/null").and_return(true)
+      allow(subject).to receive(:system).with("pgrep dnsmasq 1>/dev/null")
+      expect(subject.call).to include("Dnsmasq is installed")
+    end
+
+    it "should report that dnsmasq is running" do
+      allow(subject).to receive(:system).with("which dnsmasq 1>/dev/null").and_return(true)
+      allow(subject).to receive(:system).with("pgrep dnsmasq 1>/dev/null").and_return(true)
+      expect(subject.call).to include("Dnsmasq is running")
+    end
+
+    it "should tell me to start dnsmasq if it is not running" do
+      allow(subject).to receive(:system).with("which dnsmasq 1>/dev/null").and_return(true)
+      allow(subject).to receive(:system).with("pgrep dnsmasq 1>/dev/null").and_return(false)
+      expect(subject.call).to include("sudo brew services start dnsmasq")
+    end
+  end
+end


### PR DESCRIPTION
Add a `govuk-docker doctor` command to the CLI.

Add checks for dnsmasq to determine whether or not it is installed and running.

Print some helpful messages to report the state of dnsmasq and some remedial steps if needed.