### PR TITLE
Remove TargetRubyVersion from rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,5 @@ Rails:
   Enabled: false
 
 AllCops:
-  TargetRubyVersion: 2.6
-
   Exclude:
       - 'vendor/**/*'


### PR DESCRIPTION
If .ruby-version exists in the repo Rubocop will use it, so there's no need to specify it here.

https://github.com/rubocop-hq/rubocop/blob/master/manual/configuration.md#setting-the-target-ruby-version