### PR TITLE
Actually test if the config is valid

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,10 @@ test:
 
 	# Run the tests for the govuk-docker CLI
 	bundle exec rspec
+
 	# Test that the docker-compose config is valid. This will error if there are errors
 	# in the YAML files, or incompatible features are used.
-	bin/govuk-docker compose config
+	bin/govuk-docker compose config | grep -v "ERROR"
 
 # This will be slow and may repeat work, so generally you don't want
 # to run this.


### PR DESCRIPTION
We're currently running `bin/govuk-docker compose config` to check if the config is valid (to protect against stuff like https://github.com/alphagov/govuk-docker/pull/64). It turns out `docker-compose config` doesn't return a non-zero exit code when it fails, so the tests would still pass.

This should fail until https://github.com/alphagov/govuk-docker/pull/64 is merged.