### PR TITLE
Add check to see if repo is up-to-date with origin

### DIFF
--- a/lib/doctor/doctor.rb
+++ b/lib/doctor/doctor.rb
@@ -1,9 +1,20 @@
 module Doctor
   def self.messages
     {
+      govuk_docker: govuk_docker_messages,
       dnsmasq: dnsmasq_messages,
       docker: docker_messages,
       docker_compose: docker_compose_messages
+    }
+  end
+
+  def self.govuk_docker_messages
+    {
+      up_to_date: "✅ govuk-docker is up-to-date",
+      outdated: <<~HEREDOC,
+        ❌ govuk-docker is outdated.
+        You should pull the latest version from https://github.com/alphagov/govuk-docker/.
+      HEREDOC
     }
   end
 

--- a/lib/govuk_docker_cli.rb
+++ b/lib/govuk_docker_cli.rb
@@ -56,7 +56,13 @@ class GovukDockerCLI < Thor
 
   desc "doctor", "Various tests to help diagnose issues when running `govuk-docker`"
   def doctor
-    puts "Checking dnsmasq"
+    puts "Cheching govuk-docker"
+    puts Doctor::Checkup.new(
+      service_name: "govuk-docker",
+      checkups: %i(up_to_date),
+      messages: Doctor.messages[:govuk_docker]
+    ).call
+    puts "\r\nChecking dnsmasq"
     puts Doctor::Checkup.new(
       service_name: "dnsmasq",
       checkups: %i(installed running dnsmasq_resolver running_as_different_user),


### PR DESCRIPTION
This is implemented by checking the `git diff` between the local master
branch and the remote master branch.