### PR TITLE
Make Makefile location-independent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-GOVUK_ROOT_DIR ?= "${HOME}/govuk"
+GOVUK_ROOT_DIR   ?= $(HOME)/govuk
+GOVUK_DOCKER_DIR ?= $(GOVUK_ROOT_DIR)/govuk-docker
+GOVUK_DOCKER     ?= $(GOVUK_DOCKER_DIR)/bin/govuk-docker
+
+COMPOSE_RUN = $(GOVUK_DOCKER) compose run
+
+APPS ?= $(shell ls ${GOVUK_DOCKER_DIR}/services/*/Makefile | xargs -L 1 dirname | xargs -L 1 basename)
 
 # This is a Makefile best practice to say that these are not file
 # names.  For example, if you were to create a file called "clean",
@@ -9,8 +15,6 @@ GOVUK_ROOT_DIR ?= "${HOME}/govuk"
 #     $ make clean
 #     make: `clean' is up to date.
 .PHONY: clone pull clean test
-
-APPS ?= $(shell ls services/*/Makefile | xargs -L 1 dirname | xargs -L 1 basename)
 
 default:
 	@echo "Run 'make APP-NAME' to set up an app and its dependencies."
@@ -36,13 +40,13 @@ test:
 
 # Clone an app, for example:
 #
-#     make ../content-publisher
+#     make $HOME/govuk/content-publisher
 #
 # The 'services/%/Makefile' bit is to double-check that this is a git
 # repository, as all of our apps have a Makefile.
-../%: services/%/Makefile
+$(GOVUK_ROOT_DIR)/%: $(GOVUK_DOCKER_DIR)/services/%/Makefile
 	if [ ! -d "${GOVUK_ROOT_DIR}/$*" ]; then \
 		echo "$*" && git clone "git@github.com:alphagov/$*.git" "${GOVUK_ROOT_DIR}/$*"; \
 	fi
 
-include $(shell ls services/*/Makefile)
+include $(shell ls ${GOVUK_DOCKER_DIR}/services/*/Makefile)

--- a/services/asset-manager/Makefile
+++ b/services/asset-manager/Makefile
@@ -1,4 +1,4 @@
-asset-manager: ../asset-manager
-	bin/govuk-docker compose run asset-manager-default bundle
-	bin/govuk-docker compose run asset-manager-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	bin/govuk-docker compose run asset-manager-default rails runner 'User.first || User.create'
+asset-manager: $(GOVUK_ROOT_DIR)/asset-manager
+	$(COMPOSE_RUN) asset-manager-default bundle
+	$(COMPOSE_RUN) asset-manager-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(COMPOSE_RUN) asset-manager-default rails runner 'User.first || User.create'

--- a/services/content-data-admin/Makefile
+++ b/services/content-data-admin/Makefile
@@ -1,3 +1,3 @@
-content-data-admin: ../content-data-admin
-	bin/govuk-docker compose run content-data-admin-default bundle
-	bin/govuk-docker compose run content-data-admin-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+content-data-admin: $(GOVUK_ROOT_DIR)/content-data-admin
+	$(COMPOSE_RUN) content-data-admin-default bundle
+	$(COMPOSE_RUN) content-data-admin-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/services/content-publisher/Makefile
+++ b/services/content-publisher/Makefile
@@ -1,4 +1,4 @@
-content-publisher: ../content-publisher asset-manager publishing-api
-	bin/govuk-docker compose run content-publisher-default bundle
-	bin/govuk-docker compose run content-publisher-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	bin/govuk-docker compose run content-publisher-default yarn
+content-publisher: $(GOVUK_ROOT_DIR)/content-publisher asset-manager publishing-api
+	$(COMPOSE_RUN) content-publisher-default bundle
+	$(COMPOSE_RUN) content-publisher-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(COMPOSE_RUN) content-publisher-default yarn

--- a/services/content-store/Makefile
+++ b/services/content-store/Makefile
@@ -1,6 +1,6 @@
-content-store: ../content-store router-api govuk-content-schemas
-	bin/govuk-docker compose run content-store-default bundle
-	bin/govuk-docker compose run content-store-default rake db:create
-	bin/govuk-docker compose run content-store-default rails runner 'User.first || User.create'
-	bin/govuk-docker compose run content-store-draft rake db:create
-	bin/govuk-docker compose run content-store-draft rails runner 'User.first || User.create'
+content-store: $(GOVUK_ROOT_DIR)/content-store router-api govuk-content-schemas
+	$(COMPOSE_RUN) content-store-default bundle
+	$(COMPOSE_RUN) content-store-default rake db:create
+	$(COMPOSE_RUN) content-store-default rails runner 'User.first || User.create'
+	$(COMPOSE_RUN) content-store-draft rake db:create
+	$(COMPOSE_RUN) content-store-draft rails runner 'User.first || User.create'

--- a/services/content-tagger/Makefile
+++ b/services/content-tagger/Makefile
@@ -1,3 +1,3 @@
-content-tagger: ../content-tagger publishing-api
-	bin/govuk-docker compose run content-tagger-default bundle
-	bin/govuk-docker compose run content-tagger-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+content-tagger: $(GOVUK_ROOT_DIR)/content-tagger publishing-api
+	$(COMPOSE_RUN) content-tagger-default bundle
+	$(COMPOSE_RUN) content-tagger-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/services/email-alert-api/Makefile
+++ b/services/email-alert-api/Makefile
@@ -1,3 +1,3 @@
-email-alert-api: ../email-alert-api
-	bin/govuk-docker compose run email-alert-api-default bundle
-	bin/govuk-docker compose run email-alert-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+email-alert-api: $(GOVUK_ROOT_DIR)/email-alert-api
+	$(COMPOSE_RUN) email-alert-api-default bundle
+	$(COMPOSE_RUN) email-alert-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/services/government-frontend/Makefile
+++ b/services/government-frontend/Makefile
@@ -1,2 +1,2 @@
-government-frontend: ../government-frontend content-store router static govuk-content-schemas
-	bin/govuk-docker compose run government-frontend-default bundle
+government-frontend: $(GOVUK_ROOT_DIR)/government-frontend content-store router static govuk-content-schemas
+	$(COMPOSE_RUN) government-frontend-default bundle

--- a/services/govspeak/Makefile
+++ b/services/govspeak/Makefile
@@ -1,2 +1,2 @@
-govspeak: ../govspeak
-	bin/govuk-docker compose run govspeak-default bundle
+govspeak: $(GOVUK_ROOT_DIR)/govspeak
+	$(COMPOSE_RUN) govspeak-default bundle

--- a/services/govuk-content-schemas/Makefile
+++ b/services/govuk-content-schemas/Makefile
@@ -1,2 +1,2 @@
-govuk-content-schemas: ../govuk-content-schemas
-	bin/govuk-docker compose run govuk-content-schemas-default bundle
+govuk-content-schemas: $(GOVUK_ROOT_DIR)/govuk-content-schemas
+	$(COMPOSE_RUN) govuk-content-schemas-default bundle

--- a/services/govuk-developer-docs/Makefile
+++ b/services/govuk-developer-docs/Makefile
@@ -1,2 +1,2 @@
-govuk-developer-docs: ../govuk-developer-docs
-	bin/govuk-docker compose run govuk-developer-docs-default bundle
+govuk-developer-docs: $(GOVUK_ROOT_DIR)/govuk-developer-docs
+	$(COMPOSE_RUN) govuk-developer-docs-default bundle

--- a/services/govuk-lint/Makefile
+++ b/services/govuk-lint/Makefile
@@ -1,2 +1,2 @@
-govuk-lint: ../govuk-lint
-	bin/govuk-docker compose run govuk-lint-default bundle
+govuk-lint: $(GOVUK_ROOT_DIR)/govuk-lint
+	$(COMPOSE_RUN) govuk-lint-default bundle

--- a/services/govuk_app_config/Makefile
+++ b/services/govuk_app_config/Makefile
@@ -1,2 +1,2 @@
-govuk_app_config: ../govuk_app_config
-	bin/govuk-docker compose run govuk_app_config-default bundle
+govuk_app_config: $(GOVUK_ROOT_DIR)/govuk_app_config
+	$(COMPOSE_RUN) govuk_app_config-default bundle

--- a/services/govuk_publishing_components/Makefile
+++ b/services/govuk_publishing_components/Makefile
@@ -1,2 +1,2 @@
-govuk_publishing_components: ../govuk_publishing_components
-	bin/govuk-docker compose run govuk_publishing_components-default bundle
+govuk_publishing_components: $(GOVUK_ROOT_DIR)/govuk_publishing_components
+	$(COMPOSE_RUN) govuk_publishing_components-default bundle

--- a/services/link-checker-api/Makefile
+++ b/services/link-checker-api/Makefile
@@ -1,3 +1,3 @@
-link-checker-api: ../link-checker-api
-	bin/govuk-docker compose run link-checker-api-default bundle
-	bin/govuk-docker compose run link-checker-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+link-checker-api: $(GOVUK_ROOT_DIR)/link-checker-api
+	$(COMPOSE_RUN) link-checker-api-default bundle
+	$(COMPOSE_RUN) link-checker-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/services/miller-columns-element/Makefile
+++ b/services/miller-columns-element/Makefile
@@ -1,2 +1,2 @@
-miller-columns-element: ../miller-columns-element
-	bin/govuk-docker compose run miller-columns-element-default npm install
+miller-columns-element: $(GOVUK_ROOT_DIR)/miller-columns-element
+	$(COMPOSE_RUN) miller-columns-element-default npm install

--- a/services/plek/Makefile
+++ b/services/plek/Makefile
@@ -1,2 +1,2 @@
-plek: ../plek
-	bin/govuk-docker compose run plek-default bundle
+plek: $(GOVUK_ROOT_DIR)/plek
+	$(COMPOSE_RUN) plek-default bundle

--- a/services/publishing-api/Makefile
+++ b/services/publishing-api/Makefile
@@ -1,5 +1,5 @@
-publishing-api: ../publishing-api content-store govuk-content-schemas
-	bin/govuk-docker compose run publishing-api-default bundle
-	bin/govuk-docker compose run publishing-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	bin/govuk-docker compose run publishing-api-default rails runner 'User.first || User.create'
-	bin/govuk-docker compose run publishing-api-default rake setup_exchange
+publishing-api: $(GOVUK_ROOT_DIR)/publishing-api content-store govuk-content-schemas
+	$(COMPOSE_RUN) publishing-api-default bundle
+	$(COMPOSE_RUN) publishing-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(COMPOSE_RUN) publishing-api-default rails runner 'User.first || User.create'
+	$(COMPOSE_RUN) publishing-api-default rake setup_exchange

--- a/services/router-api/Makefile
+++ b/services/router-api/Makefile
@@ -1,2 +1,2 @@
-router-api: ../router-api router
-	bin/govuk-docker compose run router-api-default bundle
+router-api: $(GOVUK_ROOT_DIR)/router-api router
+	$(COMPOSE_RUN) router-api-default bundle

--- a/services/router/Makefile
+++ b/services/router/Makefile
@@ -1,2 +1,2 @@
-router: ../router
-	bin/govuk-docker compose run router-default sh -c "BINARY=router make build"
+router: $(GOVUK_ROOT_DIR)/router
+	$(COMPOSE_RUN) router-default sh -c "BINARY=router make build"

--- a/services/signon/Makefile
+++ b/services/signon/Makefile
@@ -1,3 +1,3 @@
-signon: ../signon
-	bin/govuk-docker compose run signon-default bundle
-	bin/govuk-docker compose run signon-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+signon: $(GOVUK_ROOT_DIR)/signon
+	$(COMPOSE_RUN) signon-default bundle
+	$(COMPOSE_RUN) signon-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/services/specialist-publisher/Makefile
+++ b/services/specialist-publisher/Makefile
@@ -1,3 +1,3 @@
-specialist-publisher: ../specialist-publisher asset-manager publishing-api
-	bin/govuk-docker compose run specialist-publisher-default bundle
-	bin/govuk-docker compose run specialist-publisher-default sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+specialist-publisher: $(GOVUK_ROOT_DIR)/specialist-publisher asset-manager publishing-api
+	$(COMPOSE_RUN) specialist-publisher-default bundle
+	$(COMPOSE_RUN) specialist-publisher-default sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/static/Makefile
+++ b/services/static/Makefile
@@ -1,2 +1,2 @@
-static: ../static
-	bin/govuk-docker compose run static-default bundle
+static: $(GOVUK_ROOT_DIR)/static
+	$(COMPOSE_RUN) static-default bundle

--- a/services/support-api/Makefile
+++ b/services/support-api/Makefile
@@ -1,3 +1,3 @@
-support-api: ../support-api
-	bin/govuk-docker compose run support-api-default bundle
-	bin/govuk-docker compose run support-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+support-api: $(GOVUK_ROOT_DIR)/support-api
+	$(COMPOSE_RUN) support-api-default bundle
+	$(COMPOSE_RUN) support-api-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/services/support/Makefile
+++ b/services/support/Makefile
@@ -1,2 +1,2 @@
-support: ../support support-api
-	bin/govuk-docker compose run support-default bundle
+support: $(GOVUK_ROOT_DIR)/support support-api
+	$(COMPOSE_RUN) support-default bundle

--- a/services/travel-advice-publisher/Makefile
+++ b/services/travel-advice-publisher/Makefile
@@ -1,3 +1,3 @@
-travel-advice-publisher: ../travel-advice-publisher asset-manager content-store publishing-api
-	bin/govuk-docker compose run travel-advice-publisher-default bundle
-	bin/govuk-docker compose run travel-advice-publisher-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+travel-advice-publisher: $(GOVUK_ROOT_DIR)/travel-advice-publisher asset-manager content-store publishing-api
+	$(COMPOSE_RUN) travel-advice-publisher-default bundle
+	$(COMPOSE_RUN) travel-advice-publisher-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/services/whitehall/Makefile
+++ b/services/whitehall/Makefile
@@ -1,5 +1,5 @@
-whitehall: ../whitehall asset-manager publishing-api static
-	bin/govuk-docker compose run whitehall-default bundle
-	bin/govuk-docker compose run whitehall-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
-	bin/govuk-docker compose run whitehall-default rake shared_mustache:compile
-	bin/govuk-docker compose run whitehall-e2e rake taxonomy:populate_end_to_end_test_data
+whitehall: $(GOVUK_ROOT_DIR)/whitehall asset-manager publishing-api static
+	$(COMPOSE_RUN) whitehall-default bundle
+	$(COMPOSE_RUN) whitehall-default sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(COMPOSE_RUN) whitehall-default rake shared_mustache:compile
+	$(COMPOSE_RUN) whitehall-e2e rake taxonomy:populate_end_to_end_test_data


### PR DESCRIPTION
Now running `make -f ~/govuk/govuk-docker/Makefile foo` should work
regardless of where you are.  $GOVUK_ROOT_DIR can be overridden to
control where things will be cloned to.