### PR TITLE
Add `govuk-docker be` alias

### DIFF
--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -89,6 +89,11 @@ class GovukDockerCLI < Thor
     Commands::Run.new(options).call(args)
   end
 
+  desc "be [ARGS]", "Alias for `run bundle exec`"
+  def be(*args)
+    Commands::Run.new(options).call(%w[bundle exec] + args)
+  end
+
   desc "startup [VARIATION]", "Run the container for a service in the `app` stack, with optional variations, such as `live` or `draft`"
   def startup(variation = nil)
     Commands::Startup.new(options).call(variation)

--- a/spec/govuk_docker_cli_spec.rb
+++ b/spec/govuk_docker_cli_spec.rb
@@ -92,6 +92,19 @@ describe GovukDockerCLI do
     end
   end
 
+  describe "be" do
+    let(:command) { "be" }
+    let(:args) { %w[rspec] }
+
+    it "runs the `run` command with `bundle exec` plus additional arguments" do
+      expect(Commands::Run)
+        .to receive(:new).with(stack: "lite", verbose: false)
+        .and_return(command_double)
+      expect(command_double).to receive(:call).with(%w[bundle exec rspec])
+      subject
+    end
+  end
+
   describe "startup" do
     let(:command) { "startup" }
 


### PR DESCRIPTION
This is a shorthand version of `govuk-docker run bundle exec`.