### PR TITLE
Search API

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ The following apps are supported by govuk-docker to some extent.
    - ✅ publishing-api
    - ✅ router
    - ✅ router-api
+   - ⚠  search-api
+    * Tests fail as they run against [both Elasticsearch instances](https://github.com/alphagov/search-api/pull/1618)
    - ✅ signon
    - ✅ smart-answers
    - ✅ specialist-publisher

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,3 +34,19 @@ services:
     image: rabbitmq
     volumes:
       - rabbitmq:/var/lib/rabbitmq
+
+  elasticsearch5:
+    image: elasticsearch:5.6.14
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+
+  elasticsearch6:
+    image: elasticsearch:6.7.0
+    environment:
+      - http.host=0.0.0.0
+      - transport.host=127.0.0.1
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ volumes:
   mysql:
   mongo:
   go:
+  elasticsearch5:
+  elasticsearch6:
 
 services:
   postgres:
@@ -42,6 +44,8 @@ services:
       - transport.host=127.0.0.1
       - xpack.security.enabled=false
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    volumes:
+      - elasticsearch5:/usr/share/elasticsearch/data
 
   elasticsearch6:
     image: elasticsearch:6.7.0
@@ -50,3 +54,5 @@ services:
       - transport.host=127.0.0.1
       - xpack.security.enabled=false
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    volumes:
+      - elasticsearch6:/usr/share/elasticsearch/data

--- a/services/nginx-proxy/docker-compose.yml
+++ b/services/nginx-proxy/docker-compose.yml
@@ -31,6 +31,7 @@ services:
           - router-api.dev.gov.uk
           - router.dev.gov.uk
           - service-manual-frontend.dev.gov.uk
+          - search-api.dev.gov.uk
           - signon.dev.gov.uk
           - smart-answers.dev.gov.uk
           - specialist-publisher.dev.gov.uk

--- a/services/search-api/Dockerfile
+++ b/services/search-api/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.6.3
+
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
+
+RUN useradd -m build
+USER build
+
+ENV EDITOR=vim

--- a/services/search-api/Makefile
+++ b/services/search-api/Makefile
@@ -1,0 +1,2 @@
+search-api: $(GOVUK_ROOT_DIR)/search-api
+	$(COMPOSE_RUN) search-api-lite bundle

--- a/services/search-api/Makefile
+++ b/services/search-api/Makefile
@@ -1,4 +1,5 @@
-search-api: $(GOVUK_ROOT_DIR)/search-api
+search-api: $(GOVUK_ROOT_DIR)/search-api publishing-api
 	$(COMPOSE_RUN) search-api-lite bundle
 	$(COMPOSE_RUN) search-api-lite env SEARCH_INDEX=all bundle exec rake search:create_all_indices
+	$(COMPOSE_RUN) search-api-lite bundle exec rake message_queue:create_queues
 

--- a/services/search-api/Makefile
+++ b/services/search-api/Makefile
@@ -1,2 +1,4 @@
 search-api: $(GOVUK_ROOT_DIR)/search-api
 	$(COMPOSE_RUN) search-api-lite bundle
+	$(COMPOSE_RUN) search-api-lite env SEARCH_INDEX=all bundle exec rake search:create_all_indices
+

--- a/services/search-api/docker-compose.yml
+++ b/services/search-api/docker-compose.yml
@@ -17,6 +17,27 @@ services:
     depends_on:
       - redis
       - elasticsearch5
+      - elasticsearch6
     environment:
       REDIS_HOST: redis
       ELASTICSEARCH_URI: http://elasticsearch5:9200
+      ELASTICSEARCH_B_URI: http://elasticsearch6:9200
+
+  search-api-app: &search-api-app
+    <<: *search-api
+    depends_on:
+      - nginx-proxy-app
+      - redis
+      - elasticsearch5
+      - elasticsearch6
+    environment:
+      REDIS_HOST: redis
+      ELASTICSEARCH_URI: http://elasticsearch5:9200
+      ELASTICSEARCH_B_URI: http://elasticsearch6:9200
+      VIRTUAL_HOST: search-api.dev.gov.uk
+      HOST: 0.0.0.0
+    ports:
+      - "3000"
+    command: bundle exec mr-sparkle --force-polling -- -p 3000
+
+

--- a/services/search-api/docker-compose.yml
+++ b/services/search-api/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.7'
+
+x-search-api: &search-api
+  build:
+    context: .
+    dockerfile: services/search-api/Dockerfile
+  image: search-api
+  volumes:
+    - ..:/govuk:delegated
+    - bundle:/usr/local/bundle
+    - home:/home/build
+  working_dir: /govuk/search-api
+
+services:
+  search-api-lite:
+    <<: *search-api
+    depends_on:
+      - redis
+      - elasticsearch5
+    environment:
+      REDIS_HOST: redis
+      ELASTICSEARCH_URI: http://elasticsearch5:9200

--- a/services/search-api/docker-compose.yml
+++ b/services/search-api/docker-compose.yml
@@ -45,4 +45,41 @@ services:
       - "3000"
     command: bundle exec mr-sparkle --force-polling -- -p 3000
 
+  search-api-worker:
+    <<: *search-api
+    depends_on:
+      - redis
+      - rabbitmq
+      - elasticsearch5
+      - elasticsearch6
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
 
+  search-api-listener-publishing-queue:
+    <<: *search-api
+    depends_on:
+      - rabbitmq
+    command: bundle exec rake message_queue:listen_to_publishing_queue
+
+  search-api-listener-insert-data:
+    <<: *search-api
+    depends_on:
+      - rabbitmq
+    command: bundle exec rake message_queue:insert_data_into_govuk
+
+  search-api-listener-bulk-insert-data:
+    <<: *search-api
+    depends_on:
+      - rabbitmq
+    command: bundle exec rake message_queue:bulk_insert_data_into_govuk
+
+  search-api-app-e2e:
+    <<: *search-api-app
+    depends_on:
+      - nginx-proxy-app
+      - redis
+      - elasticsearch5
+      - elasticsearch6
+      - search-api-worker
+      - search-api-listener-publishing-queue
+      - search-api-listener-insert-data
+      - search-api-listener-bulk-insert-data

--- a/services/search-api/docker-compose.yml
+++ b/services/search-api/docker-compose.yml
@@ -10,18 +10,23 @@ x-search-api: &search-api
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/search-api
+  environment:
+    RABBITMQ_HOSTS: rabbitmq
+    RABBITMQ_VHOST: /
+    RABBITMQ_USER: guest
+    RABBITMQ_PASSWORD: guest
+    REDIS_HOST: redis
+    ELASTICSEARCH_URI: http://elasticsearch5:9200
+    ELASTICSEARCH_B_URI: http://elasticsearch6:9200
 
 services:
   search-api-lite:
     <<: *search-api
     depends_on:
       - redis
+      - rabbitmq
       - elasticsearch5
       - elasticsearch6
-    environment:
-      REDIS_HOST: redis
-      ELASTICSEARCH_URI: http://elasticsearch5:9200
-      ELASTICSEARCH_B_URI: http://elasticsearch6:9200
 
   search-api-app: &search-api-app
     <<: *search-api


### PR DESCRIPTION
Trello: https://trello.com/c/TutEPhvS/39-set-up-search-api

I did some work cleaning up https://github.com/alphagov/govuk-docker/pull/100 as Jos/Oscar ended up fighting against Search API tests.

I tested it end-to-end and the search index gets populated:

<img width="1552" alt="Screen Shot 2019-07-05 at 09 47 37" src="https://user-images.githubusercontent.com/282717/60710155-f1b1e380-9f09-11e9-8571-b53d8af357cd.png">
