### PR TITLE
Add a govuk-docker startup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ publish a document end-to-end e.g.
 # Run whitehall rake plus any required dependencies (DBs)
 whitehall$ govuk-docker run rake
 
+# Run whitehall rake plus a minimal app stack
+whitehall$ govuk-docker run --stack app rake
+
 # Start content-tagger rails plus a minimal app stack
-content-tagger$ govuk-docker run --stack app
+content-tagger$ govuk-docker startup
 
 # Start content-publisher rails plus an end-to-end stack
-content-publisher$ govuk-docker run --stack app-e2e
+content-publisher$ govuk-docker startup e2e
 ```
 
 In the last two commands, the app will be available in your browser at *app-name.dev.gov.uk*.

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -53,4 +53,10 @@ class GovukDockerCLI < Thor
   def run(*args)
     Commands::Run.new(options[:stack], args).call
   end
+
+  desc "startup [VARIATION]", "Run the service in the current directory with the `app` stack. Variations can be provided, for example `live` or `draft`."
+  def startup(variation = nil)
+    stack = variation ? "app-#{variation}" : "app"
+    Commands::Run.new(stack, []).call
+  end
 end

--- a/spec/govuk_docker_cli_spec.rb
+++ b/spec/govuk_docker_cli_spec.rb
@@ -42,4 +42,28 @@ describe GovukDockerCLI do
       end
     end
   end
+
+  describe "startup" do
+    let(:command) { "startup" }
+
+    context "without a variation argument" do
+      it "runs in the backend stack" do
+        expect(Commands::Run)
+          .to receive(:new).with("app", [])
+          .and_return(command_double)
+        subject
+      end
+    end
+
+    context "with a variation argument" do
+      let(:args) { %w(live) }
+
+      it "runs in the specified stack" do
+        expect(Commands::Run)
+          .to receive(:new).with("app-live", [])
+          .and_return(command_double)
+        subject
+      end
+    end
+  end
 end


### PR DESCRIPTION
This makes it easy to run a service in the `app` stack. It's designed to make it very clear what its doing by the name `startup`. It doesn't allow you to change the command being run, for that you would need to use `govuk-docker run --stack app <command>`.

This command is designed to make it difficult to use this to run a stack which isn't `app` since you should be using the `run` command for that.

Examples:

- `govuk-docker startup live`
- `govuk-docker startup`

[Trello Card](https://trello.com/c/akpi3nt3/2-%F0%9F%92%AA-optimise-day-to-day-development)