### PR TITLE
 Add a setup step to clone/pull the repo

### DIFF
--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -8,6 +8,7 @@ require_relative "./commands/startup"
 require_relative "./doctor/doctor"
 require_relative "./doctor/checkup"
 require_relative "./setup/dnsmasq"
+require_relative "./setup/repo"
 
 class GovukDockerCLI < Thor
   # https://github.com/ddollar/foreman/blob/83fd5eeb8c4b522cb84d8e74031080143ea6353b/lib/foreman/cli.rb#L29-L35
@@ -93,6 +94,8 @@ class GovukDockerCLI < Thor
 
   desc "setup", "Configures and installs the various dependencies necessary to run `govuk-docker` successfully"
   def setup
+    Setup::Repo.new(shell).call
+    puts
     Setup::Dnsmasq.new(shell).call
   end
 

--- a/lib/setup/repo.rb
+++ b/lib/setup/repo.rb
@@ -1,0 +1,58 @@
+require_relative "./base"
+require_relative "../paths"
+
+class Setup::Repo < Setup::Base
+  def call
+    unless should_clone_or_pull?
+      puts "Ignoring git repo because of local changes."
+      return
+    end
+
+    return unless check_continue
+
+    clone_or_pull
+
+    puts "✅ govuk-docker is up to date!"
+  end
+
+private
+
+  def should_clone_or_pull?
+    return true unless File.directory?(path)
+    return false if repo_has_local_changes?
+
+    true
+  end
+
+  def repo_has_local_changes?
+    !system("git -C #{path} diff-index --quiet HEAD --")
+  end
+
+  def check_continue
+    puts "This will clone/pull `#{path}`."
+    puts "Any local changes may be overwriten."
+    puts
+
+    shell.yes?("Are you sure you want to continue?")
+  end
+
+  def clone_or_pull
+    if File.directory?(path)
+      pull
+    else
+      clone
+    end
+  end
+
+  def pull
+    system("git -C #{path} pull")
+  end
+
+  def clone
+    system("git clone https://github.com/alphagov/govuk-docker.git #{path}")
+  end
+
+  def path
+    GovukDocker::Paths.govuk_docker_dir
+  end
+end

--- a/spec/setup/repo_spec.rb
+++ b/spec/setup/repo_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+require_relative "../../lib/setup/repo"
+
+describe Setup::Repo do
+  let(:shell_double) { double }
+  let(:path) { "/home/test/govuk/govuk-docker" }
+
+  around do |example|
+    ClimateControl.modify(GOVUK_DOCKER_DIR: path) do
+      example.run
+    end
+  end
+
+  subject { described_class.new(shell_double) }
+
+  before do
+    allow(subject).to receive(:puts)
+    allow(shell_double).to receive(:yes?).and_return(true)
+  end
+
+  context "already cloned" do
+    before { allow(File).to receive(:directory?).with(path).and_return(true) }
+
+    context "with local changes" do
+      before { expect(subject).to receive(:system).with("git -C #{path} diff-index --quiet HEAD --").and_return(false) }
+
+      it "doesn't pull the repo" do
+        expect(subject).to_not receive(:system).with("git -C #{path} pull")
+        subject.call
+      end
+    end
+
+    context "without local changes" do
+      before { expect(subject).to receive(:system).with("git -C #{path} diff-index --quiet HEAD --").and_return(true) }
+
+      it "pulls the repo" do
+        expect(subject).to receive(:system).with("git -C #{path} pull")
+        subject.call
+      end
+    end
+  end
+
+  context "not already cloned" do
+    before { allow(File).to receive(:directory?).with(path).and_return(false) }
+
+    it "clones the repo" do
+      expect(subject).to receive(:system).with("git clone https://github.com/alphagov/govuk-docker.git #{path}")
+      subject.call
+    end
+  end
+end


### PR DESCRIPTION
This takes us towards the idea of being able to do `gem install govuk-docker` because the next step can be to do `govuk-docker install` and the repo will be cloned automatically.