### PR TITLE
use `-` instead of `_` to keep consistent with previous implementation

### DIFF
--- a/services/govuk_publishing_components/docker-compose.yml
+++ b/services/govuk_publishing_components/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     depends_on:
       - nginx-proxy
     environment:
-      VIRTUAL_HOST: govuk_publishing_components.dev.gov.uk
+      VIRTUAL_HOST: govuk-publishing-components.dev.gov.uk
     ports:
       - "9292"
     command: bundle exec rackup spec/dummy/config.ru --host 0.0.0.0


### PR DESCRIPTION
Using _ in URL names is not valid.

tester: https://regexr.com/3au3g