### PR TITLE
Allow commands to be initialized with no arguments

### DIFF
--- a/lib/commands/base.rb
+++ b/lib/commands/base.rb
@@ -4,7 +4,7 @@ require_relative '../errors/unknown_stack'
 
 module Commands
   class Base
-    def initialize(options)
+    def initialize(options = {})
       @config_directory = options[:config_directory] || default_config_directory
       @service = options[:service] || default_service
       @stack = options[:stack] || default_stack

--- a/spec/commands/prune_spec.rb
+++ b/spec/commands/prune_spec.rb
@@ -13,4 +13,8 @@ describe Commands::Prune do
 
     subject.call
   end
+
+  it "can be initialized with no arguments" do
+    described_class.new
+  end
 end


### PR DESCRIPTION
Currently running `govuk-docker prune` gives an error

```bash
GDS0123:govuk-docker (master)% govuk-docker prune
Traceback (most recent call last):
        7: from /Users/erinrajstaniland/govuk/govuk-docker/bin/govuk-docker:22:in `<main>'
        6: from /Users/erinrajstaniland/.gem/ruby/2.6.3/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
        5: from /Users/erinrajstaniland/.gem/ruby/2.6.3/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
        4: from /Users/erinrajstaniland/.gem/ruby/2.6.3/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
        3: from /Users/erinrajstaniland/.gem/ruby/2.6.3/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
        2: from /Users/erinrajstaniland/govuk/govuk-docker/lib/govuk_docker_cli.rb:70:in `prune'
        1: from /Users/erinrajstaniland/govuk/govuk-docker/lib/govuk_docker_cli.rb:70:in `new'
/Users/erinrajstaniland/govuk/govuk-docker/lib/commands/base.rb:7:in `initialize': wrong number of arguments (given 0, expected 1) (ArgumentError)
```