### PR TITLE
Respect exit codes

### DIFF
--- a/lib/commands/build.rb
+++ b/lib/commands/build.rb
@@ -4,6 +4,6 @@ require_relative './compose'
 class Commands::Build < Commands::Base
   def call
     check_service_exists
-    system("make", "-f", "#{config_directory}/Makefile", service)
+    system_command "make", "-f", "#{config_directory}/Makefile", service
   end
 end

--- a/lib/commands/compose.rb
+++ b/lib/commands/compose.rb
@@ -5,7 +5,7 @@ class Commands::Compose < Commands::Base
     args.insert(0, "docker-compose")
     args.insert(1, *docker_compose_args)
     verbose ? display_full_commands(args) : display_truncated_commands(args)
-    system(*args)
+    system_command(*args)
   end
 
 private

--- a/lib/commands/prune.rb
+++ b/lib/commands/prune.rb
@@ -2,7 +2,7 @@ require_relative './base'
 
 class Commands::Prune < Commands::Base
   def call
-    commands.each { |command| system(command) }
+    commands.each { |command| system_command command }
   end
 
 private

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -19,6 +19,10 @@ class GovukDockerCLI < Thor
 
       super
     end
+
+    def exit_on_failure?
+      true
+    end
   end
 
   package_name "govuk-docker"

--- a/spec/commands/base_spec.rb
+++ b/spec/commands/base_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+require_relative "../../lib/commands/base"
+
+describe Commands::Base do
+  subject { described_class.new }
+
+  describe "#system_command" do
+    it "runs a given system command" do
+      expect(subject).to receive(:system).with("arg") { true }
+      subject.system_command("arg")
+    end
+
+    it "raises for non-zero exit codes" do
+      allow(subject).to receive(:system)
+      expect { subject.system_command }.to raise_error("Non-zero exit code")
+    end
+  end
+end

--- a/spec/commands/build_spec.rb
+++ b/spec/commands/build_spec.rb
@@ -8,10 +8,14 @@ describe Commands::Build do
 
   subject { described_class.new(config_directory: config_directory, service: service) }
 
+  before do
+    allow(subject).to receive(:system) { 0 }
+  end
+
   context "when a service exists" do
     let(:service) { "example-service" }
 
-    it "should run docker compose" do
+    it "should make the service" do
       expect(subject).to receive(:system).with("make", "-f", "#{config_directory}/Makefile", "example-service")
       subject.call
     end

--- a/spec/commands/compose_spec.rb
+++ b/spec/commands/compose_spec.rb
@@ -6,8 +6,10 @@ describe Commands::Compose do
   let(:verbose) { nil }
 
   subject { described_class.new(config_directory: config_directory, verbose: verbose) }
+
   before do
     allow(subject).to receive(:puts)
+    allow(subject).to receive(:system) { 0 }
   end
 
   context "when in verbose mode" do
@@ -42,7 +44,7 @@ describe Commands::Compose do
 
   context "when in silent mode" do
     let(:verbose) { false }
-    it "outputs a truncated list of docker commands" do
+    it "outputs a truncated list of docker compose files" do
       expect(subject).to receive(:system).with(
         "docker-compose",
         "-f", "spec/fixtures/docker-compose.yml",

--- a/spec/commands/prune_spec.rb
+++ b/spec/commands/prune_spec.rb
@@ -3,14 +3,24 @@ require_relative "../../lib/commands/prune"
 
 describe Commands::Prune do
   let(:config_directory) { "spec/fixtures" }
-
   subject { described_class.new(config_directory: config_directory) }
 
-  it "calls the necessary prune commands" do
-    expect(subject).to receive(:system).with("docker container prune -f")
-    expect(subject).to receive(:system).with("docker volume rm $(docker volume ls -q -f 'dangling=true' | grep -x '.{64,}') 2> /dev/null")
-    expect(subject).to receive(:system).with("docker image prune -f")
+  before do
+    allow(subject).to receive(:system) { 0 }
+  end
 
+  it "removes exited containers" do
+    expect(subject).to receive(:system).with("docker container prune -f")
+    subject.call
+  end
+
+  it "removes temporary anonymous volumes" do
+    expect(subject).to receive(:system).with("docker volume rm $(docker volume ls -q -f 'dangling=true' | grep -x '.{64,}') 2> /dev/null")
+    subject.call
+  end
+
+  it "removes temporary anonymous images" do
+    expect(subject).to receive(:system).with("docker image prune -f")
     subject.call
   end
 


### PR DESCRIPTION
https://trello.com/c/2XWgdfo7/5-%F0%9F%92%A5-make-setup-super-fast-and-easy

This fixes an issue we've been having where the CLI was always exiting with '0', even when the invoked command was malformed or had failed.