### PR TITLE
Create generic Doctor Checkup class

### DIFF
--- a/lib/doctor/checkup.rb
+++ b/lib/doctor/checkup.rb
@@ -1,0 +1,55 @@
+module Doctor
+  class Checkup
+    def initialize(service_name:, checkups:, messages:)
+      @checkups = checkups
+      @service_name = service_name
+      @messages = messages
+      @return_message = []
+    end
+
+    def call
+      checkup
+      generate_return_message
+      return_message.join("\r\n")
+    end
+
+    def checkup
+      installed? if checkups.include?(:installed)
+      running? if checkups.include?(:running)
+    end
+
+    def installed?
+      @installed ||= system "which #{service_name} 1>/dev/null"
+    end
+
+    def running?
+      @running ||= system "pgrep #{service_name} 1>/dev/null"
+    end
+
+  private
+
+    attr_reader :checkups, :service_name, :messages
+    attr_accessor :return_message
+
+    def generate_return_message
+      install_state_message if checkups.include?(:installed)
+      run_state_message if checkups.include?(:running)
+    end
+
+    def install_state_message
+      return_message << if installed?
+                          messages[:installed]
+                        else
+                          messages[:not_installed]
+                        end
+    end
+
+    def run_state_message
+      return_message << if running?
+                          messages[:running]
+                        else
+                          messages[:not_running]
+                        end
+    end
+  end
+end

--- a/lib/doctor/doctor.rb
+++ b/lib/doctor/doctor.rb
@@ -1,0 +1,53 @@
+module Doctor
+  def self.messages
+    {
+      dnsmasq: dnsmasq_messages,
+      docker: docker_messages,
+      docker_compose: docker_compose_messages
+    }
+  end
+
+  def self.docker_messages
+    {
+      installed: "✅ Docker is installed",
+      not_installed: <<~HEREDOC,
+        ❌ Docker not found.
+        You should install Docker by grabbing the latest image from https://docs.docker.com/docker-for-mac/release-notes/.
+        For manual installation, visit https://docs.docker.com/install/.
+      HEREDOC
+      running: "✅ Docker is running",
+      not_running: <<~HEREDOC
+        ❌ Docker is not running.
+        You should start it with `sudo brew services start dnsmasq`.
+      HEREDOC
+    }
+  end
+
+  def self.docker_compose_messages
+    {
+      installed: "✅ Docker is installed",
+      not_installed: <<~HEREDOC,
+        ❌ Docker Compose not found.
+        You should install Docker by grabbing the latest image from https://docs.docker.com/docker-for-mac/release-notes/.
+        For manual installation, visit https://docs.docker.com/compose/install/
+      HEREDOC
+    }
+  end
+
+  def self.dnsmasq_messages
+    {
+      installed: "✅ Dnsmasq is installed",
+      not_installed: <<~HEREDOC,
+        ❌ Dnsmasq not found.
+        You should install it with `brew install dnsmasq`.
+        For a manual installation, visit http://www.thekelleys.org.uk/dnsmasq/doc.html
+      HEREDOC
+      running: "✅ Dnsmasq is running",
+      not_running: <<~HEREDOC
+        ❌ Dnsmasq is not running.
+        Dnsmasq needs to run as root.
+        You should start it with `sudo brew services start dnsmasq`.
+      HEREDOC
+    }
+  end
+end

--- a/spec/doctor/checkup_spec.rb
+++ b/spec/doctor/checkup_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+require "./lib/doctor/checkup"
+
+describe Doctor::Checkup do
+  let(:service_name) { "fake_service" }
+  let(:messages) {
+    {
+      installed: "fake_service is installed",
+      not_installed: "fake_service is not installed",
+      running: "fake_service is running",
+      not_running: "fake_service is not running"
+    }
+  }
+
+  context "when a service is installed" do
+    it "should report that it is installed" do
+      subject = described_class.new(
+        service_name: service_name,
+        checkups: %i(installed),
+        messages: messages
+      )
+
+      allow(subject).to receive(:system).with("which fake_service 1>/dev/null").and_return(true)
+
+      expect(subject.call).to eq("fake_service is installed")
+    end
+  end
+
+  context "when a service is not installed" do
+    it "should report that it needs to be installed" do
+      subject = described_class.new(
+        service_name: service_name,
+        checkups: %i(installed),
+        messages: messages
+      )
+
+      allow(subject).to receive(:system).with("which fake_service 1>/dev/null").and_return(false)
+
+      expect(subject.call).to eq("fake_service is not installed")
+    end
+  end
+
+  context "when a service is running" do
+    it "should report that it is running" do
+      subject = described_class.new(
+        service_name: service_name,
+        checkups: %i(running),
+        messages: messages
+      )
+
+      allow(subject).to receive(:system).with("pgrep fake_service 1>/dev/null").and_return(true)
+
+      expect(subject.call).to eq("fake_service is running")
+    end
+  end
+
+  context "when a service is not running" do
+    it "should report that it needs to be running" do
+      subject = described_class.new(
+        service_name: service_name,
+        checkups: %i(running),
+        messages: messages
+      )
+
+      allow(subject).to receive(:system).with("pgrep fake_service 1>/dev/null").and_return(false)
+
+      expect(subject.call).to eq("fake_service is not running")
+    end
+  end
+
+  context "when a service is installed and running" do
+    it "should report that it is installed and running" do
+      subject = described_class.new(
+        service_name: service_name,
+        checkups: %i(installed running),
+        messages: messages
+      )
+
+      allow(subject).to receive(:system).with("pgrep fake_service 1>/dev/null").and_return(true)
+      allow(subject).to receive(:system).with("which fake_service 1>/dev/null").and_return(true)
+
+      expect(subject.call).to eq("fake_service is installed\r\nfake_service is running")
+    end
+  end
+end


### PR DESCRIPTION
We have a few classes now that do very similar things when running
`govuk-doctor`. 

Create a generic `Checkup` class that will be able to run the various tests for us based on arguments passed in.

Also extract the messages we need for dnsmasq, docker and docker-compose when testing for install or run state.

The intent is to call the new checkup class as follows:

```
Doctor::Checkup.new(
  service_name: "dnsmasq",
  checkups: [:installed, :running],
  messages: Doctor.messages[:dnsmasq]
).call
```

Future commits will start to strangle off the old code.