### PR TITLE
Always use GOVUK_DOCKER instead of govuk-docker

### DIFF
--- a/services/asset-manager/Makefile
+++ b/services/asset-manager/Makefile
@@ -1,5 +1,5 @@
 asset-manager: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
-	govuk-docker compose run $@-lite bin/rails runner 'User.first || User.create'
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) compose run $@-lite bin/rails runner 'User.first || User.create'

--- a/services/calculators/Makefile
+++ b/services/calculators/Makefile
@@ -1,3 +1,3 @@
 calculators: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/calendars/Makefile
+++ b/services/calendars/Makefile
@@ -1,3 +1,3 @@
 calendars: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/collections-publisher/Makefile
+++ b/services/collections-publisher/Makefile
@@ -1,4 +1,4 @@
 collections-publisher: $(GOVUK_ROOT_DIR)/$@ publishing-api content-store link-checker-api
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/services/collections/Makefile
+++ b/services/collections/Makefile
@@ -1,3 +1,3 @@
 collections: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/content-data-admin/Makefile
+++ b/services/content-data-admin/Makefile
@@ -1,4 +1,4 @@
 content-data-admin: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/content-publisher/Makefile
+++ b/services/content-publisher/Makefile
@@ -1,5 +1,5 @@
 content-publisher: $(GOVUK_ROOT_DIR)/$@ asset-manager publishing-api
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
-	govuk-docker compose run $@-lite yarn
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) compose run $@-lite yarn

--- a/services/content-store/Makefile
+++ b/services/content-store/Makefile
@@ -1,7 +1,7 @@
 content-store: $(GOVUK_ROOT_DIR)/$@ router-api govuk-content-schemas
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite bin/rake db:create
-	govuk-docker compose run $@-lite bin/rails runner 'User.first || User.create'
-	govuk-docker compose run $@-app-draft bin/rake db:create
-	govuk-docker compose run $@-app-draft bin/rails runner 'User.first || User.create'
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite bin/rake db:create
+	$(GOVUK_DOCKER) compose run $@-lite bin/rails runner 'User.first || User.create'
+	$(GOVUK_DOCKER) compose run $@-app-draft bin/rake db:create
+	$(GOVUK_DOCKER) compose run $@-app-draft bin/rails runner 'User.first || User.create'

--- a/services/content-tagger/Makefile
+++ b/services/content-tagger/Makefile
@@ -1,4 +1,4 @@
 content-tagger: $(GOVUK_ROOT_DIR)/$@ publishing-api
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/email-alert-api/Makefile
+++ b/services/email-alert-api/Makefile
@@ -1,4 +1,4 @@
 email-alert-api: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/government-frontend/Makefile
+++ b/services/government-frontend/Makefile
@@ -1,3 +1,3 @@
 government-frontend: $(GOVUK_ROOT_DIR)/$@ content-store router static govuk-content-schemas
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/govspeak/Makefile
+++ b/services/govspeak/Makefile
@@ -1,3 +1,3 @@
 govspeak: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/govuk-content-schemas/Makefile
+++ b/services/govuk-content-schemas/Makefile
@@ -1,3 +1,3 @@
 govuk-content-schemas: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/govuk-developer-docs/Makefile
+++ b/services/govuk-developer-docs/Makefile
@@ -1,3 +1,3 @@
 govuk-developer-docs: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/govuk-lint/Makefile
+++ b/services/govuk-lint/Makefile
@@ -1,2 +1,2 @@
 govuk-lint: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/govuk_app_config/Makefile
+++ b/services/govuk_app_config/Makefile
@@ -1,3 +1,3 @@
 govuk_app_config: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/govuk_publishing_components/Makefile
+++ b/services/govuk_publishing_components/Makefile
@@ -1,3 +1,3 @@
 govuk_publishing_components: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/info-frontend/Makefile
+++ b/services/info-frontend/Makefile
@@ -1,3 +1,3 @@
 info-frontend: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/link-checker-api/Makefile
+++ b/services/link-checker-api/Makefile
@@ -1,4 +1,4 @@
 link-checker-api: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/miller-columns-element/Makefile
+++ b/services/miller-columns-element/Makefile
@@ -1,3 +1,3 @@
 miller-columns-element: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite npm install
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite npm install

--- a/services/plek/Makefile
+++ b/services/plek/Makefile
@@ -1,3 +1,3 @@
 plek: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/publishing-api/Makefile
+++ b/services/publishing-api/Makefile
@@ -1,6 +1,6 @@
 publishing-api: $(GOVUK_ROOT_DIR)/$@ content-store govuk-content-schemas
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
-	govuk-docker compose run $@-lite bin/rails runner 'User.first || User.create'
-	govuk-docker compose run $@-lite bin/rake setup_exchange
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) compose run $@-lite bin/rails runner 'User.first || User.create'
+	$(GOVUK_DOCKER) compose run $@-lite bin/rake setup_exchange

--- a/services/router-api/Makefile
+++ b/services/router-api/Makefile
@@ -1,3 +1,3 @@
 router-api: $(GOVUK_ROOT_DIR)/$@ router
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/router/Makefile
+++ b/services/router/Makefile
@@ -1,3 +1,3 @@
 router: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite sh -c "BINARY=router make build"
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite sh -c "BINARY=router make build"

--- a/services/search-api/Makefile
+++ b/services/search-api/Makefile
@@ -1,5 +1,5 @@
 search-api: $(GOVUK_ROOT_DIR)/$@ publishing-api
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite env SEARCH_INDEX=all bundle exec rake search:create_all_indices
-	govuk-docker compose run $@-lite bundle exec rake message_queue:create_queues
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite env SEARCH_INDEX=all bundle exec rake search:create_all_indices
+	$(GOVUK_DOCKER) compose run $@-lite bundle exec rake message_queue:create_queues
 

--- a/services/service-manual-frontend/Makefile
+++ b/services/service-manual-frontend/Makefile
@@ -1,3 +1,3 @@
 service-manual-frontend: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/signon/Makefile
+++ b/services/signon/Makefile
@@ -1,4 +1,4 @@
 signon: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/smart-answers/Makefile
+++ b/services/smart-answers/Makefile
@@ -1,3 +1,3 @@
 smart-answers: $(GOVUK_ROOT_DIR)/$@ asset-manager publishing-api static
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/specialist-publisher/Makefile
+++ b/services/specialist-publisher/Makefile
@@ -1,4 +1,4 @@
 specialist-publisher: $(GOVUK_ROOT_DIR)/$@ asset-manager publishing-api
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/static/Makefile
+++ b/services/static/Makefile
@@ -1,3 +1,3 @@
 static: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/support-api/Makefile
+++ b/services/support-api/Makefile
@@ -1,3 +1,3 @@
 support-api: $(GOVUK_ROOT_DIR)/$@
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/support/Makefile
+++ b/services/support/Makefile
@@ -1,3 +1,3 @@
 support: $(GOVUK_ROOT_DIR)/$@ support-api
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/travel-advice-publisher/Makefile
+++ b/services/travel-advice-publisher/Makefile
@@ -1,4 +1,4 @@
 travel-advice-publisher: $(GOVUK_ROOT_DIR)/$@ asset-manager content-store publishing-api
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/whitehall/Makefile
+++ b/services/whitehall/Makefile
@@ -1,6 +1,6 @@
 whitehall: $(GOVUK_ROOT_DIR)/$@ asset-manager publishing-api static
-	govuk-docker compose build $@-lite
-	govuk-docker compose run $@-lite bundle
-	govuk-docker compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
-	govuk-docker compose run $@-lite bin/rake shared_mustache:compile
-	govuk-docker compose run $@-app-e2e bin/rake taxonomy:populate_end_to_end_test_data
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) compose run $@-lite bin/rake shared_mustache:compile
+	$(GOVUK_DOCKER) compose run $@-app-e2e bin/rake taxonomy:populate_end_to_end_test_data


### PR DESCRIPTION
https://trello.com/c/2XWgdfo7/5-%F0%9F%92%A5-make-setup-super-fast-and-easy

Previously we used the 'govuk-docker' command, which may not work if the
user hasn't setup their PATH correctly. This helps make the setup more
robust by using GOVUK_DOCKER to derive the correct path to the bin file.