### PR TITLE
Refactor arguments to base commands constructor

### DIFF
--- a/lib/commands/base.rb
+++ b/lib/commands/base.rb
@@ -4,11 +4,11 @@ require_relative '../errors/unknown_stack'
 
 module Commands
   class Base
-    def initialize(config_directory = nil, service = nil, stack = nil, verbose = false)
+    def initialize(config_directory = nil, service = nil, stack = nil, verbose = nil)
       @config_directory = config_directory || default_config_directory
       @service = service || default_service
-      @stack = stack
-      @verbose = verbose
+      @stack = stack || default_stack
+      @verbose = verbose || default_verbose
     end
 
   private
@@ -37,6 +37,15 @@ module Commands
       [base_path] + Dir.glob(services_path)
     end
 
+    def service_exists?
+      search_string = "services/#{service}/docker-compose.yml"
+      docker_compose_paths.any? { |path| path.include?(search_string) }
+    end
+
+    def stack_exists?
+      available_stacks.include?(stack)
+    end
+
     def default_config_directory
       File.join(__dir__, "..", "..")
     end
@@ -45,13 +54,12 @@ module Commands
       ENV.fetch("GOVUK_DOCKER_SERVICE", File.basename(Dir.pwd))
     end
 
-    def service_exists?
-      search_string = "services/#{service}/docker-compose.yml"
-      docker_compose_paths.any? { |path| path.include?(search_string) }
+    def default_stack
+      "lite"
     end
 
-    def stack_exists?
-      available_stacks.include?(stack)
+    def default_verbose
+      false
     end
   end
 end

--- a/lib/commands/base.rb
+++ b/lib/commands/base.rb
@@ -4,17 +4,16 @@ require_relative '../errors/unknown_stack'
 
 module Commands
   class Base
-    def initialize(service = nil, config_directory = nil, system = nil, stack = nil, verbose = false)
+    def initialize(service = nil, config_directory = nil, stack = nil, verbose = false)
       @service = service || default_service
       @config_directory = config_directory || default_config_directory
-      @system = system || default_system
       @stack = stack
       @verbose = verbose
     end
 
   private
 
-    attr_reader :config_directory, :service, :system, :stack, :verbose
+    attr_reader :config_directory, :service, :stack, :verbose
 
     def available_stacks
       service_path = File.join(config_directory, "services/#{service}/docker-compose.yml")
@@ -44,10 +43,6 @@ module Commands
 
     def default_service
       ENV.fetch("GOVUK_DOCKER_SERVICE", File.basename(Dir.pwd))
-    end
-
-    def default_system
-      Kernel.method(:system)
     end
 
     def service_exists?

--- a/lib/commands/base.rb
+++ b/lib/commands/base.rb
@@ -4,9 +4,9 @@ require_relative '../errors/unknown_stack'
 
 module Commands
   class Base
-    def initialize(service = nil, config_directory = nil, stack = nil, verbose = false)
-      @service = service || default_service
+    def initialize(config_directory = nil, service = nil, stack = nil, verbose = false)
       @config_directory = config_directory || default_config_directory
+      @service = service || default_service
       @stack = stack
       @verbose = verbose
     end

--- a/lib/commands/build.rb
+++ b/lib/commands/build.rb
@@ -4,6 +4,6 @@ require_relative './compose'
 class Commands::Build < Commands::Base
   def call
     check_service_exists
-    system.call("make", "-f", "#{config_directory}/Makefile", service)
+    system("make", "-f", "#{config_directory}/Makefile", service)
   end
 end

--- a/lib/commands/compose.rb
+++ b/lib/commands/compose.rb
@@ -1,7 +1,7 @@
 require_relative './base'
 
 class Commands::Compose < Commands::Base
-  def call(verbose, *args)
+  def call(args)
     args.insert(0, "docker-compose")
     args.insert(1, *docker_compose_args)
     verbose ? display_full_commands(args) : display_truncated_commands(args)

--- a/lib/commands/compose.rb
+++ b/lib/commands/compose.rb
@@ -5,7 +5,7 @@ class Commands::Compose < Commands::Base
     args.insert(0, "docker-compose")
     args.insert(1, *docker_compose_args)
     verbose ? display_full_commands(args) : display_truncated_commands(args)
-    system.call(*args)
+    system(*args)
   end
 
 private

--- a/lib/commands/prune.rb
+++ b/lib/commands/prune.rb
@@ -2,7 +2,7 @@ require_relative './base'
 
 class Commands::Prune < Commands::Base
   def call
-    commands.each { |command| system.call(command) }
+    commands.each { |command| system(command) }
   end
 
 private

--- a/lib/commands/run.rb
+++ b/lib/commands/run.rb
@@ -2,8 +2,8 @@ require_relative './base'
 require_relative './compose'
 
 class Commands::Run < Commands::Base
-  def initialize(stack, verbose, args, service = nil, config_directory = nil)
-    super(service, config_directory, stack, verbose)
+  def initialize(args, config_directory = nil, service = nil, stack = nil, verbose = false)
+    super(config_directory, service, stack, verbose)
     @args = args
   end
 

--- a/lib/commands/run.rb
+++ b/lib/commands/run.rb
@@ -5,9 +5,12 @@ class Commands::Run < Commands::Base
   def call(args = [])
     check_service_exists
     check_stack_exists
-    Commands::Compose.new.call(
-      verbose, "run", "--rm", "--service-ports", container_name, *docker_compose_args(args)
-    )
+
+    Commands::Compose
+      .new(config_directory, service, stack, verbose)
+      .call(
+        ["run", "--rm", "--service-ports", container_name] + docker_compose_args(args)
+      )
   end
 
 private

--- a/lib/commands/run.rb
+++ b/lib/commands/run.rb
@@ -3,7 +3,7 @@ require_relative './compose'
 
 class Commands::Run < Commands::Base
   def initialize(stack, verbose, args, service = nil, config_directory = nil)
-    super(service, config_directory, nil, stack, verbose)
+    super(service, config_directory, stack, verbose)
     @args = args
   end
 

--- a/lib/commands/run.rb
+++ b/lib/commands/run.rb
@@ -2,7 +2,7 @@ require_relative './base'
 require_relative './compose'
 
 class Commands::Run < Commands::Base
-  def initialize(args, config_directory = nil, service = nil, stack = nil, verbose = false)
+  def initialize(args, config_directory = nil, service = nil, stack = nil, verbose = nil)
     super(config_directory, service, stack, verbose)
     @args = args
   end

--- a/lib/commands/run.rb
+++ b/lib/commands/run.rb
@@ -2,16 +2,11 @@ require_relative './base'
 require_relative './compose'
 
 class Commands::Run < Commands::Base
-  def initialize(args, config_directory = nil, service = nil, stack = nil, verbose = nil)
-    super(config_directory, service, stack, verbose)
-    @args = args
-  end
-
-  def call
+  def call(args = [])
     check_service_exists
     check_stack_exists
     Commands::Compose.new.call(
-      verbose, "run", "--rm", "--service-ports", container_name, *extra_args
+      verbose, "run", "--rm", "--service-ports", container_name, *docker_compose_args(args)
     )
   end
 
@@ -23,7 +18,7 @@ private
     "#{service}-#{stack}"
   end
 
-  def extra_args
+  def docker_compose_args(args)
     return [] if args.empty?
     return args if args.first == "env"
 

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -78,7 +78,7 @@ class GovukDockerCLI < Thor
   option :service, default: nil
   option :verbose, type: :boolean, default: false
   def run(*args)
-    Commands::Run.new(args, nil, options[:service], options[:stack], options[:verbose]).call
+    Commands::Run.new(nil, options[:service], options[:stack], options[:verbose]).call(args)
   end
 
   desc "startup [VARIATION]", "Run the service in the current directory with the `app` stack. Variations can be provided, for example `live` or `draft`."
@@ -86,6 +86,6 @@ class GovukDockerCLI < Thor
   option :verbose, type: :boolean, default: false
   def startup(variation = nil)
     stack = variation ? "app-#{variation}" : "app"
-    Commands::Run.new([], nil, options[:service], stack, options[:verbose]).call
+    Commands::Run.new(nil, options[:service], stack, options[:verbose]).call
   end
 end

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -44,7 +44,7 @@ class GovukDockerCLI < Thor
   LONGDESC
   option :verbose, type: :boolean, default: false
   def compose(*args)
-    Commands::Compose.new.call(options[:verbose], *args)
+    Commands::Compose.new(nil, nil, nil, options[:verbose]).call(args)
   end
 
   desc "doctor", "Various tests to help diagnose issues when running govuk-docker"

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -29,7 +29,7 @@ class GovukDockerCLI < Thor
   LONGDESC
   option :service, default: nil
   def build
-    Commands::Build.new(options[:service]).call
+    Commands::Build.new(nil, options[:service]).call
   end
 
   desc "compose ARGS", "Run `docker-compose` with ARGS"

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -78,13 +78,14 @@ class GovukDockerCLI < Thor
   option :service, default: nil
   option :verbose, type: :boolean, default: false
   def run(*args)
-    Commands::Run.new(options[:stack], options[:verbose], args, options[:service]).call
+    Commands::Run.new(args, nil, options[:service], options[:stack], options[:verbose]).call
   end
 
   desc "startup [VARIATION]", "Run the service in the current directory with the `app` stack. Variations can be provided, for example `live` or `draft`."
+  option :service, default: nil
   option :verbose, type: :boolean, default: false
   def startup(variation = nil)
     stack = variation ? "app-#{variation}" : "app"
-    Commands::Run.new(stack, options[:verbose], []).call
+    Commands::Run.new([], nil, options[:service], stack, options[:verbose]).call
   end
 end

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -5,15 +5,14 @@ require_relative "../../lib/errors/unknown_service"
 describe Commands::Build do
   let(:config_directory) { "spec/fixtures" }
   let(:service) { nil }
-  let(:system) { double(:system) }
 
-  subject { described_class.new(service, config_directory, system) }
+  subject { described_class.new(service, config_directory) }
 
   context "when a service exists" do
     let(:service) { "example-service" }
 
     it "should run docker compose" do
-      expect(system).to receive(:call).with("make", "-f", "#{config_directory}/Makefile", "example-service")
+      expect(subject).to receive(:system).with("make", "-f", "#{config_directory}/Makefile", "example-service")
       subject.call
     end
   end

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -6,7 +6,7 @@ describe Commands::Build do
   let(:config_directory) { "spec/fixtures" }
   let(:service) { nil }
 
-  subject { described_class.new(service, config_directory) }
+  subject { described_class.new(config_directory, service) }
 
   context "when a service exists" do
     let(:service) { "example-service" }

--- a/spec/commands/compose_spec.rb
+++ b/spec/commands/compose_spec.rb
@@ -5,7 +5,7 @@ describe Commands::Compose do
   let(:config_directory) { "spec/fixtures" }
   let(:verbose) { nil }
 
-  subject { described_class.new(config_directory) }
+  subject { described_class.new(config_directory, nil, nil, verbose) }
 
   context "when in verbose mode" do
     let(:verbose) { true }
@@ -17,7 +17,7 @@ describe Commands::Compose do
         "fake args"
       )
 
-      subject.call(verbose, "fake args")
+      subject.call(["fake args"])
     end
 
     it "outputs the full list of docker compose files" do
@@ -28,7 +28,7 @@ describe Commands::Compose do
         "test args"
       )
 
-      expect { subject.call(verbose, "test args") }.
+      expect { subject.call(["test args"]) }.
         to output("docker-compose -f spec/fixtures/docker-compose.yml -f spec/fixtures/services/example-service/docker-compose.yml test args\n").to_stdout
     end
   end
@@ -43,7 +43,7 @@ describe Commands::Compose do
         "test args"
       )
 
-      expect { subject.call(verbose, "test args") }.
+      expect { subject.call(["test args"]) }.
        to output("docker-compose -f [...] test args\n").to_stdout
     end
   end

--- a/spec/commands/compose_spec.rb
+++ b/spec/commands/compose_spec.rb
@@ -2,16 +2,15 @@ require "spec_helper"
 require_relative "../../lib/commands/compose"
 
 describe Commands::Compose do
-  let(:fake_system) { double }
   let(:config_directory) { "spec/fixtures" }
   let(:verbose) { nil }
 
-  subject { described_class.new(nil, config_directory, fake_system) }
+  subject { described_class.new(nil, config_directory) }
 
   context "when in verbose mode" do
     let(:verbose) { true }
     it "calls docker-compose with the correct configure files and arguments" do
-      expect(fake_system).to receive(:call).with(
+      expect(subject).to receive(:system).with(
         "docker-compose",
         "-f", "spec/fixtures/docker-compose.yml",
         "-f", "spec/fixtures/services/example-service/docker-compose.yml",
@@ -22,7 +21,7 @@ describe Commands::Compose do
     end
 
     it "outputs the full list of docker compose files" do
-      expect(fake_system).to receive(:call).with(
+      expect(subject).to receive(:system).with(
         "docker-compose",
         "-f", "spec/fixtures/docker-compose.yml",
         "-f", "spec/fixtures/services/example-service/docker-compose.yml",
@@ -37,7 +36,7 @@ describe Commands::Compose do
   context "when in silent mode" do
     let(:verbose) { false }
     it "outputs a truncated list of docker commands" do
-      expect(fake_system).to receive(:call).with(
+      expect(subject).to receive(:system).with(
         "docker-compose",
         "-f", "spec/fixtures/docker-compose.yml",
         "-f", "spec/fixtures/services/example-service/docker-compose.yml",

--- a/spec/commands/compose_spec.rb
+++ b/spec/commands/compose_spec.rb
@@ -5,7 +5,7 @@ describe Commands::Compose do
   let(:config_directory) { "spec/fixtures" }
   let(:verbose) { nil }
 
-  subject { described_class.new(nil, config_directory) }
+  subject { described_class.new(config_directory) }
 
   context "when in verbose mode" do
     let(:verbose) { true }

--- a/spec/commands/prune_spec.rb
+++ b/spec/commands/prune_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../lib/commands/prune"
 describe Commands::Prune do
   let(:config_directory) { "spec/fixtures" }
 
-  subject { described_class.new(nil, config_directory) }
+  subject { described_class.new(config_directory) }
 
   it "calls the necessary prune commands" do
     expect(subject).to receive(:system).with("docker container prune -f")

--- a/spec/commands/prune_spec.rb
+++ b/spec/commands/prune_spec.rb
@@ -3,14 +3,13 @@ require_relative "../../lib/commands/prune"
 
 describe Commands::Prune do
   let(:config_directory) { "spec/fixtures" }
-  let(:fake_system) { double }
 
-  subject { described_class.new(nil, config_directory, fake_system) }
+  subject { described_class.new(nil, config_directory) }
 
   it "calls the necessary prune commands" do
-    expect(fake_system).to receive(:call).with("docker container prune -f")
-    expect(fake_system).to receive(:call).with("docker volume rm $(docker volume ls -q -f 'dangling=true' | grep -x '.{64,}') 2> /dev/null")
-    expect(fake_system).to receive(:call).with("docker image prune -f")
+    expect(subject).to receive(:system).with("docker container prune -f")
+    expect(subject).to receive(:system).with("docker volume rm $(docker volume ls -q -f 'dangling=true' | grep -x '.{64,}') 2> /dev/null")
+    expect(subject).to receive(:system).with("docker image prune -f")
 
     subject.call
   end

--- a/spec/commands/run_spec.rb
+++ b/spec/commands/run_spec.rb
@@ -8,7 +8,7 @@ describe Commands::Run do
   let(:args)    { nil }
   let(:verbose) { false }
 
-  subject { described_class.new(args, config_directory, service, stack, verbose) }
+  subject { described_class.new(config_directory, service, stack, verbose) }
 
   context "with a service that exists" do
     let(:service) { "example-service" }
@@ -24,7 +24,7 @@ describe Commands::Run do
         expect(compose_command).to receive(:call).with(
           verbose, "run", "--rm", "--service-ports", "example-service-lite"
         )
-        subject.call
+        subject.call(args)
       end
     end
 
@@ -36,7 +36,7 @@ describe Commands::Run do
           verbose, "run", "--rm", "--service-ports", "example-service-lite",
           "env", "bundle", "exec", "rake", "lint"
         )
-        subject.call
+        subject.call(args)
       end
     end
 
@@ -48,7 +48,7 @@ describe Commands::Run do
           verbose, "run", "--rm", "--service-ports", "example-service-lite",
           "env", "bundle", "exec", "rake", "lint"
         )
-        subject.call
+        subject.call(args)
       end
     end
   end
@@ -58,7 +58,7 @@ describe Commands::Run do
     let(:stack) { "lite" }
 
     it "should fail" do
-      expect { subject.call }.to raise_error(UnknownService)
+      expect { subject.call(args) }.to raise_error(UnknownService)
     end
   end
 
@@ -67,7 +67,7 @@ describe Commands::Run do
     let(:stack) { "no-example-stack" }
 
     it "should fail" do
-      expect { subject.call }.to raise_error(UnknownStack)
+      expect { subject.call(args) }.to raise_error(UnknownStack)
     end
   end
 end

--- a/spec/commands/run_spec.rb
+++ b/spec/commands/run_spec.rb
@@ -8,7 +8,7 @@ describe Commands::Run do
   let(:args)    { nil }
   let(:verbose) { false }
 
-  subject { described_class.new(stack, verbose, args, service, config_directory) }
+  subject { described_class.new(args, config_directory, service, stack, verbose) }
 
   context "with a service that exists" do
     let(:service) { "example-service" }

--- a/spec/commands/run_spec.rb
+++ b/spec/commands/run_spec.rb
@@ -15,14 +15,18 @@ describe Commands::Run do
     let(:stack) { "lite" }
 
     let(:compose_command) { double }
-    before { expect(Commands::Compose).to receive(:new).and_return(compose_command) }
+    before do
+      expect(Commands::Compose).to receive(:new)
+        .with(config_directory, service, stack, verbose)
+        .and_return(compose_command)
+    end
 
     context "with no extra arguments" do
       let(:args) { [] }
 
       it "should run docker compose" do
         expect(compose_command).to receive(:call).with(
-          verbose, "run", "--rm", "--service-ports", "example-service-lite"
+          ["run", "--rm", "--service-ports", "example-service-lite"]
         )
         subject.call(args)
       end
@@ -33,8 +37,7 @@ describe Commands::Run do
 
       it "should run docker compose using the `env` command" do
         expect(compose_command).to receive(:call).with(
-          verbose, "run", "--rm", "--service-ports", "example-service-lite",
-          "env", "bundle", "exec", "rake", "lint"
+          ["run", "--rm", "--service-ports", "example-service-lite", "env", "bundle", "exec", "rake", "lint"]
         )
         subject.call(args)
       end
@@ -45,8 +48,7 @@ describe Commands::Run do
 
       it "should run docker compose without duplicating `env`" do
         expect(compose_command).to receive(:call).with(
-          verbose, "run", "--rm", "--service-ports", "example-service-lite",
-          "env", "bundle", "exec", "rake", "lint"
+          ["run", "--rm", "--service-ports", "example-service-lite", "env", "bundle", "exec", "rake", "lint"]
         )
         subject.call(args)
       end

--- a/spec/govuk_docker_cli_spec.rb
+++ b/spec/govuk_docker_cli_spec.rb
@@ -115,7 +115,7 @@ describe GovukDockerCLI do
     context "without the service argument" do
       it "builds the working directory's service" do
         expect(Commands::Build)
-          .to receive(:new).with(nil)
+          .to receive(:new).with(nil, nil)
           .and_return(command_double)
         subject
       end
@@ -126,7 +126,7 @@ describe GovukDockerCLI do
 
       it "builds the specified service" do
         expect(Commands::Build)
-          .to receive(:new).with("static")
+          .to receive(:new).with(nil, "static")
           .and_return(command_double)
         subject
       end

--- a/spec/govuk_docker_cli_spec.rb
+++ b/spec/govuk_docker_cli_spec.rb
@@ -14,7 +14,7 @@ describe GovukDockerCLI do
     context "without stack and service arguments" do
       it "runs in the lite stack" do
         expect(Commands::Run)
-          .to receive(:new).with("lite", false, [], nil)
+          .to receive(:new).with([], nil, nil, "lite", false)
           .and_return(command_double)
         subject
       end
@@ -25,7 +25,7 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with("app", false, [], "static")
+          .to receive(:new).with([], nil, "static", "app", false)
           .and_return(command_double)
         subject
       end
@@ -36,7 +36,7 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with("app", false, [], nil)
+          .to receive(:new).with([], nil, nil, "app", false)
           .and_return(command_double)
         subject
       end
@@ -47,7 +47,7 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with("lite", false, [], "static")
+          .to receive(:new).with([], nil, "static", "lite", false)
           .and_return(command_double)
         subject
       end
@@ -58,7 +58,7 @@ describe GovukDockerCLI do
 
       it "runs the command with additional arguments" do
         expect(Commands::Run)
-          .to receive(:new).with("lite", false, %w[bundle exec rspec], nil)
+          .to receive(:new).with(%w[bundle exec rspec], nil, nil, "lite", false)
           .and_return(command_double)
         subject
       end
@@ -68,7 +68,7 @@ describe GovukDockerCLI do
       let(:args) { ["--verbose"] }
       it "runs in the verbose mode" do
         expect(Commands::Run)
-          .to receive(:new).with('lite', true, [], nil)
+          .to receive(:new).with([], nil, nil, 'lite', true)
           .and_return(command_double)
         subject
       end
@@ -78,7 +78,7 @@ describe GovukDockerCLI do
       let(:args) { [] }
       it "runs in silent mode" do
         expect(Commands::Run)
-          .to receive(:new).with('lite', false, [], nil)
+          .to receive(:new).with([], nil, nil, 'lite', false)
           .and_return(command_double)
         subject
       end
@@ -89,9 +89,9 @@ describe GovukDockerCLI do
     let(:command) { "startup" }
 
     context "without a variation argument" do
-      it "runs in the backend stack" do
+      it "runs in the app stack" do
         expect(Commands::Run)
-          .to receive(:new).with("app", false, [])
+          .to receive(:new).with([], nil, nil, "app", false)
           .and_return(command_double)
         subject
       end
@@ -102,7 +102,7 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with("app-live", false, [])
+          .to receive(:new).with([], nil, nil, "app-live", false)
           .and_return(command_double)
         subject
       end

--- a/spec/govuk_docker_cli_spec.rb
+++ b/spec/govuk_docker_cli_spec.rb
@@ -14,8 +14,9 @@ describe GovukDockerCLI do
     context "without stack and service arguments" do
       it "runs in the lite stack" do
         expect(Commands::Run)
-          .to receive(:new).with([], nil, nil, "lite", false)
+          .to receive(:new).with(nil, nil, "lite", false)
           .and_return(command_double)
+        expect(command_double).to receive(:call).with([])
         subject
       end
     end
@@ -25,8 +26,9 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with([], nil, "static", "app", false)
+          .to receive(:new).with(nil, "static", "app", false)
           .and_return(command_double)
+        expect(command_double).to receive(:call).with([])
         subject
       end
     end
@@ -36,8 +38,9 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with([], nil, nil, "app", false)
+          .to receive(:new).with(nil, nil, "app", false)
           .and_return(command_double)
+        expect(command_double).to receive(:call).with([])
         subject
       end
     end
@@ -47,8 +50,9 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with([], nil, "static", "lite", false)
+          .to receive(:new).with(nil, "static", "lite", false)
           .and_return(command_double)
+        expect(command_double).to receive(:call).with([])
         subject
       end
     end
@@ -58,8 +62,9 @@ describe GovukDockerCLI do
 
       it "runs the command with additional arguments" do
         expect(Commands::Run)
-          .to receive(:new).with(%w[bundle exec rspec], nil, nil, "lite", false)
+          .to receive(:new).with(nil, nil, "lite", false)
           .and_return(command_double)
+        expect(command_double).to receive(:call).with(%w[bundle exec rspec])
         subject
       end
     end
@@ -68,8 +73,9 @@ describe GovukDockerCLI do
       let(:args) { ["--verbose"] }
       it "runs in the verbose mode" do
         expect(Commands::Run)
-          .to receive(:new).with([], nil, nil, 'lite', true)
+          .to receive(:new).with(nil, nil, 'lite', true)
           .and_return(command_double)
+        expect(command_double).to receive(:call).with([])
         subject
       end
     end
@@ -78,8 +84,9 @@ describe GovukDockerCLI do
       let(:args) { [] }
       it "runs in silent mode" do
         expect(Commands::Run)
-          .to receive(:new).with([], nil, nil, 'lite', false)
+          .to receive(:new).with(nil, nil, 'lite', false)
           .and_return(command_double)
+        expect(command_double).to receive(:call).with([])
         subject
       end
     end
@@ -91,8 +98,9 @@ describe GovukDockerCLI do
     context "without a variation argument" do
       it "runs in the app stack" do
         expect(Commands::Run)
-          .to receive(:new).with([], nil, nil, "app", false)
+          .to receive(:new).with(nil, nil, "app", false)
           .and_return(command_double)
+        expect(command_double).to receive(:call).with(no_args)
         subject
       end
     end
@@ -102,8 +110,9 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with([], nil, nil, "app-live", false)
+          .to receive(:new).with(nil, nil, "app-live", false)
           .and_return(command_double)
+        expect(command_double).to receive(:call).with(no_args)
         subject
       end
     end


### PR DESCRIPTION
This refactors all the commands to have a consistent constructor interface, taken from the `Base` command. Any custom arguments that are specific to the command behaviour itself is passed into `call`.

I've also removed our injection of `system` with a mock in the tests to reduce the number of arguments we're passing around and because it follows what we've done in the doctor and install classes.

I think this helps to reduce any confusion when calling the commands and makes the code easier to read.

The next steps from here would be to directly pass [Thor class options](http://whatisthor.com/#class-options) into the constructor and the [Thor method options](http://whatisthor.com/#options-and-flags) into `call` for all the commands. This would reduce the number of `nil`s we need, but I wanted to start with this PR before making too many bigger changes.