### PR TITLE
Add some helpful commands to `govuk-docker help compose`

### DIFF
--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -24,6 +24,15 @@ class GovukDockerCLI < Thor
   end
 
   desc "compose ARGS", "Run `docker-compose` with ARGS"
+  long_desc <<-LONGDESC
+    List all stacks across all apps:
+
+    > govuk-docker compose ps --services
+
+    Stop all containers
+
+    > govuk-docker compose stop
+  LONGDESC
   def compose(*args)
     Commands::Compose.new.call(*args)
   end


### PR DESCRIPTION
I tried to get it in the same style as the normal help text:

```ruby
long_desc <<-LONGDESC
Some helpful compose commands are:
  ps --services  # List all stacks across all apps
  stop           # Stop all containers
LONGDESC
```

But Thor mangled the whitespace, so this is the best I can do.

Looks like this:

```
gds8092 [master] >>>  govuk-docker help compose
Usage:
  govuk-docker compose ARGS

Description:
  List all stacks across all apps:

  > govuk-docker compose ps --services

  Stop all containers

  > govuk-docker compose stop
```