### PR TITLE
Expose mongodb ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@ services:
     image: mongo:2.4
     volumes:
       - mongo:/data/db
+    ports:
+      - "27017:27017"
+      - "27018:27018"
 
   mysql:
     image: mysql:5.5.58


### PR DESCRIPTION
Exposing mongodb (27017,27018) ports so we can connect to it from
the host machine.