### PR TITLE
Accept service argument for run & build commands

### DIFF
--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -19,9 +19,14 @@ class GovukDockerCLI < Thor
 
   package_name "govuk-docker"
 
-  desc "build", "Build the service in the current directory"
+  desc "build [ARGS]", "Build a service"
+  long_desc <<~LONGDESC
+    By default, it builds the service in the current directory.
+    It can build a different service if specified (e.g. `govuk-docker build --service static`).
+  LONGDESC
+  option :service, default: nil
   def build
-    Commands::Build.new.call
+    Commands::Build.new(options[:service]).call
   end
 
   desc "compose ARGS", "Run `docker-compose` with ARGS"
@@ -49,10 +54,17 @@ class GovukDockerCLI < Thor
     Commands::Prune.new.call
   end
 
-  desc "run [ARGS]", "Run the service in the current directory with the specified stack (for example `govuk-docker run --stack app`)"
+  desc "run [ARGS]", "Run a service"
+  long_desc <<~LONGDESC
+    By default, it runs the service in the current directory with the `lite` stack.
+    It can run a different service if specified (e.g. `govuk-docker run --service static`).
+    It can run with a different stack if specified (e.g. `govuk-docker run --stack app`).
+    These two options can be combined (e.g. `govuk-docker run --service static --stack app`).
+  LONGDESC
   option :stack, default: "lite"
+  option :service, default: nil
   def run(*args)
-    Commands::Run.new(options[:stack], args).call
+    Commands::Run.new(options[:stack], args, options[:service]).call
   end
 
   desc "startup [VARIATION]", "Run the service in the current directory with the `app` stack. Variations can be provided, for example `live` or `draft`."

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -12,7 +12,7 @@ describe Commands::Build do
   context "when a service exists" do
     let(:service) { "example-service" }
 
-    it "should run docker compose when a service exists" do
+    it "should run docker compose" do
       expect(system).to receive(:call).with("make", "-f", "#{config_directory}/Makefile", "example-service")
       subject.call
     end

--- a/spec/govuk_docker_cli_spec.rb
+++ b/spec/govuk_docker_cli_spec.rb
@@ -11,21 +11,43 @@ describe GovukDockerCLI do
   describe "run" do
     let(:command) { "run" }
 
-    context "without a stack argument" do
+    context "without stack and service arguments" do
       it "runs in the lite stack" do
         expect(Commands::Run)
-          .to receive(:new).with("lite", [])
+          .to receive(:new).with("lite", [], nil)
           .and_return(command_double)
         subject
       end
     end
 
-    context "with a stack argument" do
+    context "with stack and service arguments" do
+      let(:args) { ["--service", "static", "--stack", "app"] }
+
+      it "runs in the specified stack" do
+        expect(Commands::Run)
+          .to receive(:new).with("app", [], "static")
+          .and_return(command_double)
+        subject
+      end
+    end
+
+    context "with stack argument and no service argument" do
       let(:args) { ["--stack", "app"] }
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with("app", [])
+          .to receive(:new).with("app", [], nil)
+          .and_return(command_double)
+        subject
+      end
+    end
+
+    context "with service argument and no stack argument" do
+      let(:args) { ["--service", "static"] }
+
+      it "runs in the specified stack" do
+        expect(Commands::Run)
+          .to receive(:new).with("lite", [], "static")
           .and_return(command_double)
         subject
       end
@@ -36,7 +58,7 @@ describe GovukDockerCLI do
 
       it "runs the command with additinal arguments" do
         expect(Commands::Run)
-          .to receive(:new).with("lite", %w[bundle exec rspec])
+          .to receive(:new).with("lite", %w[bundle exec rspec], nil)
           .and_return(command_double)
         subject
       end
@@ -61,6 +83,30 @@ describe GovukDockerCLI do
       it "runs in the specified stack" do
         expect(Commands::Run)
           .to receive(:new).with("app-live", [])
+          .and_return(command_double)
+        subject
+      end
+    end
+  end
+
+  describe "build" do
+    let(:command) { "build" }
+
+    context "without the service argument" do
+      it "builds the working directory's service" do
+        expect(Commands::Build)
+          .to receive(:new).with(nil)
+          .and_return(command_double)
+        subject
+      end
+    end
+
+    context "with the service argument" do
+      let(:args) { ["--service", "static"] }
+
+      it "builds the specified service" do
+        expect(Commands::Build)
+          .to receive(:new).with("static")
           .and_return(command_double)
         subject
       end


### PR DESCRIPTION
This will allow us to run commands such as
`govuk-docker build --service static`
and
`govuk-docker run --service static`
directly from the govuk-docker directory to build or run a specific app.