### PR TITLE
Add calculators

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ The following apps are supported by govuk-docker to some extent.
 
    - ✅ asset-manager
    - ✅ calendars
+   - ⚠ calculators
+      * Web UI doesn't work without the content item being present in the content-store.
    - ⚠ content-data-admin
       * **TODO: Missing support for a webserver stack**
    - ✅ content-publisher

--- a/services/calculators/Dockerfile
+++ b/services/calculators/Dockerfile
@@ -1,0 +1,14 @@
+FROM ruby:2.6.3
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
+RUN apt-get install -y nodejs
+
+# Dependencies required for Google Chrome
+RUN apt-get install -y libxss1 libappindicator1 libindicator7
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>&1 && \
+    apt install -y ./google-chrome*.deb && \
+    rm ./google-chrome*.deb
+
+RUN useradd -m build
+USER build
+
+ENV EDITOR=vim

--- a/services/calculators/Makefile
+++ b/services/calculators/Makefile
@@ -1,0 +1,2 @@
+calculators: ../calculators
+	bin/govuk-docker compose run calculators-lite bundle

--- a/services/calculators/docker-compose.yml
+++ b/services/calculators/docker-compose.yml
@@ -1,0 +1,56 @@
+version: '3.7'
+
+x-calculators: &calculators
+  build:
+    context: .
+    dockerfile: services/calculators/Dockerfile
+  image: calculators
+  volumes:
+    - ..:/govuk:delegated
+    - bundle:/usr/local/bundle
+    - home:/home/build
+  working_dir: /govuk/calculators
+
+services:
+  calculators-lite:
+    <<: *calculators
+    # Tests need the privileged flag
+    privileged: true
+    volumes:
+      - ..:/govuk:delegated
+      - bundle:/usr/local/bundle
+
+  calculators-app: &calculators-app
+    <<: *calculators
+    depends_on:
+      - router-live
+      - content-store-live
+      - static-live
+    environment:
+      GOVUK_ASSET_ROOT: calculators.dev.gov.uk
+      VIRTUAL_HOST: calculators.dev.gov.uk
+      HOST: 0.0.0.0
+    ports:
+      - "3000"
+    command: bin/rails s -P /tmp/rails.pid
+
+  calculators-draft:
+    <<: *calculators-app
+    depends_on:
+      - router-draft
+      - content-store-draft
+      - static-draft
+    environment:
+      GOVUK_ASSET_ROOT: draft-calculators.dev.gov.uk
+      VIRTUAL_HOST: draft-calculators.dev.gov.uk
+      PLEK_HOSTNAME_PREFIX: "draft-"
+      HOST: 0.0.0.0
+
+  calculators-live:
+    <<: *calculators-app
+    environment:
+      GOVUK_WEBSITE_ROOT: https://www.gov.uk
+      PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
+      PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
+      VIRTUAL_HOST: calculators.dev.gov.uk
+      HOST: 0.0.0.0


### PR DESCRIPTION
This adds the calculators app as a service. The web UI doesn't work without the content item being present, but the tests can be run. We'll try to solve the seed data issue separately.

https://trello.com/c/5NrIr7Ih