### PR TITLE
Fix calendars routing

### DIFF
--- a/services/nginx-proxy/docker-compose.yml
+++ b/services/nginx-proxy/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       default:
         aliases:
           - asset-manager.dev.gov.uk
+          - calendars.dev.gov.uk
           - content-publisher.dev.gov.uk
           - content-store.dev.gov.uk
           - content-tagger.dev.gov.uk


### PR DESCRIPTION
http://www.dev.gov.uk/bank-holidays/england-and-wales.json did
not route to the calendars app.

Added it to the nginx-proxy configuration.