### PR TITLE
Add a paths helper class

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "climate_control"
 gem "colorize"
 gem "govuk-lint"
 gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
+    climate_control (0.2.0)
     coderay (1.1.2)
     colorize (0.8.1)
     diff-lcs (1.3)
@@ -66,6 +67,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  climate_control
   colorize
   govuk-lint
   pry

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ node {
     overrideTestTask: {
       stage("Run tests") {
         govuk.withStatsdTiming("test_task") {
-          sh "make test"
+          sh "GOVUK_DOCKER_DIR=. make test"
         }
       }
     }

--- a/lib/commands/base.rb
+++ b/lib/commands/base.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require_relative '../paths'
 require_relative '../errors/unknown_service'
 require_relative '../errors/unknown_stack'
 
@@ -51,7 +52,7 @@ module Commands
     end
 
     def default_config_directory
-      File.join(__dir__, "..", "..")
+      GovukDocker::Paths.govuk_docker_dir
     end
 
     def default_service

--- a/lib/paths.rb
+++ b/lib/paths.rb
@@ -1,0 +1,11 @@
+module GovukDocker
+  class Paths
+    def self.govuk_root_dir
+      ENV.fetch("GOVUK_ROOT_DIR", File.join(ENV.fetch("HOME"), "govuk"))
+    end
+
+    def self.govuk_docker_dir
+      ENV.fetch("GOVUK_DOCKER_DIR", File.join(govuk_root_dir, "govuk-docker"))
+    end
+  end
+end

--- a/spec/paths_spec.rb
+++ b/spec/paths_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+require_relative "../lib/paths"
+
+describe GovukDocker::Paths do
+  describe "govuk_root_dir" do
+    subject { described_class.govuk_root_dir }
+
+    context "when GOVUK_ROOT_DIR is not set" do
+      it "uses HOME environment variable" do
+        ClimateControl.modify GOVUK_ROOT_DIR: nil, HOME: "/home/test" do
+          expect(subject).to eq("/home/test/govuk")
+        end
+      end
+    end
+
+    context "when GOVUK_ROOT_DIR is set" do
+      it "uses the environment variable" do
+        ClimateControl.modify GOVUK_ROOT_DIR: "/govuk" do
+          expect(subject).to eq("/govuk")
+        end
+      end
+    end
+  end
+
+  describe "govuk_docker_dir" do
+    subject { described_class.govuk_docker_dir }
+
+    context "when GOVUK_DOCKER_DIR is not set" do
+      it "uses govuk_root_dir" do
+        ClimateControl.modify GOVUK_DOCKER_DIR: nil do
+          expect(described_class).to receive(:govuk_root_dir).and_return("/home/test/govuk")
+          expect(subject).to eq("/home/test/govuk/govuk-docker")
+        end
+      end
+    end
+
+    context "when GOVUK_DOCKER_DIR is set" do
+      it "uses the environment variable" do
+        ClimateControl.modify GOVUK_DOCKER_DIR: "/govuk/govuk-docker" do
+          expect(subject).to eq("/govuk/govuk-docker")
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'climate_control'
 require 'pry'
 require 'thor'
 


### PR DESCRIPTION
More and more commands are starting to need to know where govuk-docker is so I thought it would be useful to pull that out into a class. By doing this we can be consistent with the use of environment variables and make sure they match the ones used by the Makefile.

See #111 for more details on the environment variables.