### PR TITLE
Add explicit build step to Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,6 @@ GOVUK_ROOT_DIR   ?= $(HOME)/govuk
 GOVUK_DOCKER_DIR ?= $(GOVUK_ROOT_DIR)/govuk-docker
 GOVUK_DOCKER     ?= $(GOVUK_DOCKER_DIR)/bin/govuk-docker
 
-COMPOSE_RUN = $(GOVUK_DOCKER) compose run
-
 APPS ?= $(shell ls ${GOVUK_DOCKER_DIR}/services/*/Makefile | xargs -L 1 dirname | xargs -L 1 basename)
 
 # This is a Makefile best practice to say that these are not file

--- a/services/asset-manager/Makefile
+++ b/services/asset-manager/Makefile
@@ -1,4 +1,5 @@
-asset-manager: $(GOVUK_ROOT_DIR)/asset-manager
-	$(COMPOSE_RUN) asset-manager-lite bundle
-	$(COMPOSE_RUN) asset-manager-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
-	$(COMPOSE_RUN) asset-manager-lite bin/rails runner 'User.first || User.create'
+asset-manager: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	govuk-docker compose run $@-lite bin/rails runner 'User.first || User.create'

--- a/services/calculators/Makefile
+++ b/services/calculators/Makefile
@@ -1,2 +1,3 @@
-calculators: $(GOVUK_ROOT_DIR)/calculators
-	$(COMPOSE_RUN) calculators-lite bundle
+calculators: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/calendars/Makefile
+++ b/services/calendars/Makefile
@@ -1,2 +1,3 @@
-calendars: $(GOVUK_ROOT_DIR)/calendars
-	$(COMPOSE_RUN) calendars-lite bundle
+calendars: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/collections-publisher/Makefile
+++ b/services/collections-publisher/Makefile
@@ -1,3 +1,4 @@
-collections-publisher: $(GOVUK_ROOT_DIR)/collections-publisher publishing-api content-store link-checker-api
-	$(COMPOSE_RUN) collections-publisher-lite bundle
-	$(COMPOSE_RUN) collections-publisher-lite sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+collections-publisher: $(GOVUK_ROOT_DIR)/$@ publishing-api content-store link-checker-api
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/services/collections/Makefile
+++ b/services/collections/Makefile
@@ -1,2 +1,3 @@
-collections: $(GOVUK_ROOT_DIR)/collections
-	$(COMPOSE_RUN) collections-lite bundle
+collections: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/content-data-admin/Makefile
+++ b/services/content-data-admin/Makefile
@@ -1,3 +1,4 @@
-content-data-admin: $(GOVUK_ROOT_DIR)/content-data-admin
-	$(COMPOSE_RUN) content-data-admin-lite bundle
-	$(COMPOSE_RUN) content-data-admin-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+content-data-admin: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/content-publisher/Makefile
+++ b/services/content-publisher/Makefile
@@ -1,4 +1,5 @@
-content-publisher: $(GOVUK_ROOT_DIR)/content-publisher asset-manager publishing-api
-	$(COMPOSE_RUN) content-publisher-lite bundle
-	$(COMPOSE_RUN) content-publisher-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
-	$(COMPOSE_RUN) content-publisher-lite yarn
+content-publisher: $(GOVUK_ROOT_DIR)/$@ asset-manager publishing-api
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	govuk-docker compose run $@-lite yarn

--- a/services/content-store/Makefile
+++ b/services/content-store/Makefile
@@ -1,6 +1,7 @@
-content-store: $(GOVUK_ROOT_DIR)/content-store router-api govuk-content-schemas
-	$(COMPOSE_RUN) content-store-lite bundle
-	$(COMPOSE_RUN) content-store-lite bin/rake db:create
-	$(COMPOSE_RUN) content-store-lite bin/rails runner 'User.first || User.create'
-	$(COMPOSE_RUN) content-store-app-draft bin/rake db:create
-	$(COMPOSE_RUN) content-store-app-draft bin/rails runner 'User.first || User.create'
+content-store: $(GOVUK_ROOT_DIR)/$@ router-api govuk-content-schemas
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite bin/rake db:create
+	govuk-docker compose run $@-lite bin/rails runner 'User.first || User.create'
+	govuk-docker compose run $@-app-draft bin/rake db:create
+	govuk-docker compose run $@-app-draft bin/rails runner 'User.first || User.create'

--- a/services/content-tagger/Makefile
+++ b/services/content-tagger/Makefile
@@ -1,3 +1,4 @@
-content-tagger: $(GOVUK_ROOT_DIR)/content-tagger publishing-api
-	$(COMPOSE_RUN) content-tagger-lite bundle
-	$(COMPOSE_RUN) content-tagger-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+content-tagger: $(GOVUK_ROOT_DIR)/$@ publishing-api
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/email-alert-api/Makefile
+++ b/services/email-alert-api/Makefile
@@ -1,3 +1,4 @@
-email-alert-api: $(GOVUK_ROOT_DIR)/email-alert-api
-	$(COMPOSE_RUN) email-alert-api-lite bundle
-	$(COMPOSE_RUN) email-alert-api-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+email-alert-api: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/government-frontend/Makefile
+++ b/services/government-frontend/Makefile
@@ -1,2 +1,3 @@
-government-frontend: $(GOVUK_ROOT_DIR)/government-frontend content-store router static govuk-content-schemas
-	$(COMPOSE_RUN) government-frontend-lite bundle
+government-frontend: $(GOVUK_ROOT_DIR)/$@ content-store router static govuk-content-schemas
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/govspeak/Makefile
+++ b/services/govspeak/Makefile
@@ -1,2 +1,3 @@
-govspeak: $(GOVUK_ROOT_DIR)/govspeak
-	$(COMPOSE_RUN) govspeak-lite bundle
+govspeak: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/govuk-content-schemas/Makefile
+++ b/services/govuk-content-schemas/Makefile
@@ -1,2 +1,3 @@
-govuk-content-schemas: $(GOVUK_ROOT_DIR)/govuk-content-schemas
-	$(COMPOSE_RUN) govuk-content-schemas-lite bundle
+govuk-content-schemas: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/govuk-developer-docs/Makefile
+++ b/services/govuk-developer-docs/Makefile
@@ -1,2 +1,3 @@
-govuk-developer-docs: $(GOVUK_ROOT_DIR)/govuk-developer-docs
-	$(COMPOSE_RUN) govuk-developer-docs-lite bundle
+govuk-developer-docs: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/govuk-lint/Makefile
+++ b/services/govuk-lint/Makefile
@@ -1,2 +1,2 @@
-govuk-lint: $(GOVUK_ROOT_DIR)/govuk-lint
-	$(COMPOSE_RUN) govuk-lint-lite bundle
+govuk-lint: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose run $@-lite bundle

--- a/services/govuk_app_config/Makefile
+++ b/services/govuk_app_config/Makefile
@@ -1,2 +1,3 @@
-govuk_app_config: $(GOVUK_ROOT_DIR)/govuk_app_config
-	$(COMPOSE_RUN) govuk_app_config-lite bundle
+govuk_app_config: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/govuk_publishing_components/Makefile
+++ b/services/govuk_publishing_components/Makefile
@@ -1,2 +1,3 @@
-govuk_publishing_components: $(GOVUK_ROOT_DIR)/govuk_publishing_components
-	$(COMPOSE_RUN) govuk_publishing_components-lite bundle
+govuk_publishing_components: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/info-frontend/Makefile
+++ b/services/info-frontend/Makefile
@@ -1,2 +1,3 @@
-info-frontend: $(GOVUK_ROOT_DIR)/info-frontend
-	$(COMPOSE_RUN) info-frontend-lite bundle
+info-frontend: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/link-checker-api/Makefile
+++ b/services/link-checker-api/Makefile
@@ -1,3 +1,4 @@
-link-checker-api: $(GOVUK_ROOT_DIR)/link-checker-api
-	$(COMPOSE_RUN) link-checker-api-lite bundle
-	$(COMPOSE_RUN) link-checker-api-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+link-checker-api: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/miller-columns-element/Makefile
+++ b/services/miller-columns-element/Makefile
@@ -1,2 +1,3 @@
-miller-columns-element: $(GOVUK_ROOT_DIR)/miller-columns-element
-	$(COMPOSE_RUN) miller-columns-element-lite npm install
+miller-columns-element: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite npm install

--- a/services/plek/Makefile
+++ b/services/plek/Makefile
@@ -1,2 +1,3 @@
-plek: $(GOVUK_ROOT_DIR)/plek
-	$(COMPOSE_RUN) plek-lite bundle
+plek: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/publishing-api/Makefile
+++ b/services/publishing-api/Makefile
@@ -1,5 +1,6 @@
-publishing-api: $(GOVUK_ROOT_DIR)/publishing-api content-store govuk-content-schemas
-	$(COMPOSE_RUN) publishing-api-lite bundle
-	$(COMPOSE_RUN) publishing-api-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
-	$(COMPOSE_RUN) publishing-api-lite bin/rails runner 'User.first || User.create'
-	$(COMPOSE_RUN) publishing-api-lite bin/rake setup_exchange
+publishing-api: $(GOVUK_ROOT_DIR)/$@ content-store govuk-content-schemas
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	govuk-docker compose run $@-lite bin/rails runner 'User.first || User.create'
+	govuk-docker compose run $@-lite bin/rake setup_exchange

--- a/services/router-api/Makefile
+++ b/services/router-api/Makefile
@@ -1,2 +1,3 @@
-router-api: $(GOVUK_ROOT_DIR)/router-api router
-	$(COMPOSE_RUN) router-api-lite bundle
+router-api: $(GOVUK_ROOT_DIR)/$@ router
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/router/Makefile
+++ b/services/router/Makefile
@@ -1,2 +1,3 @@
-router: $(GOVUK_ROOT_DIR)/router
-	$(COMPOSE_RUN) router-lite sh -c "BINARY=router make build"
+router: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite sh -c "BINARY=router make build"

--- a/services/search-api/Makefile
+++ b/services/search-api/Makefile
@@ -1,5 +1,5 @@
-search-api: $(GOVUK_ROOT_DIR)/search-api publishing-api
-	$(COMPOSE_RUN) search-api-lite bundle
-	$(COMPOSE_RUN) search-api-lite env SEARCH_INDEX=all bundle exec rake search:create_all_indices
-	$(COMPOSE_RUN) search-api-lite bundle exec rake message_queue:create_queues
+search-api: $(GOVUK_ROOT_DIR)/$@ publishing-api
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite env SEARCH_INDEX=all bundle exec rake search:create_all_indices
+	govuk-docker compose run $@-lite bundle exec rake message_queue:create_queues
 

--- a/services/service-manual-frontend/Makefile
+++ b/services/service-manual-frontend/Makefile
@@ -1,2 +1,3 @@
-service-manual-frontend: $(GOVUK_ROOT_DIR)/service-manual-frontend
-	$(COMPOSE_RUN) service-manual-frontend-lite bundle
+service-manual-frontend: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/signon/Makefile
+++ b/services/signon/Makefile
@@ -1,3 +1,4 @@
-signon: $(GOVUK_ROOT_DIR)/signon
-	$(COMPOSE_RUN) signon-lite bundle
-	$(COMPOSE_RUN) signon-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+signon: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/smart-answers/Makefile
+++ b/services/smart-answers/Makefile
@@ -1,2 +1,3 @@
-smart-answers: $(GOVUK_ROOT_DIR)/smart-answers asset-manager publishing-api static
-	$(COMPOSE_RUN) smart-answers-lite bundle
+smart-answers: $(GOVUK_ROOT_DIR)/$@ asset-manager publishing-api static
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/specialist-publisher/Makefile
+++ b/services/specialist-publisher/Makefile
@@ -1,3 +1,4 @@
-specialist-publisher: $(GOVUK_ROOT_DIR)/specialist-publisher asset-manager publishing-api
-	$(COMPOSE_RUN) specialist-publisher-lite bundle
-	$(COMPOSE_RUN) specialist-publisher-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+specialist-publisher: $(GOVUK_ROOT_DIR)/$@ asset-manager publishing-api
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/static/Makefile
+++ b/services/static/Makefile
@@ -1,2 +1,3 @@
-static: $(GOVUK_ROOT_DIR)/static
-	$(COMPOSE_RUN) static-lite bundle
+static: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/support-api/Makefile
+++ b/services/support-api/Makefile
@@ -1,3 +1,3 @@
-support-api: $(GOVUK_ROOT_DIR)/support-api
-	$(COMPOSE_RUN) support-api-lite bundle
-	$(COMPOSE_RUN) support-api-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+support-api: $(GOVUK_ROOT_DIR)/$@
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/support/Makefile
+++ b/services/support/Makefile
@@ -1,2 +1,3 @@
-support: $(GOVUK_ROOT_DIR)/support support-api
-	$(COMPOSE_RUN) support-lite bundle
+support: $(GOVUK_ROOT_DIR)/$@ support-api
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle

--- a/services/travel-advice-publisher/Makefile
+++ b/services/travel-advice-publisher/Makefile
@@ -1,3 +1,4 @@
-travel-advice-publisher: $(GOVUK_ROOT_DIR)/travel-advice-publisher asset-manager content-store publishing-api
-	$(COMPOSE_RUN) travel-advice-publisher-lite bundle
-	$(COMPOSE_RUN) travel-advice-publisher-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+travel-advice-publisher: $(GOVUK_ROOT_DIR)/$@ asset-manager content-store publishing-api
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/whitehall/Makefile
+++ b/services/whitehall/Makefile
@@ -1,5 +1,6 @@
-whitehall: $(GOVUK_ROOT_DIR)/whitehall asset-manager publishing-api static
-	$(COMPOSE_RUN) whitehall-lite bundle
-	$(COMPOSE_RUN) whitehall-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
-	$(COMPOSE_RUN) whitehall-lite bin/rake shared_mustache:compile
-	$(COMPOSE_RUN) whitehall-app-e2e bin/rake taxonomy:populate_end_to_end_test_data
+whitehall: $(GOVUK_ROOT_DIR)/$@ asset-manager publishing-api static
+	govuk-docker compose build $@-lite
+	govuk-docker compose run $@-lite bundle
+	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	govuk-docker compose run $@-lite bin/rake shared_mustache:compile
+	govuk-docker compose run $@-app-e2e bin/rake taxonomy:populate_end_to_end_test_data


### PR DESCRIPTION
https://trello.com/c/2XWgdfo7/5-%F0%9F%92%A5-make-setup-super-fast-and-easy

Previously we relied on docker-compose to auto-build each service image
at the point when it is first run. If a Dockerfile changes, we need to
support users in rebuilding their images, which docker-compose will not
do by default. This adds an explicit 'compose build app-name-lite' step
to each service Makefile to help ensure this happens.

Rather than repeating service names over and over, this also replaces
the service name with '$@', which strongly coupled the name of the
service to the Makefile target. At the same time, it didn't make much
sense to add another command variable to do the build, so this replaces
COMPOSE_RUN with explicit use of govuk-docker compose run, alongside
govuk-docker compose build.