### PR TITLE
Rescue Errno::EHOSTDOWN errors

### DIFF
--- a/lib/commands/startup.rb
+++ b/lib/commands/startup.rb
@@ -71,5 +71,7 @@ private
     else
       false
     end
+  rescue Errno::EHOSTDOWN
+    false
   end
 end


### PR DESCRIPTION
Treat Errno::EHOSTDOWN errors like unsuccessful request and try connecting again