### PR TITLE
Add docker and docker-compose to Setup script

### DIFF
--- a/lib/doctor/doctor.rb
+++ b/lib/doctor/doctor.rb
@@ -18,7 +18,7 @@ module Doctor
       running: "✅ Docker is running",
       not_running: <<~HEREDOC
         ❌ Docker is not running.
-        You should start it with `sudo brew services start dnsmasq`.
+        You should start it with `sudo brew services start docker`.
       HEREDOC
     }
   end

--- a/lib/doctor/doctor.rb
+++ b/lib/doctor/doctor.rb
@@ -18,7 +18,7 @@ module Doctor
       running: "✅ Docker is running",
       not_running: <<~HEREDOC
         ❌ Docker is not running.
-        You should start it with `sudo brew services start docker`.
+        Please make sure Docker is running before using govuk-docker.
       HEREDOC
     }
   end

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -7,6 +7,7 @@ require_relative "./commands/run"
 require_relative "./commands/startup"
 require_relative "./doctor/doctor"
 require_relative "./doctor/checkup"
+require_relative "./setup/docker"
 require_relative "./setup/dnsmasq"
 require_relative "./setup/repo"
 
@@ -93,9 +94,15 @@ class GovukDockerCLI < Thor
   end
 
   desc "setup", "Configures and installs the various dependencies necessary to run `govuk-docker` successfully"
+  long_desc <<~LONGDESC
+    * Docker
+    * Docker-compose
+    * Dnsmasq
+  LONGDESC
   def setup
     Setup::Repo.new(shell).call
     puts
+    Setup::Docker.new(shell).call
     Setup::Dnsmasq.new(shell).call
   end
 

--- a/lib/setup/docker.rb
+++ b/lib/setup/docker.rb
@@ -1,0 +1,28 @@
+require_relative "./base"
+
+class Setup::Docker < Setup::Base
+  def call
+    return unless check_continue
+
+    install_docker
+    install_docker_compose
+    puts "✅ Docker and Docker-compose installation and configuration complete!"
+  end
+
+private
+
+  def check_continue
+    puts "This will install Docker and Docker-compose via Brew."
+    shell.yes?("Are you sure you want to continue?")
+  end
+
+  def install_docker
+    puts "⏳ Installing Docker"
+    system("brew cask install docker")
+  end
+
+  def install_docker_compose
+    puts "⏳ Installing Docker-compose"
+    system("brew install docker-compose")
+  end
+end

--- a/lib/setup/docker.rb
+++ b/lib/setup/docker.rb
@@ -1,4 +1,5 @@
 require_relative "./base"
+require_relative "../doctor/checkup"
 
 class Setup::Docker < Setup::Base
   def call
@@ -17,11 +18,23 @@ private
   end
 
   def install_docker
+    return if Doctor::Checkup.new(
+      service_name: "docker",
+      checkups: %i(installed),
+      messages: {}
+    ).installed?
+
     puts "⏳ Installing Docker"
     system("brew cask install docker")
   end
 
   def install_docker_compose
+    return if Doctor::Checkup.new(
+      service_name: "docker-compose",
+      checkups: %i(installed),
+      messages: {}
+    ).installed?
+
     puts "⏳ Installing Docker-compose"
     system("brew install docker-compose")
   end

--- a/spec/setup/docker_spec.rb
+++ b/spec/setup/docker_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+require_relative "../../lib/setup/docker"
+
+describe Setup::Docker do
+  let(:shell_double) { double }
+
+  subject { described_class.new(shell_double) }
+  before { allow(subject).to receive(:puts) }
+
+  context "disallowing the script to continue" do
+    it "shouldn't do anything" do
+      expect(subject).to receive(:puts).with(/This will install Docker/)
+      expect(shell_double).to receive(:yes?).and_return(false)
+      expect(subject).to_not receive(:system)
+      subject.call
+    end
+  end
+
+  context "allowing the script to continue" do
+    before do
+      allow(shell_double).to receive(:yes?).and_return(true)
+      allow(subject).to receive(:system).with("brew cask install docker")
+      allow(subject).to receive(:system).with("brew install docker-compose")
+      allow(subject).to receive(:puts)
+    end
+
+    context "docker dependencies are not installed" do
+      it "installs docker using brew" do
+        expect(subject).to receive(:puts).with(/Installing Docker/)
+        expect(subject).to receive(:system).with("brew cask install docker")
+        subject.call
+      end
+
+      it "installs docker-compose using brew" do
+        expect(subject).to receive(:puts).with(/Installing Docker-compose/)
+        expect(subject).to receive(:system).with("brew install docker-compose")
+        subject.call
+      end
+    end
+  end
+end

--- a/spec/setup/docker_spec.rb
+++ b/spec/setup/docker_spec.rb
@@ -11,6 +11,7 @@ describe Setup::Docker do
     it "shouldn't do anything" do
       expect(subject).to receive(:puts).with(/This will install Docker/)
       expect(shell_double).to receive(:yes?).and_return(false)
+      expect(Doctor::Checkup).to_not receive(:new)
       expect(subject).to_not receive(:system)
       subject.call
     end
@@ -25,6 +26,11 @@ describe Setup::Docker do
     end
 
     context "docker dependencies are not installed" do
+      before do
+        allow(Doctor::Checkup).to receive(:new).with(service_name: "docker", checkups: %i(installed), messages: {}).and_return(double(installed?: false))
+        allow(Doctor::Checkup).to receive(:new).with(service_name: "docker-compose", checkups: %i(installed), messages: {}).and_return(double(installed?: false))
+      end
+
       it "installs docker using brew" do
         expect(subject).to receive(:puts).with(/Installing Docker/)
         expect(subject).to receive(:system).with("brew cask install docker")
@@ -34,6 +40,21 @@ describe Setup::Docker do
       it "installs docker-compose using brew" do
         expect(subject).to receive(:puts).with(/Installing Docker-compose/)
         expect(subject).to receive(:system).with("brew install docker-compose")
+        subject.call
+      end
+    end
+
+    context "docker dependencies are already installed" do
+      before do
+        allow(Doctor::Checkup).to receive(:new).with(service_name: "docker", checkups: %i(installed), messages: {}).and_return(double(installed?: true))
+        allow(Doctor::Checkup).to receive(:new).with(service_name: "docker-compose", checkups: %i(installed), messages: {}).and_return(double(installed?: true))
+      end
+      it "doesn't install docker using brew" do
+        expect(subject).to_not receive(:system).with("brew cask install docker")
+        subject.call
+      end
+      it "doesn't install docker-compose using brew" do
+        expect(subject).to_not receive(:system).with("brew install docker-compose")
         subject.call
       end
     end


### PR DESCRIPTION
This will automatically attempt to install docker and docker-compose via brew when running `govuk-docker setup` unless they are already available.