### PR TITLE
 Pass thor class options directly into commands

### DIFF
--- a/lib/commands/base.rb
+++ b/lib/commands/base.rb
@@ -4,11 +4,11 @@ require_relative '../errors/unknown_stack'
 
 module Commands
   class Base
-    def initialize(config_directory = nil, service = nil, stack = nil, verbose = nil)
-      @config_directory = config_directory || default_config_directory
-      @service = service || default_service
-      @stack = stack || default_stack
-      @verbose = verbose || default_verbose
+    def initialize(options)
+      @config_directory = options[:config_directory] || default_config_directory
+      @service = options[:service] || default_service
+      @stack = options[:stack] || default_stack
+      @verbose = options[:verbose] || default_verbose
     end
 
   private

--- a/lib/commands/run.rb
+++ b/lib/commands/run.rb
@@ -7,7 +7,7 @@ class Commands::Run < Commands::Base
     check_stack_exists
 
     Commands::Compose
-      .new(config_directory, service, stack, verbose)
+      .new(config_directory: config_directory, service: service, stack: stack, verbose: verbose)
       .call(
         ["run", "--rm", "--service-ports", container_name] + docker_compose_args(args)
       )

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -22,6 +22,10 @@ class GovukDockerCLI < Thor
 
   package_name "govuk-docker"
 
+  class_option :service, type: :string, default: nil
+  class_option :stack, type: :string, default: "lite"
+  class_option :verbose, type: :boolean, default: false
+
   desc "build [ARGS]", "Build a service"
   long_desc <<~LONGDESC
     By default, it builds the service in the current directory.
@@ -29,7 +33,7 @@ class GovukDockerCLI < Thor
   LONGDESC
   option :service, default: nil
   def build
-    Commands::Build.new(nil, options[:service]).call
+    Commands::Build.new(options).call
   end
 
   desc "compose ARGS", "Run `docker-compose` with ARGS"
@@ -42,9 +46,8 @@ class GovukDockerCLI < Thor
 
     > govuk-docker compose stop
   LONGDESC
-  option :verbose, type: :boolean, default: false
   def compose(*args)
-    Commands::Compose.new(nil, nil, nil, options[:verbose]).call(args)
+    Commands::Compose.new(options).call(args)
   end
 
   desc "doctor", "Various tests to help diagnose issues when running govuk-docker"
@@ -74,18 +77,13 @@ class GovukDockerCLI < Thor
     It can run with a different stack if specified (e.g. `govuk-docker run --stack app`).
     These two options can be combined (e.g. `govuk-docker run --service static --stack app`).
   LONGDESC
-  option :stack, default: "lite"
-  option :service, default: nil
-  option :verbose, type: :boolean, default: false
   def run(*args)
-    Commands::Run.new(nil, options[:service], options[:stack], options[:verbose]).call(args)
+    Commands::Run.new(options).call(args)
   end
 
   desc "startup [VARIATION]", "Run the service in the current directory with the `app` stack. Variations can be provided, for example `live` or `draft`."
-  option :service, default: nil
-  option :verbose, type: :boolean, default: false
   def startup(variation = nil)
     stack = variation ? "app-#{variation}" : "app"
-    Commands::Run.new(nil, options[:service], stack, options[:verbose]).call
+    Commands::Run.new(options.merge(stack: stack)).call
   end
 end

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -26,7 +26,7 @@ class GovukDockerCLI < Thor
   class_option :stack, type: :string, default: "lite"
   class_option :verbose, type: :boolean, default: false
 
-  desc "build [ARGS]", "Build a service"
+  desc "build", "Build the service"
   long_desc <<~LONGDESC
     By default, it builds the service in the current directory.
     It can build a different service if specified (e.g. `govuk-docker build --service static`).
@@ -70,7 +70,7 @@ class GovukDockerCLI < Thor
     Commands::Prune.new.call
   end
 
-  desc "run [ARGS]", "Run a service"
+  desc "run [ARGS]", "Run the service"
   long_desc <<~LONGDESC
     By default, it runs the service in the current directory with the `lite` stack.
     It can run a different service if specified (e.g. `govuk-docker run --service static`).

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -6,7 +6,7 @@ describe Commands::Build do
   let(:config_directory) { "spec/fixtures" }
   let(:service) { nil }
 
-  subject { described_class.new(config_directory, service) }
+  subject { described_class.new(config_directory: config_directory, service: service) }
 
   context "when a service exists" do
     let(:service) { "example-service" }

--- a/spec/commands/compose_spec.rb
+++ b/spec/commands/compose_spec.rb
@@ -5,7 +5,7 @@ describe Commands::Compose do
   let(:config_directory) { "spec/fixtures" }
   let(:verbose) { nil }
 
-  subject { described_class.new(config_directory, nil, nil, verbose) }
+  subject { described_class.new(config_directory: config_directory, verbose: verbose) }
 
   context "when in verbose mode" do
     let(:verbose) { true }

--- a/spec/commands/prune_spec.rb
+++ b/spec/commands/prune_spec.rb
@@ -4,7 +4,7 @@ require_relative "../../lib/commands/prune"
 describe Commands::Prune do
   let(:config_directory) { "spec/fixtures" }
 
-  subject { described_class.new(config_directory) }
+  subject { described_class.new(config_directory: config_directory) }
 
   it "calls the necessary prune commands" do
     expect(subject).to receive(:system).with("docker container prune -f")

--- a/spec/commands/run_spec.rb
+++ b/spec/commands/run_spec.rb
@@ -8,7 +8,7 @@ describe Commands::Run do
   let(:args)    { nil }
   let(:verbose) { false }
 
-  subject { described_class.new(config_directory, service, stack, verbose) }
+  subject { described_class.new(config_directory: config_directory, service: service, stack: stack, verbose: verbose) }
 
   context "with a service that exists" do
     let(:service) { "example-service" }
@@ -17,7 +17,7 @@ describe Commands::Run do
     let(:compose_command) { double }
     before do
       expect(Commands::Compose).to receive(:new)
-        .with(config_directory, service, stack, verbose)
+        .with(config_directory: config_directory, service: service, stack: stack, verbose: verbose)
         .and_return(compose_command)
     end
 

--- a/spec/govuk_docker_cli_spec.rb
+++ b/spec/govuk_docker_cli_spec.rb
@@ -14,7 +14,7 @@ describe GovukDockerCLI do
     context "without stack and service arguments" do
       it "runs in the lite stack" do
         expect(Commands::Run)
-          .to receive(:new).with(nil, nil, "lite", false)
+          .to receive(:new).with(stack: "lite", verbose: false)
           .and_return(command_double)
         expect(command_double).to receive(:call).with([])
         subject
@@ -26,7 +26,7 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with(nil, "static", "app", false)
+          .to receive(:new).with(service: "static", stack: "app", verbose: false)
           .and_return(command_double)
         expect(command_double).to receive(:call).with([])
         subject
@@ -38,7 +38,7 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with(nil, nil, "app", false)
+          .to receive(:new).with(stack: "app", verbose: false)
           .and_return(command_double)
         expect(command_double).to receive(:call).with([])
         subject
@@ -50,7 +50,7 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with(nil, "static", "lite", false)
+          .to receive(:new).with(service: "static", stack: "lite", verbose: false)
           .and_return(command_double)
         expect(command_double).to receive(:call).with([])
         subject
@@ -62,7 +62,7 @@ describe GovukDockerCLI do
 
       it "runs the command with additional arguments" do
         expect(Commands::Run)
-          .to receive(:new).with(nil, nil, "lite", false)
+          .to receive(:new).with(stack: "lite", verbose: false)
           .and_return(command_double)
         expect(command_double).to receive(:call).with(%w[bundle exec rspec])
         subject
@@ -73,7 +73,7 @@ describe GovukDockerCLI do
       let(:args) { ["--verbose"] }
       it "runs in the verbose mode" do
         expect(Commands::Run)
-          .to receive(:new).with(nil, nil, 'lite', true)
+          .to receive(:new).with(stack: "lite", verbose: true)
           .and_return(command_double)
         expect(command_double).to receive(:call).with([])
         subject
@@ -84,7 +84,7 @@ describe GovukDockerCLI do
       let(:args) { [] }
       it "runs in silent mode" do
         expect(Commands::Run)
-          .to receive(:new).with(nil, nil, 'lite', false)
+          .to receive(:new).with(stack: "lite", verbose: false)
           .and_return(command_double)
         expect(command_double).to receive(:call).with([])
         subject
@@ -98,7 +98,7 @@ describe GovukDockerCLI do
     context "without a variation argument" do
       it "runs in the app stack" do
         expect(Commands::Run)
-          .to receive(:new).with(nil, nil, "app", false)
+          .to receive(:new).with(stack: "app", verbose: false)
           .and_return(command_double)
         expect(command_double).to receive(:call).with(no_args)
         subject
@@ -110,7 +110,7 @@ describe GovukDockerCLI do
 
       it "runs in the specified stack" do
         expect(Commands::Run)
-          .to receive(:new).with(nil, nil, "app-live", false)
+          .to receive(:new).with(stack: "app-live", verbose: false)
           .and_return(command_double)
         expect(command_double).to receive(:call).with(no_args)
         subject
@@ -124,7 +124,7 @@ describe GovukDockerCLI do
     context "without the service argument" do
       it "builds the working directory's service" do
         expect(Commands::Build)
-          .to receive(:new).with(nil, nil)
+          .to receive(:new).with(stack: "lite", verbose: false)
           .and_return(command_double)
         subject
       end
@@ -135,7 +135,7 @@ describe GovukDockerCLI do
 
       it "builds the specified service" do
         expect(Commands::Build)
-          .to receive(:new).with(nil, "static")
+          .to receive(:new).with(service: "static", stack: "lite", verbose: false)
           .and_return(command_double)
         subject
       end


### PR DESCRIPTION
This simplifies the code and avoids the need to pass around lots of `nil`s. I think it also makes it clearer where these options are as they are now referenced with keywords.

This also exposes these arguments/flags from `govuk-docker help` which makes them easier to discover.