### PR TITLE
Add doctor docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,11 @@ state and suggest remedial steps if it finds anything wrong
 govuk-docker doctor
 ```
 
-This will currently only test whether you have dnsmasq installed and running.
+This will test whether or not your system meets the following requirements:
+
+* dnsmasq installed and running
+* docker installed
+* docker-compose installed
 
 ### How to: diagnose and troubleshoot
 

--- a/lib/doctor/dnsmasq.rb
+++ b/lib/doctor/dnsmasq.rb
@@ -5,8 +5,8 @@ module Doctor
     end
 
     def call
-      get_dnsmasq_install_state
-      get_dnsmasq_run_state
+      install_state?
+      run_state?
 
       message.join("\r\n")
     end
@@ -29,7 +29,7 @@ module Doctor
       You should start it with `sudo brew services start dnsmasq`.
     HEREDOC
 
-    def get_dnsmasq_install_state
+    def install_state?
       message << if dnsmasq_installed?
                    DNSMASQ_INSTALLED
                  else
@@ -41,7 +41,7 @@ module Doctor
       system "which dnsmasq 1>/dev/null"
     end
 
-    def get_dnsmasq_run_state
+    def run_state?
       return unless dnsmasq_installed?
 
       message << if dnsmasq_running?

--- a/lib/doctor/docker.rb
+++ b/lib/doctor/docker.rb
@@ -1,0 +1,36 @@
+module Doctor
+  class Docker
+    def initialize
+      @message = []
+    end
+
+    def call
+      install_state?
+
+      message.join
+    end
+
+  private
+
+    attr_reader :message
+
+    DOCKER_INSTALLED = "✅ Docker is installed".freeze
+    INSTALL_DOCKER = <<~HEREDOC.freeze
+      ❌ Docker not found.
+      You should install docker by grabbing the latest image from https://docs.docker.com/docker-for-mac/release-notes/.
+      For manual installation, visit https://docs.docker.com/install/.
+    HEREDOC
+
+    def install_state?
+      message << if docker_installed?
+                   DOCKER_INSTALLED
+                 else
+                   INSTALL_DOCKER
+                 end
+    end
+
+    def docker_installed?
+      system "which docker 1>/dev/null"
+    end
+  end
+end

--- a/lib/doctor/docker_compose.rb
+++ b/lib/doctor/docker_compose.rb
@@ -1,0 +1,36 @@
+module Doctor
+  class DockerCompose
+    def initialize
+      @message = []
+    end
+
+    def call
+      install_state?
+
+      message.join
+    end
+
+  private
+
+    attr_reader :message
+
+    DOCKER_COMPOSE_INSTALLED = "✅ Docker Compose is installed".freeze
+    INSTALL_DOCKER_COMPOSE = <<~HEREDOC.freeze
+      ❌ Docker Compose not found.
+      You should install docker by grabbing the latest image from https://docs.docker.com/docker-for-mac/release-notes/.
+      For manual installation, visit https://docs.docker.com/compose/install/
+    HEREDOC
+
+    def install_state?
+      message << if docker_installed?
+                   DOCKER_COMPOSE_INSTALLED
+                 else
+                   INSTALL_DOCKER_COMPOSE
+                 end
+    end
+
+    def docker_installed?
+      system "which docker-compose 1>/dev/null"
+    end
+  end
+end

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -6,6 +6,7 @@ require_relative "./commands/prune"
 require_relative "./commands/run"
 require_relative "./doctor/dnsmasq"
 require_relative "./doctor/docker"
+require_relative "./doctor/docker_compose"
 
 class GovukDockerCLI < Thor
   # https://github.com/ddollar/foreman/blob/83fd5eeb8c4b522cb84d8e74031080143ea6353b/lib/foreman/cli.rb#L29-L35
@@ -45,6 +46,8 @@ class GovukDockerCLI < Thor
     puts Doctor::Dnsmasq.new.call
     puts "\r\nChecking docker"
     puts Doctor::Docker.new.call
+    puts "\r\nChecking docker-compose"
+    puts Doctor::DockerCompose.new.call
   end
 
   desc "prune", "Remove all docker containers, volumes and images"

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -5,6 +5,7 @@ require_relative "./commands/compose"
 require_relative "./commands/prune"
 require_relative "./commands/run"
 require_relative "./doctor/dnsmasq"
+require_relative "./doctor/docker"
 
 class GovukDockerCLI < Thor
   # https://github.com/ddollar/foreman/blob/83fd5eeb8c4b522cb84d8e74031080143ea6353b/lib/foreman/cli.rb#L29-L35
@@ -42,6 +43,8 @@ class GovukDockerCLI < Thor
   def doctor
     puts "Checking dnsmasq"
     puts Doctor::Dnsmasq.new.call
+    puts "\r\nChecking docker"
+    puts Doctor::Docker.new.call
   end
 
   desc "prune", "Remove all docker containers, volumes and images"

--- a/spec/doctor/docker_compose_spec.rb
+++ b/spec/doctor/docker_compose_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "./lib/doctor/docker_compose.rb"
+
+describe Doctor::DockerCompose do
+  subject { described_class.new }
+
+  context "when docker compose is installed" do
+    it "should tell me that docker compose is installed" do
+      allow(subject).to receive(:system).with("which docker-compose 1>/dev/null").and_return(true)
+      expect(subject.call).to include("Docker Compose is installed")
+    end
+  end
+
+  context "when docker is not installed" do
+    it "should tell me to install docker" do
+      allow(subject).to receive(:system).with("which docker-compose 1>/dev/null").and_return(false)
+      expect(subject.call).to include("Docker Compose not found")
+    end
+  end
+end

--- a/spec/doctor/docker_spec.rb
+++ b/spec/doctor/docker_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "./lib/doctor/docker.rb"
+
+describe Doctor::Docker do
+  subject { described_class.new }
+
+  context "when docker is installed" do
+    it "should tell me that docker is installed" do
+      allow(subject).to receive(:system).with("which docker 1>/dev/null").and_return(true)
+      expect(subject.call).to include("Docker is installed")
+    end
+  end
+
+  context "when docker is not installed" do
+    it "should tell me to install docker" do
+      allow(subject).to receive(:system).with("which docker 1>/dev/null").and_return(false)
+      expect(subject.call).to include("Docker not found")
+    end
+  end
+end


### PR DESCRIPTION
Add a check for docker and docker-compose installation on the system.

Output either a message confirming that it is installed or some basic instructions on where to get docker.

This creates a class that is remarkably similar to https://github.com/alphagov/govuk-docker/blob/adb20b5208b101bb4bc722180a2ef9890852bfa2/lib/doctor/dnsmasq.rb and there's certainly room for some refactoring. We'll get to that in a later commit.