### PR TITLE
Standard cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,14 @@ COMPOSE_RUN = $(GOVUK_DOCKER) compose run
 APPS ?= $(shell ls ${GOVUK_DOCKER_DIR}/services/*/Makefile | xargs -L 1 dirname | xargs -L 1 basename)
 
 # This is a Makefile best practice to say that these are not file
-# names.  For example, if you were to create a file called "clean",
-# then `make clean` should still invoke the rule, it shouldn't do
+# names.  For example, if you were to create a file called "test",
+# then `make test` should still invoke the rule, it shouldn't do
 # this:
 #
-#     $ touch clean
-#     $ make clean
-#     make: `clean' is up to date.
-.PHONY: clone pull clean test all-apps
+#     $ touch test
+#     $ make test
+#     make: `test' is up to date.
+.PHONY: clone pull test all-apps
 
 default:
 	@echo "Run 'make APP-NAME' to set up an app and its dependencies."
@@ -26,10 +26,6 @@ clone: $(addprefix ../,$(APPS))
 
 pull:
 	echo $(APPS) | cut -d/ -f3 | xargs -P8 -n1 ./bin/update-git-repo.sh
-
-clean:
-	bin/govuk-docker compose stop
-	bin/govuk-docker prune
 
 test:
 	# Linting
@@ -43,7 +39,9 @@ test:
 
 # This will be slow and may repeat work, so generally you don't want
 # to run this.
-all-apps: $(APPS) clean
+all-apps: $(APPS)
+	bin/govuk-docker compose stop
+	bin/govuk-docker prune
 
 # Clone an app, for example:
 #

--- a/lib/commands/build.rb
+++ b/lib/commands/build.rb
@@ -5,5 +5,7 @@ class Commands::Build < Commands::Base
   def call
     check_service_exists
     system.call("make", "-f", "#{config_directory}/Makefile", service)
+    Commands::Compose.new.call("stop")
+    Commands::Prune.new.call
   end
 end

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -5,15 +5,26 @@ require_relative "../../lib/errors/unknown_service"
 describe Commands::Build do
   let(:config_directory) { "spec/fixtures" }
   let(:service) { nil }
-  let(:system) { double(:system) }
+  let(:system) { double(:system, call: true) }
 
   subject { described_class.new(service, config_directory, system) }
 
   context "when a service exists" do
     let(:service) { "example-service" }
+    let(:compose_command) { instance_double Commands::Compose, call: true }
+    let(:prune_command) { instance_double Commands::Prune, call: true }
 
-    it "should run docker compose when a service exists" do
+    before { expect(Commands::Compose).to receive(:new).and_return(compose_command) }
+    before { expect(Commands::Prune).to receive(:new).and_return(prune_command) }
+
+    it "should run make for the service" do
       expect(system).to receive(:call).with("make", "-f", "#{config_directory}/Makefile", "example-service")
+      subject.call
+    end
+
+    it "should cleanup after itself" do
+      expect(compose_command).to receive(:call).with("stop")
+      expect(prune_command).to receive(:call)
       subject.call
     end
   end

--- a/spec/commands/run_spec.rb
+++ b/spec/commands/run_spec.rb
@@ -13,7 +13,7 @@ describe Commands::Run do
     let(:service) { "example-service" }
     let(:stack) { "lite" }
 
-    let(:compose_command) { double }
+    let(:compose_command) { instance_double Commands::Compose }
     before { expect(Commands::Compose).to receive(:new).and_return(compose_command) }
 
     context "with no extra arguments" do

--- a/spec/govuk_docker_cli_spec.rb
+++ b/spec/govuk_docker_cli_spec.rb
@@ -5,7 +5,7 @@ describe GovukDockerCLI do
   let(:command) { nil }
   let(:args) { [] }
   subject { described_class.start([command] + args) }
-  let(:command_double) { double }
+  let(:command_double) { instance_double Commands::Run }
   before { allow(command_double).to receive(:call) }
 
   describe "run" do


### PR DESCRIPTION
This PR looks at standardising our approach to cleanup, so that we always do it after setting-up something. After writing this, I'm wondering if we should even have automated cleanup at all? It doesn't seem write to forcibly stop all services after making one of them, and the global case is so rarely used that someone could reasonably be expected to do the two individual commands themselves.