### PR TITLE
Rename nginx-proxy container to nginx-proxy-app

### DIFF
--- a/services/asset-manager/docker-compose.yml
+++ b/services/asset-manager/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     depends_on:
       - mongo
       - redis
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       MONGODB_URI: "mongodb://mongo/asset-manager"
       REDIS_URL: redis://redis
@@ -42,7 +42,7 @@ services:
     depends_on:
       - mongo
       - redis
-      - nginx-proxy
+      - nginx-proxy-app
       - asset-manager-worker
 
   asset-manager-worker:

--- a/services/calculators/docker-compose.yml
+++ b/services/calculators/docker-compose.yml
@@ -49,7 +49,7 @@ services:
   calculators-app-live:
     <<: *calculators
     depends_on:
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api

--- a/services/calendars/docker-compose.yml
+++ b/services/calendars/docker-compose.yml
@@ -51,7 +51,7 @@ services:
   calendars-app-live:
     <<: *calendars
     depends_on:
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api

--- a/services/content-publisher/docker-compose.yml
+++ b/services/content-publisher/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - redis
       - publishing-api-app
       - asset-manager-app
-      - nginx-proxy
+      - nginx-proxy-app
       - content-store-app
     environment:
       DATABASE_URL: "postgresql://postgres@postgres/content-publisher"
@@ -49,7 +49,7 @@ services:
       - content-publisher-worker
       - publishing-api-app-e2e
       - asset-manager-app-e2e
-      - nginx-proxy
+      - nginx-proxy-app
 
   content-publisher-worker:
     <<: *content-publisher

--- a/services/content-store/docker-compose.yml
+++ b/services/content-store/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     depends_on:
       - mongo
       - router-api-app
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       MONGODB_URI: "mongodb://mongo/content-store"
       VIRTUAL_HOST: content-store.dev.gov.uk
@@ -39,7 +39,7 @@ services:
     depends_on:
       - mongo
       - router-api-app-draft
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       PLEK_HOSTNAME_PREFIX: "draft-"
       MONGODB_URI: "mongodb://mongo/draft-content-store"

--- a/services/content-tagger/docker-compose.yml
+++ b/services/content-tagger/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     depends_on:
       - postgres
       - publishing-api-app
-      - nginx-proxy
+      - nginx-proxy-app
       - redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres/content-tagger"

--- a/services/government-frontend/docker-compose.yml
+++ b/services/government-frontend/docker-compose.yml
@@ -48,7 +48,7 @@ services:
   government-frontend-app-live:
     <<: *government-frontend
     depends_on:
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api

--- a/services/govuk-developer-docs/docker-compose.yml
+++ b/services/govuk-developer-docs/docker-compose.yml
@@ -20,7 +20,7 @@ services:
   govuk-developer-docs-app:
     <<: *govuk-developer-docs
     depends_on:
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       VIRTUAL_HOST: govuk-developer-docs.dev.gov.uk
     ports:

--- a/services/govuk_publishing_components/docker-compose.yml
+++ b/services/govuk_publishing_components/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   govuk_publishing_components-app:
     <<: *govuk_publishing_components
     depends_on:
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       VIRTUAL_HOST: govuk-publishing-components.dev.gov.uk
     ports:

--- a/services/info-frontend/docker-compose.yml
+++ b/services/info-frontend/docker-compose.yml
@@ -34,7 +34,7 @@ services:
   info-frontend-app-live:
     <<: *info-frontend-base
     depends_on:
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api

--- a/services/link-checker-api/docker-compose.yml
+++ b/services/link-checker-api/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     <<: *link-checker-api
     depends_on:
       - link-checker-api-worker
-      - nginx-proxy
+      - nginx-proxy-app
       - postgres
       - redis
     environment:

--- a/services/nginx-proxy/docker-compose.yml
+++ b/services/nginx-proxy/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 
 services:
-  nginx-proxy:
+  nginx-proxy-app:
     image: jwilder/nginx-proxy:latest
     ports:
       - "80:80"

--- a/services/publishing-api/docker-compose.yml
+++ b/services/publishing-api/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     depends_on:
       - postgres
       - redis
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       DATABASE_URL: "postgresql://postgres@postgres/publishing-api"
       REDIS_URL: redis://redis
@@ -46,7 +46,7 @@ services:
     depends_on:
       - postgres
       - redis
-      - nginx-proxy
+      - nginx-proxy-app
       - publishing-api-worker
 
   publishing-api-worker:

--- a/services/service-manual-frontend/docker-compose.yml
+++ b/services/service-manual-frontend/docker-compose.yml
@@ -46,7 +46,7 @@ services:
   service-manual-frontend-app-live:
     <<: *service-manual-frontend-base
     depends_on:
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api

--- a/services/signon/docker-compose.yml
+++ b/services/signon/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     <<: *signon
     depends_on:
       - mysql
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       DATABASE_URL: "mysql2://root:root@mysql/signon_development"
       VIRTUAL_HOST: signon.dev.gov.uk

--- a/services/smart-answers/docker-compose.yml
+++ b/services/smart-answers/docker-compose.yml
@@ -19,7 +19,7 @@ services:
   smart-answers-app:
     <<: *smart-answers
     depends_on:
-      - nginx-proxy
+      - nginx-proxy-app
       - publishing-api-app
       - asset-manager-app
       - static-app

--- a/services/specialist-publisher/docker-compose.yml
+++ b/services/specialist-publisher/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     depends_on:
       - mongo
       - redis
-      - nginx-proxy
+      - nginx-proxy-app
       - publishing-api-app
       - asset-manager-app
       - email-alert-api-app
@@ -50,7 +50,7 @@ services:
       - publishing-api-app-e2e
       - asset-manager-app-e2e
       - email-alert-api-app
-      - nginx-proxy
+      - nginx-proxy-app
 
   specialist-publisher-worker:
     <<: *specialist-publisher

--- a/services/support-api/docker-compose.yml
+++ b/services/support-api/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     depends_on:
       - postgres
       - redis
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       DATABASE_URL: "postgresql://postgres@postgres/support-api"
       REDIS_URL: redis://redis

--- a/services/support/docker-compose.yml
+++ b/services/support/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     <<: *support
     depends_on:
       - redis
-      - nginx-proxy
+      - nginx-proxy-app
       - support-api-app
     environment:
       VIRTUAL_HOST: support.dev.gov.uk

--- a/services/travel-advice-publisher/docker-compose.yml
+++ b/services/travel-advice-publisher/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - publishing-api-app
       - asset-manager-app
       - content-store-app
-      - nginx-proxy
+      - nginx-proxy-app
     environment:
       MONGODB_URI: "mongodb://mongo/travel-advice-publisher"
       REDIS_URL: redis://redis
@@ -49,7 +49,7 @@ services:
       - travel-advice-publisher-worker
       - publishing-api-app-e2e
       - asset-manager-app-e2e
-      - nginx-proxy
+      - nginx-proxy-app
 
   travel-advice-publisher-worker:
     <<: *travel-advice-publisher

--- a/services/whitehall/docker-compose.yml
+++ b/services/whitehall/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - mysql
       - redis
       - static-app
-      - nginx-proxy
+      - nginx-proxy-app
       - asset-manager-app
       - publishing-api-app
     environment:
@@ -48,6 +48,6 @@ services:
       - mysql
       - redis
       - static-app
-      - nginx-proxy
+      - nginx-proxy-app
       - asset-manager-app-e2e
       - publishing-api-app-e2e


### PR DESCRIPTION
Currently govuk-docker assumes all containers have the format `#{service}-#{stack}` and this is not the case for nginx-proxy.

Rather than change govuk-docker to support this special case, I thought it would be better to rename `nginx-proxy` for consistency with our other apps. This allows you to run it using `govuk-docker startup`.