### PR TITLE
Add manuals-frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The following apps are supported by govuk-docker to some extent.
    - ✅ govuk_app_config
    - ✅ govuk_publishing_components
    - ✅ info-frontend
+   - ✅ manuals-frontend
    - ✅ miller-columns-element
    - ✅ plek
    - ✅ publisher

--- a/services/manuals-frontend/Dockerfile
+++ b/services/manuals-frontend/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:2.6.3
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y vim
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>&1 && \
+    apt install -y ./google-chrome*.deb && \
+    rm ./google-chrome*.deb
+
+RUN export VERSION=2.1.1 && \
+    wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$VERSION-linux-x86_64.tar.bz2 2>&1 && \
+    tar -vxf phantomjs-$VERSION-linux-x86_64.tar.bz2 && \
+    cp -v phantomjs-$VERSION-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs && \
+    rm -vr phantomjs-$VERSION-linux-x86_64
+
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN apt-get update -qq && apt-get install -y nodejs
+
+RUN useradd -m build
+USER build
+
+ENV EDITOR=vim

--- a/services/manuals-frontend/Makefile
+++ b/services/manuals-frontend/Makefile
@@ -1,0 +1,3 @@
+manuals-frontend: $(GOVUK_ROOT_DIR)/$@ content-store router static govuk-content-schemas
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/manuals-frontend/docker-compose.yml
+++ b/services/manuals-frontend/docker-compose.yml
@@ -1,0 +1,59 @@
+version: '3.7'
+
+x-manuals-frontend: &manuals-frontend
+  build:
+    context: .
+    dockerfile: services/manuals-frontend/Dockerfile
+  image: manuals-frontend
+  volumes:
+    - $GOVUK_ROOT_DIR:/govuk:delegated
+    - bundle:/usr/local/bundle
+  working_dir: /govuk/manuals-frontend
+
+services:
+  manuals-frontend-lite:
+    <<: *manuals-frontend
+    privileged: true
+
+  manuals-frontend-app: &manuals-frontend-app
+    <<: *manuals-frontend
+    depends_on:
+      - router-app
+      - content-store-app
+      - static-app
+    environment:
+      GOVUK_ASSET_ROOT: manuals-frontend.dev.gov.uk
+      VIRTUAL_HOST: manuals-frontend.dev.gov.uk
+      HOST: 0.0.0.0
+    ports:
+      - "3000"
+    command: bin/rails s -P /tmp/rails.pid
+
+  manuals-frontend-app-draft:
+    <<: *manuals-frontend
+    depends_on:
+      - router-app-draft
+      - content-store-app-draft
+      - static-app-draft
+    environment:
+      GOVUK_ASSET_ROOT: draft-manuals-frontend.dev.gov.uk
+      VIRTUAL_HOST: draft-manuals-frontend.dev.gov.uk
+      PLEK_HOSTNAME_PREFIX: "draft-"
+      HOST: 0.0.0.0
+    ports:
+      - "3000"
+    command: bin/rails s -P /tmp/rails.pid
+
+  manuals-frontend-app-live:
+    <<: *manuals-frontend
+    depends_on:
+      - nginx-proxy-app
+    environment:
+      GOVUK_WEBSITE_ROOT: https://www.gov.uk
+      PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
+      PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
+      VIRTUAL_HOST: manuals-frontend.dev.gov.uk
+      HOST: 0.0.0.0
+    ports:
+      - "3000"
+    command: bin/rails s -P /tmp/rails.pid

--- a/services/nginx-proxy/docker-compose.yml
+++ b/services/nginx-proxy/docker-compose.yml
@@ -20,6 +20,7 @@ services:
           - content-tagger.dev.gov.uk
           - draft-content-store.dev.gov.uk
           - draft-government-frontend.dev.gov.uk
+          - draft-manuals-frontend.dev.gov.uk
           - draft-origin.dev.gov.uk
           - draft-router-api.dev.gov.uk
           - draft-router.dev.gov.uk
@@ -28,6 +29,7 @@ services:
           - govuk_publishing_components.dev.gov.uk
           - govuk-developer-docs.dev.gov.uk
           - link-checker-api.dev.gov.uk
+          - manuals-frontend.dev.gov.uk
           - publisher.dev.gov.uk
           - publishing-api.dev.gov.uk
           - router-api.dev.gov.uk


### PR DESCRIPTION
Everything works, however we need content in the content store for the app stack to work nicely.  Because of this, I've included a live-app stack.

![Screenshot 2019-07-05 13 52 55](https://user-images.githubusercontent.com/773037/60723736-63028e00-9f2c-11e9-886f-b094e218b827.png)
