### PR TITLE
Really actually test if the config is valid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+stderr.log

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ clean:
 
 test:
 	# Linting
-	bundle exec rubocop .
+	bundle exec rubocop . --parallel
 
 	# Run the tests for the govuk-docker CLI
 	bundle exec rspec

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ test:
 
 	# Test that the docker-compose config is valid. This will error if there are errors
 	# in the YAML files, or incompatible features are used.
-	bin/govuk-docker compose config --quiet | grep -v "ERROR"
+	sh bin/test-docker-compose.sh
 
 # This will be slow and may repeat work, so generally you don't want
 # to run this.

--- a/bin/test-docker-compose.sh
+++ b/bin/test-docker-compose.sh
@@ -1,0 +1,12 @@
+set -eux
+
+# Redirect STDERR to a file
+bin/govuk-docker compose config --quiet 2> stderr.log
+
+# And check if the file is empty
+if [ -s stderr.log ]; then
+  cat stderr.log
+  exit 1
+else
+  echo "No errors found in docker compose config"
+fi


### PR DESCRIPTION
It turns out that https://github.com/alphagov/govuk-docker/pull/67 didn't work, because the "ERROR" output is something weird.

The error output is *hopefully* always sent to STDERR, so we can capture that and check if we see errors this way.

https://trello.com/c/B0TSiqy5