### PR TITLE
Add an all-apps target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOVUK_ROOT_DIR ?= "${HOME}/govuk"
 #     $ touch clean
 #     $ make clean
 #     make: `clean' is up to date.
-.PHONY: clone pull clean test
+.PHONY: clone pull clean test all-apps
 
 APPS ?= $(shell ls services/*/Makefile | xargs -L 1 dirname | xargs -L 1 basename)
 
@@ -33,6 +33,10 @@ test:
 	# Test that the docker-compose config is valid. This will error if there are errors
 	# in the YAML files, or incompatible features are used.
 	bin/govuk-docker compose config
+
+# This will be slow and may repeat work, so generally you don't want
+# to run this.
+all-apps: $(APPS) clean
 
 # Clone an app, for example:
 #


### PR DESCRIPTION
This is useful for teams which involve all the apps, like Platform Health.