### PR TITLE
 Rename 'run-this' to 'run' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ publish a document end-to-end e.g.
 
 ```
 # Run whitehall rake plus any required dependencies (DBs)
-whitehall$ govuk-docker run-this rake
+whitehall$ govuk-docker run rake
 
 # Start content-tagger rails plus a minimal backend stack
-content-tagger$ govuk-docker run-this --stack backend
+content-tagger$ govuk-docker run --stack backend
 
 # Start content-publisher rails plus an end-to-end stack
-content-publisher$ govuk-docker run-this --stack e2e
+content-publisher$ govuk-docker run --stack e2e
 ```
 
 In the last two commands, the app will be available in your browser at *app-name.dev.gov.uk*.
@@ -147,13 +147,13 @@ Sometimes things go wrong or some investigation is needed. As govuk-docker is ju
 
 ```
 # tail logs for running services
-govuk-docker logs -f
+govuk-docker compose logs -f
 
 # get all the running containers
 docker ps -a
 
 # get a terminal inside a service
-govuk-docker run-this bash
+govuk-docker run bash
 ```
 
 ### How to: add a new service

--- a/lib/commands/run.rb
+++ b/lib/commands/run.rb
@@ -1,7 +1,7 @@
 require_relative './base'
 require_relative './compose'
 
-class Commands::RunThis < Commands::Base
+class Commands::Run < Commands::Base
   def initialize(stack, args, service = nil, config_directory = nil)
     super(service, config_directory)
     @stack = stack

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -44,6 +44,4 @@ class GovukDockerCLI < Thor
   def run(*args)
     Commands::Run.new(options[:stack], args).call
   end
-
-  map "run-this" => "run"
 end

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -7,6 +7,15 @@ require_relative "./commands/run_this"
 require_relative "./doctor/dnsmasq"
 
 class GovukDockerCLI < Thor
+  # https://github.com/ddollar/foreman/blob/83fd5eeb8c4b522cb84d8e74031080143ea6353b/lib/foreman/cli.rb#L29-L35
+  class << self
+    # Hackery. Take the run method away from Thor so that we can redefine it.
+    def is_thor_reserved_word?(word, type)
+      return false if word == "run"
+      super
+    end
+  end
+
   package_name "govuk-docker"
 
   desc "build-this", "Build the service in the current directory"

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -3,7 +3,7 @@ require "thor"
 require_relative "./commands/build_this"
 require_relative "./commands/compose"
 require_relative "./commands/prune"
-require_relative "./commands/run_this"
+require_relative "./commands/run"
 require_relative "./doctor/dnsmasq"
 
 class GovukDockerCLI < Thor
@@ -39,9 +39,11 @@ class GovukDockerCLI < Thor
     Commands::Prune.new.call
   end
 
-  desc "run-this [ARGS]", "Run the service in the current directory with the specified stack (for example `govuk-docker run-this --stack backend`)"
+  desc "run [ARGS]", "Run the service in the current directory with the specified stack (for example `govuk-docker run --stack backend`)"
   option :stack, default: "default"
-  def run_this(*args)
-    Commands::RunThis.new(options[:stack], args).call
+  def run(*args)
+    Commands::Run.new(options[:stack], args).call
   end
+
+  map "run-this" => "run"
 end

--- a/spec/commands/run_spec.rb
+++ b/spec/commands/run_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
-require_relative "../../lib/commands/run_this"
+require_relative "../../lib/commands/run"
 
-describe Commands::RunThis do
+describe Commands::Run do
   let(:config_directory) { "spec/fixtures" }
   let(:service) { nil }
   let(:stack) { nil }

--- a/spec/govuk_docker_cli_spec.rb
+++ b/spec/govuk_docker_cli_spec.rb
@@ -8,12 +8,12 @@ describe GovukDockerCLI do
   let(:command_double) { double }
   before { allow(command_double).to receive(:call) }
 
-  describe "run-this" do
-    let(:command) { "run-this" }
+  describe "run" do
+    let(:command) { "run" }
 
     context "without a stack argument" do
       it "runs in the default stack" do
-        expect(Commands::RunThis)
+        expect(Commands::Run)
           .to receive(:new).with("default", [])
           .and_return(command_double)
         subject
@@ -24,7 +24,7 @@ describe GovukDockerCLI do
       let(:args) { ["--stack", "backend"] }
 
       it "runs in the specified stack" do
-        expect(Commands::RunThis)
+        expect(Commands::Run)
           .to receive(:new).with("backend", [])
           .and_return(command_double)
         subject
@@ -35,7 +35,7 @@ describe GovukDockerCLI do
       let(:args) { ["bundle", "exec", "rspec"] }
 
       it "runs the command with additinal arguments" do
-        expect(Commands::RunThis)
+        expect(Commands::Run)
           .to receive(:new).with("default", ["bundle", "exec", "rspec"])
           .and_return(command_double)
         subject


### PR DESCRIPTION
Now that we're no longer allowing arbitrary docker-compose commands we no longer have a clash with the docker-compose run command so we can rename 'run-this' to 'run' meaning devs have to type less.

I've allowed the old 'run-this' command to exist for backwards compatibility reasons but it will be removed at some point in the future.

[Trello Card](https://trello.com/c/akpi3nt3/2-%F0%9F%92%AA-optimise-day-to-day-development)