### PR TITLE
Add verbose option to `run` and `compose` commands

### DIFF
--- a/lib/commands/base.rb
+++ b/lib/commands/base.rb
@@ -4,16 +4,17 @@ require_relative '../errors/unknown_stack'
 
 module Commands
   class Base
-    def initialize(service = nil, config_directory = nil, system = nil, stack = nil)
+    def initialize(service = nil, config_directory = nil, system = nil, stack = nil, verbose = false)
       @service = service || default_service
       @config_directory = config_directory || default_config_directory
       @system = system || default_system
       @stack = stack
+      @verbose = verbose
     end
 
   private
 
-    attr_reader :config_directory, :service, :system, :stack
+    attr_reader :config_directory, :service, :system, :stack, :verbose
 
     def available_stacks
       service_path = File.join(config_directory, "services/#{service}/docker-compose.yml")

--- a/lib/commands/compose.rb
+++ b/lib/commands/compose.rb
@@ -4,11 +4,21 @@ class Commands::Compose < Commands::Base
   def call(verbose, *args)
     args.insert(0, "docker-compose")
     args.insert(1, *docker_compose_args)
-    puts args.join(" ")
+    verbose ? display_full_commands(args) : display_truncated_commands(args)
     system.call(*args)
   end
 
 private
+
+  def display_full_commands(args)
+    puts args.join(" ")
+  end
+
+  def display_truncated_commands(args)
+    args = args - docker_compose_args
+    args.insert(1, '-f [...]')
+    puts args.join(" ")
+  end
 
   def docker_compose_args
     docker_compose_paths.flat_map { |filename| ["-f", filename] }

--- a/lib/commands/compose.rb
+++ b/lib/commands/compose.rb
@@ -1,7 +1,7 @@
 require_relative './base'
 
 class Commands::Compose < Commands::Base
-  def call(*args)
+  def call(verbose, *args)
     args.insert(0, "docker-compose")
     args.insert(1, *docker_compose_args)
     puts args.join(" ")

--- a/lib/commands/run.rb
+++ b/lib/commands/run.rb
@@ -2,8 +2,8 @@ require_relative './base'
 require_relative './compose'
 
 class Commands::Run < Commands::Base
-  def initialize(stack, args, service = nil, config_directory = nil)
-    super(service, config_directory, nil, stack)
+  def initialize(stack, verbose, args, service = nil, config_directory = nil)
+    super(service, config_directory, nil, stack, verbose)
     @args = args
   end
 
@@ -11,7 +11,7 @@ class Commands::Run < Commands::Base
     check_service_exists
     check_stack_exists
     Commands::Compose.new.call(
-      "run", "--rm", "--service-ports", container_name, *extra_args
+      verbose, "run", "--rm", "--service-ports", container_name, *extra_args
     )
   end
 

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -41,8 +41,9 @@ class GovukDockerCLI < Thor
 
     > govuk-docker compose stop
   LONGDESC
+  option :verbose, type: :boolean, default: false
   def compose(*args)
-    Commands::Compose.new.call(*args)
+    Commands::Compose.new.call(options[:verbose], *args)
   end
 
   desc "doctor", "Various tests to help diagnose issues when running govuk-docker"

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -69,13 +69,15 @@ class GovukDockerCLI < Thor
   LONGDESC
   option :stack, default: "lite"
   option :service, default: nil
+  option :verbose, type: :boolean, default: false
   def run(*args)
-    Commands::Run.new(options[:stack], args, options[:service]).call
+    Commands::Run.new(options[:stack], options[:verbose], args, options[:service]).call
   end
 
   desc "startup [VARIATION]", "Run the service in the current directory with the `app` stack. Variations can be provided, for example `live` or `draft`."
+  option :verbose, type: :boolean, default: false
   def startup(variation = nil)
     stack = variation ? "app-#{variation}" : "app"
-    Commands::Run.new(stack, []).call
+    Commands::Run.new(stack, options[:verbose], []).call
   end
 end

--- a/spec/commands/compose_spec.rb
+++ b/spec/commands/compose_spec.rb
@@ -4,18 +4,48 @@ require_relative "../../lib/commands/compose"
 describe Commands::Compose do
   let(:fake_system) { double }
   let(:config_directory) { "spec/fixtures" }
-  let(:verbose) { true }
+  let(:verbose) { nil }
 
   subject { described_class.new(nil, config_directory, fake_system) }
 
-  it "calls docker-compose with the correct configure files and arguments" do
-    expect(fake_system).to receive(:call).with(
-      "docker-compose",
-      "-f", "spec/fixtures/docker-compose.yml",
-      "-f", "spec/fixtures/services/example-service/docker-compose.yml",
-      "fake args"
-    )
+  context "when in verbose mode" do
+    let(:verbose) { true }
+    it "calls docker-compose with the correct configure files and arguments" do
+      expect(fake_system).to receive(:call).with(
+        "docker-compose",
+        "-f", "spec/fixtures/docker-compose.yml",
+        "-f", "spec/fixtures/services/example-service/docker-compose.yml",
+        "fake args"
+      )
 
-    subject.call(verbose, "fake args")
+      subject.call(verbose, "fake args")
+    end
+
+    it "outputs the full list of docker compose files" do
+      expect(fake_system).to receive(:call).with(
+        "docker-compose",
+        "-f", "spec/fixtures/docker-compose.yml",
+        "-f", "spec/fixtures/services/example-service/docker-compose.yml",
+        "test args"
+      )
+
+      expect { subject.call(verbose, "test args") }.
+        to output("docker-compose -f spec/fixtures/docker-compose.yml -f spec/fixtures/services/example-service/docker-compose.yml test args\n").to_stdout
+    end
+  end
+
+  context "when in silent mode" do
+    let(:verbose) { false }
+    it "outputs a truncated list of docker commands" do
+      expect(fake_system).to receive(:call).with(
+        "docker-compose",
+        "-f", "spec/fixtures/docker-compose.yml",
+        "-f", "spec/fixtures/services/example-service/docker-compose.yml",
+        "test args"
+      )
+
+      expect { subject.call(verbose, "test args") }.
+       to output("docker-compose -f [...] test args\n").to_stdout
+    end
   end
 end

--- a/spec/commands/compose_spec.rb
+++ b/spec/commands/compose_spec.rb
@@ -4,6 +4,7 @@ require_relative "../../lib/commands/compose"
 describe Commands::Compose do
   let(:fake_system) { double }
   let(:config_directory) { "spec/fixtures" }
+  let(:verbose) { true }
 
   subject { described_class.new(nil, config_directory, fake_system) }
 
@@ -15,6 +16,6 @@ describe Commands::Compose do
       "fake args"
     )
 
-    subject.call("fake args")
+    subject.call(verbose, "fake args")
   end
 end

--- a/spec/commands/run_spec.rb
+++ b/spec/commands/run_spec.rb
@@ -4,10 +4,11 @@ require_relative "../../lib/commands/run"
 describe Commands::Run do
   let(:config_directory) { "spec/fixtures" }
   let(:service) { nil }
-  let(:stack) { nil }
-  let(:args) { nil }
+  let(:stack)   { nil }
+  let(:args)    { nil }
+  let(:verbose) { false }
 
-  subject { described_class.new(stack, args, service, config_directory) }
+  subject { described_class.new(stack, verbose, args, service, config_directory) }
 
   context "with a service that exists" do
     let(:service) { "example-service" }
@@ -21,7 +22,7 @@ describe Commands::Run do
 
       it "should run docker compose" do
         expect(compose_command).to receive(:call).with(
-          "run", "--rm", "--service-ports", "example-service-lite"
+          verbose, "run", "--rm", "--service-ports", "example-service-lite"
         )
         subject.call
       end
@@ -32,7 +33,7 @@ describe Commands::Run do
 
       it "should run docker compose using the `env` command" do
         expect(compose_command).to receive(:call).with(
-          "run", "--rm", "--service-ports", "example-service-lite",
+          verbose, "run", "--rm", "--service-ports", "example-service-lite",
           "env", "bundle", "exec", "rake", "lint"
         )
         subject.call
@@ -44,7 +45,7 @@ describe Commands::Run do
 
       it "should run docker compose without duplicating `env`" do
         expect(compose_command).to receive(:call).with(
-          "run", "--rm", "--service-ports", "example-service-lite",
+          verbose, "run", "--rm", "--service-ports", "example-service-lite",
           "env", "bundle", "exec", "rake", "lint"
         )
         subject.call

--- a/spec/govuk_docker_cli_spec.rb
+++ b/spec/govuk_docker_cli_spec.rb
@@ -14,7 +14,7 @@ describe GovukDockerCLI do
     context "without stack and service arguments" do
       it "runs in the lite stack" do
         expect(Commands::Run)
-          .to receive(:new).with("lite", [], nil)
+          .to receive(:new).with("lite", false, [], nil)
           .and_return(command_double)
         subject
       end
@@ -25,7 +25,7 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with("app", [], "static")
+          .to receive(:new).with("app", false, [], "static")
           .and_return(command_double)
         subject
       end
@@ -36,7 +36,7 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with("app", [], nil)
+          .to receive(:new).with("app", false, [], nil)
           .and_return(command_double)
         subject
       end
@@ -47,7 +47,7 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with("lite", [], "static")
+          .to receive(:new).with("lite", false, [], "static")
           .and_return(command_double)
         subject
       end
@@ -56,9 +56,29 @@ describe GovukDockerCLI do
     context "with additional arguments" do
       let(:args) { %w[bundle exec rspec] }
 
-      it "runs the command with additinal arguments" do
+      it "runs the command with additional arguments" do
         expect(Commands::Run)
-          .to receive(:new).with("lite", %w[bundle exec rspec], nil)
+          .to receive(:new).with("lite", false, ["bundle", "exec", "rspec"], nil)
+          .and_return(command_double)
+        subject
+      end
+    end
+
+    context "with a verbose argument" do
+      let(:args) { ["--verbose"] }
+        it "runs in the verbose mode" do
+        expect(Commands::Run)
+          .to receive(:new).with('lite', true, [], nil)
+          .and_return(command_double)
+        subject
+      end
+    end
+
+    context "without a verbose argument" do
+      let(:args) { [] }
+        it "runs in silent mode" do
+        expect(Commands::Run)
+          .to receive(:new).with('lite', false, [], nil)
           .and_return(command_double)
         subject
       end
@@ -71,7 +91,7 @@ describe GovukDockerCLI do
     context "without a variation argument" do
       it "runs in the backend stack" do
         expect(Commands::Run)
-          .to receive(:new).with("app", [])
+          .to receive(:new).with("app", false, [])
           .and_return(command_double)
         subject
       end
@@ -82,7 +102,7 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with("app-live", [])
+          .to receive(:new).with("app-live", false, [])
           .and_return(command_double)
         subject
       end

--- a/spec/govuk_docker_cli_spec.rb
+++ b/spec/govuk_docker_cli_spec.rb
@@ -58,7 +58,7 @@ describe GovukDockerCLI do
 
       it "runs the command with additional arguments" do
         expect(Commands::Run)
-          .to receive(:new).with("lite", false, ["bundle", "exec", "rspec"], nil)
+          .to receive(:new).with("lite", false, %w[bundle exec rspec], nil)
           .and_return(command_double)
         subject
       end
@@ -66,7 +66,7 @@ describe GovukDockerCLI do
 
     context "with a verbose argument" do
       let(:args) { ["--verbose"] }
-        it "runs in the verbose mode" do
+      it "runs in the verbose mode" do
         expect(Commands::Run)
           .to receive(:new).with('lite', true, [], nil)
           .and_return(command_double)
@@ -76,7 +76,7 @@ describe GovukDockerCLI do
 
     context "without a verbose argument" do
       let(:args) { [] }
-        it "runs in silent mode" do
+      it "runs in silent mode" do
         expect(Commands::Run)
           .to receive(:new).with('lite', false, [], nil)
           .and_return(command_double)


### PR DESCRIPTION
Unless the user explicitly passes a `--verbose` flag the potentially very long list of service's docker compose files will be replaced in the terminal output by `-f [...]`

`whitehall $govuk-docker run --verbose`

```
docker-compose -f /Users/example_user/govuk/govuk-docker/lib/commands/../../docker-compose.yml -f /Users/example_user/govuk/govuk-docker/lib/commands/../../services/content-store/docker-compose.yml -f /Users/example_user/govuk/govuk-docker/lib/commands/../../services/signon/docker-compose.yml  run --rm --service-ports whitehall-default
```

`whitehall $govuk-docker run`
```    
docker-compose -f [...] run --rm --service-ports whitehall-default
``` 
