### PR TITLE
Install Dnsmasq

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ for example:
 make content-publisher government-frontend
 ```
 
+The govuk-docker command can configure Dnsmasq for you:
+
+```
+govuk-docker install
+```
+
+If this doesn't work for whatever reason, follow the instructions below to
+install manually:
+
 If you have been using the vagrant based dev vm, take a backup
 of  `/etc/resolver/dev.gov.uk`.
 

--- a/lib/doctor/dnsmasq.rb
+++ b/lib/doctor/dnsmasq.rb
@@ -11,6 +11,10 @@ module Doctor
       message.join("\r\n")
     end
 
+    def installed?
+      system "which dnsmasq 1>/dev/null"
+    end
+
   private
 
     attr_reader :message
@@ -30,19 +34,15 @@ module Doctor
     HEREDOC
 
     def install_state?
-      message << if dnsmasq_installed?
+      message << if installed?
                    DNSMASQ_INSTALLED
                  else
                    INSTALL_DNSMASQ
                  end
     end
 
-    def dnsmasq_installed?
-      system "which dnsmasq 1>/dev/null"
-    end
-
     def run_state?
-      return unless dnsmasq_installed?
+      return unless installed?
 
       message << if dnsmasq_running?
                    DNSMASQ_RUNNING

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -7,6 +7,7 @@ require_relative "./commands/run"
 require_relative "./doctor/dnsmasq"
 require_relative "./doctor/docker"
 require_relative "./doctor/docker_compose"
+require_relative "./install/dnsmasq"
 
 class GovukDockerCLI < Thor
   # https://github.com/ddollar/foreman/blob/83fd5eeb8c4b522cb84d8e74031080143ea6353b/lib/foreman/cli.rb#L29-L35
@@ -53,6 +54,11 @@ class GovukDockerCLI < Thor
     puts Doctor::Docker.new.call
     puts "\r\nChecking docker-compose"
     puts Doctor::DockerCompose.new.call
+  end
+
+  desc "install", "Configures and installs the various dependencies necessary to run govuk-docker successfully"
+  def install
+    Install::Dnsmasq.new.call
   end
 
   desc "prune", "Remove all docker containers, volumes and images"

--- a/lib/install/dnsmasq.rb
+++ b/lib/install/dnsmasq.rb
@@ -1,8 +1,10 @@
+require "thor"
 require_relative "../doctor/dnsmasq"
 
 module Install
   class Dnsmasq
     def call
+      check_macos
       install_dnsmasq
       configure_etc_resolver_devgovuk
       configure_usr_local_etc_dnsmasq
@@ -12,6 +14,18 @@ module Install
     end
 
   private
+
+    def macos?
+      %x[uname -a].include?("Darwin")
+    end
+
+    def check_macos
+      return if macos?
+
+      puts "This script currently only works on MacOS."
+      puts "Are you sure you want to continue?"
+      Thor::Shell::Basic.new.yes?
+    end
 
     def install_dnsmasq
       return if Doctor::Dnsmasq.new.installed?

--- a/lib/install/dnsmasq.rb
+++ b/lib/install/dnsmasq.rb
@@ -4,7 +4,8 @@ require_relative "../doctor/dnsmasq"
 module Install
   class Dnsmasq
     def call
-      check_macos
+      return unless check_continue
+
       install_dnsmasq
       configure_etc_resolver_devgovuk
       configure_usr_local_etc_dnsmasq
@@ -15,16 +16,19 @@ module Install
 
   private
 
-    def macos?
-      %x[uname -a].include?("Darwin")
-    end
+    def check_continue
+      puts "Any local changes in these files may get overwriten by this script:"
+      puts "- /etc/resolver/dev.gov.uk"
+      puts "- /usr/local/etc/dnsmasq.conf"
+      puts "- /usr/local/etc/dnsmasq.d/development.conf"
+      puts
 
-    def check_macos
-      return if macos?
+      unless %x[uname -a].include?("Darwin")
+        puts "This script is designed to run on MacOS."
+        puts
+      end
 
-      puts "This script currently only works on MacOS."
-      puts "Are you sure you want to continue?"
-      Thor::Shell::Basic.new.yes?
+      Thor::Shell::Basic.new.yes?("Are you sure you want to continue?")
     end
 
     def install_dnsmasq

--- a/lib/install/dnsmasq.rb
+++ b/lib/install/dnsmasq.rb
@@ -1,0 +1,39 @@
+require_relative "../doctor/dnsmasq"
+
+module Install
+  class Dnsmasq
+    def call
+      install_dnsmasq
+      configure_etc_resolver_devgovuk
+      configure_usr_local_etc_dnsmasq
+      configure_usr_local_etc_dnsmasq_developmentconf
+      restart_dnsmasq
+      verify_dns
+      puts "✅ Dnsmasq installation and configuration complete!"
+    end
+
+  private
+
+    def install_dnsmasq
+      return if Doctor::Dnsmasq.new.installed?
+
+      puts "⏳ Installing dnsmasq"
+      system("brew install dnsmasq")
+    end
+
+    def configure_etc_resolver_devgovuk
+    end
+
+    def configure_usr_local_etc_dnsmasq
+    end
+
+    def configure_usr_local_etc_dnsmasq_developmentconf
+    end
+
+    def restart_dnsmasq
+    end
+
+    def verify_dns
+    end
+  end
+end

--- a/spec/install/dnsmasq_spec.rb
+++ b/spec/install/dnsmasq_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+require_relative "../../lib/install/dnsmasq"
+
+describe Install::Dnsmasq do
+  subject { described_class.new }
+
+  context "dnsmasq isn't installed" do
+    before do
+      allow(Doctor::Dnsmasq).to receive(:new).and_return(double(installed?: false))
+    end
+
+    it "installs dnsmasq using brew" do
+      expect(subject).to receive(:system).with("brew install dnsmasq")
+      subject.call
+    end
+  end
+
+  context "dnsmasq is installed" do
+    before do
+      allow(Doctor::Dnsmasq).to receive(:new).and_return(double(installed?: true))
+    end
+
+    it "doesn't install dnsmasq with brew" do
+      expect(subject).to_not receive(:system).with("brew install dnsmasq")
+      subject.call
+    end
+  end
+end

--- a/spec/install/dnsmasq_spec.rb
+++ b/spec/install/dnsmasq_spec.rb
@@ -5,6 +5,7 @@ describe Install::Dnsmasq do
   subject { described_class.new }
 
   before do
+    allow(subject).to receive(:macos?).and_return(true)
     allow(Doctor::Dnsmasq).to receive(:new).and_return(double(installed?: false))
     allow(subject).to receive(:system).with("brew install dnsmasq")
     allow(File).to receive(:read).with("/etc/resolver/dev.gov.uk").and_return("")
@@ -45,6 +46,20 @@ describe Install::Dnsmasq do
 
     it "doesn't install dnsmasq with brew" do
       expect(subject).to_not receive(:system).with("brew install dnsmasq")
+      subject.call
+    end
+  end
+
+  context "on a non-MacOS machine" do
+    before do
+      expect(subject).to receive(:macos?).and_return(false)
+    end
+
+    it "asks the user to continue" do
+      shell_double = double
+      expect(Thor::Shell::Basic).to receive(:new).and_return(shell_double)
+      expect(shell_double).to receive(:yes?)
+
       subject.call
     end
   end

--- a/spec/install/dnsmasq_spec.rb
+++ b/spec/install/dnsmasq_spec.rb
@@ -4,63 +4,66 @@ require_relative "../../lib/install/dnsmasq"
 describe Install::Dnsmasq do
   subject { described_class.new }
 
+  let(:shell_double) { double }
   before do
-    allow(subject).to receive(:macos?).and_return(true)
-    allow(Doctor::Dnsmasq).to receive(:new).and_return(double(installed?: false))
-    allow(subject).to receive(:system).with("brew install dnsmasq")
-    allow(File).to receive(:read).with("/etc/resolver/dev.gov.uk").and_return("")
-    allow(File).to receive(:read).with("/usr/local/etc/dnsmasq.conf").and_return("")
-    allow(File).to receive(:read).with("/usr/local/etc/dnsmasq.d/development.conf").and_return("")
-    allow(File).to receive(:write).with("/etc/resolver/dev.gov.uk", anything)
-    allow(File).to receive(:open).with("/usr/local/etc/dnsmasq.conf", anything)
-    allow(File).to receive(:write).with("/usr/local/etc/dnsmasq.d/development.conf", anything)
-    allow(subject).to receive(:system).with("sudo brew services restart dnsmasq")
+    allow(Thor::Shell::Basic).to receive(:new).and_return(shell_double)
   end
 
-  it "installs dnsmasq using brew" do
-    expect(subject).to receive(:system).with("brew install dnsmasq")
-    subject.call
-  end
-
-  it "writes to the various files" do
-    expect(File).to receive(:write)
-      .with("/etc/resolver/dev.gov.uk", "nameserver 127.0.0.1\n")
-    expect(File).to receive(:write)
-      .with("/usr/local/etc/dnsmasq.d/development.conf", "address=/dev.gov.uk/127.0.0.1\n")
-    file_double = double
-    expect(File).to receive(:open).with("/usr/local/etc/dnsmasq.conf", "a").and_yield(file_double)
-    expect(file_double).to receive(:write).with("\nconf-dir=/usr/local/etc/dnsmasq.d,*.conf\n")
-
-    subject.call
-  end
-
-  it "restarts dnsmasq" do
-    expect(subject).to receive(:system).with("sudo brew services restart dnsmasq")
-    subject.call
-  end
-
-  context "dnsmasq is already installed" do
-    before do
-      expect(Doctor::Dnsmasq).to receive(:new).and_return(double(installed?: true))
-    end
-
-    it "doesn't install dnsmasq with brew" do
-      expect(subject).to_not receive(:system).with("brew install dnsmasq")
+  context "disallowing the script to continue" do
+    it "shouldn't do anything" do
+      expect(shell_double).to receive(:yes?).and_return(false)
+      expect(Doctor::Dnsmasq).to_not receive(:new)
+      expect(File).to_not receive(:read)
+      expect(subject).to_not receive(:system)
       subject.call
     end
   end
 
-  context "on a non-MacOS machine" do
+  context "allowing the script to continue" do
     before do
-      expect(subject).to receive(:macos?).and_return(false)
+      allow(shell_double).to receive(:yes?).and_return(true)
+      allow(Doctor::Dnsmasq).to receive(:new).and_return(double(installed?: false))
+      allow(subject).to receive(:system).with("brew install dnsmasq")
+      allow(File).to receive(:read).with("/etc/resolver/dev.gov.uk").and_return("")
+      allow(File).to receive(:read).with("/usr/local/etc/dnsmasq.conf").and_return("")
+      allow(File).to receive(:read).with("/usr/local/etc/dnsmasq.d/development.conf").and_return("")
+      allow(File).to receive(:write).with("/etc/resolver/dev.gov.uk", anything)
+      allow(File).to receive(:open).with("/usr/local/etc/dnsmasq.conf", anything)
+      allow(File).to receive(:write).with("/usr/local/etc/dnsmasq.d/development.conf", anything)
+      allow(subject).to receive(:system).with("sudo brew services restart dnsmasq")
     end
 
-    it "asks the user to continue" do
-      shell_double = double
-      expect(Thor::Shell::Basic).to receive(:new).and_return(shell_double)
-      expect(shell_double).to receive(:yes?)
+    it "installs dnsmasq using brew" do
+      expect(subject).to receive(:system).with("brew install dnsmasq")
+      subject.call
+    end
+
+    it "writes to the various files" do
+      expect(File).to receive(:write)
+        .with("/etc/resolver/dev.gov.uk", "nameserver 127.0.0.1\n")
+      expect(File).to receive(:write)
+        .with("/usr/local/etc/dnsmasq.d/development.conf", "address=/dev.gov.uk/127.0.0.1\n")
+      file_double = double
+      expect(File).to receive(:open).with("/usr/local/etc/dnsmasq.conf", "a").and_yield(file_double)
+      expect(file_double).to receive(:write).with("\nconf-dir=/usr/local/etc/dnsmasq.d,*.conf\n")
 
       subject.call
+    end
+
+    it "restarts dnsmasq" do
+      expect(subject).to receive(:system).with("sudo brew services restart dnsmasq")
+      subject.call
+    end
+
+    context "dnsmasq is already installed" do
+      before do
+        expect(Doctor::Dnsmasq).to receive(:new).and_return(double(installed?: true))
+      end
+
+      it "doesn't install dnsmasq with brew" do
+        expect(subject).to_not receive(:system).with("brew install dnsmasq")
+        subject.call
+      end
     end
   end
 end

--- a/spec/install/dnsmasq_spec.rb
+++ b/spec/install/dnsmasq_spec.rb
@@ -4,20 +4,43 @@ require_relative "../../lib/install/dnsmasq"
 describe Install::Dnsmasq do
   subject { described_class.new }
 
-  context "dnsmasq isn't installed" do
-    before do
-      allow(Doctor::Dnsmasq).to receive(:new).and_return(double(installed?: false))
-    end
-
-    it "installs dnsmasq using brew" do
-      expect(subject).to receive(:system).with("brew install dnsmasq")
-      subject.call
-    end
+  before do
+    allow(Doctor::Dnsmasq).to receive(:new).and_return(double(installed?: false))
+    allow(subject).to receive(:system).with("brew install dnsmasq")
+    allow(File).to receive(:read).with("/etc/resolver/dev.gov.uk").and_return("")
+    allow(File).to receive(:read).with("/usr/local/etc/dnsmasq.conf").and_return("")
+    allow(File).to receive(:read).with("/usr/local/etc/dnsmasq.d/development.conf").and_return("")
+    allow(File).to receive(:write).with("/etc/resolver/dev.gov.uk", anything)
+    allow(File).to receive(:open).with("/usr/local/etc/dnsmasq.conf", anything)
+    allow(File).to receive(:write).with("/usr/local/etc/dnsmasq.d/development.conf", anything)
+    allow(subject).to receive(:system).with("sudo brew services restart dnsmasq")
   end
 
-  context "dnsmasq is installed" do
+  it "installs dnsmasq using brew" do
+    expect(subject).to receive(:system).with("brew install dnsmasq")
+    subject.call
+  end
+
+  it "writes to the various files" do
+    expect(File).to receive(:write)
+      .with("/etc/resolver/dev.gov.uk", "nameserver 127.0.0.1\n")
+    expect(File).to receive(:write)
+      .with("/usr/local/etc/dnsmasq.d/development.conf", "address=/dev.gov.uk/127.0.0.1\n")
+    file_double = double
+    expect(File).to receive(:open).with("/usr/local/etc/dnsmasq.conf", "a").and_yield(file_double)
+    expect(file_double).to receive(:write).with("\nconf-dir=/usr/local/etc/dnsmasq.d,*.conf\n")
+
+    subject.call
+  end
+
+  it "restarts dnsmasq" do
+    expect(subject).to receive(:system).with("sudo brew services restart dnsmasq")
+    subject.call
+  end
+
+  context "dnsmasq is already installed" do
     before do
-      allow(Doctor::Dnsmasq).to receive(:new).and_return(double(installed?: true))
+      expect(Doctor::Dnsmasq).to receive(:new).and_return(double(installed?: true))
     end
 
     it "doesn't install dnsmasq with brew" do


### PR DESCRIPTION
This adds a `govuk-docker install` command which currently only installs and configures Dnsmasq. This is currently limited only to MacOS machines, but it could be extended in the future to support different operating systems.

[Trello Card](https://trello.com/c/akpi3nt3/2-%F0%9F%92%AA-optimise-day-to-day-development)