### PR TITLE
Use GOVUK_ROOT_DIR in docker-compose files

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+GOVUK_ROOT_DIR=~/govuk

--- a/services/asset-manager/docker-compose.yml
+++ b/services/asset-manager/docker-compose.yml
@@ -6,7 +6,7 @@ x-asset-manager: &asset-manager
     dockerfile: services/asset-manager/Dockerfile
   image: asset-manager
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/asset-manager

--- a/services/calculators/docker-compose.yml
+++ b/services/calculators/docker-compose.yml
@@ -6,7 +6,7 @@ x-calculators: &calculators
     dockerfile: services/calculators/Dockerfile
   image: calculators
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/calculators
@@ -17,7 +17,7 @@ services:
     # Tests need the privileged flag
     privileged: true
     volumes:
-      - ..:/govuk:delegated
+      - $GOVUK_ROOT_DIR:/govuk:delegated
       - bundle:/usr/local/bundle
 
   calculators-app: &calculators-app

--- a/services/calendars/docker-compose.yml
+++ b/services/calendars/docker-compose.yml
@@ -6,7 +6,7 @@ x-calendars: &calendars
     dockerfile: services/calendars/Dockerfile
   image: calendars
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
   working_dir: /govuk/calendars
 
@@ -14,7 +14,7 @@ services:
   calendars-lite:
     <<: *calendars
     volumes:
-      - ..:/govuk:delegated
+      - $GOVUK_ROOT_DIR:/govuk:delegated
       - bundle:/usr/local/bundle
 
   calendars-app: &calendars-app

--- a/services/collections-publisher/docker-compose.yml
+++ b/services/collections-publisher/docker-compose.yml
@@ -6,7 +6,7 @@ x-collections-publisher: &collections-publisher
     dockerfile: services/collections-publisher/Dockerfile
   image: collections-publisher
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/collections-publisher

--- a/services/collections/docker-compose.yml
+++ b/services/collections/docker-compose.yml
@@ -6,7 +6,7 @@ x-collections: &collections
     dockerfile: services/collections/Dockerfile
   image: collections
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
   working_dir: /govuk/collections
 
@@ -14,7 +14,7 @@ services:
   collections-lite:
     <<: *collections
     volumes:
-      - ..:/govuk:delegated
+      - $GOVUK_ROOT_DIR:/govuk:delegated
       - bundle:/usr/local/bundle
 
   # TODO: doesn't work yet because collections also relies on search-api

--- a/services/content-data-admin/docker-compose.yml
+++ b/services/content-data-admin/docker-compose.yml
@@ -6,7 +6,7 @@ x-content-data-admin: &content-data-admin
     dockerfile: services/content-data-admin/Dockerfile
   image: content-data-admin
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/content-data-admin

--- a/services/content-publisher/docker-compose.yml
+++ b/services/content-publisher/docker-compose.yml
@@ -6,7 +6,7 @@ x-content-publisher: &content-publisher
     dockerfile: services/content-publisher/Dockerfile
   image: content-publisher
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/content-publisher

--- a/services/content-store/docker-compose.yml
+++ b/services/content-store/docker-compose.yml
@@ -6,7 +6,7 @@ x-content-store: &content-store
     dockerfile: services/content-store/Dockerfile
   image: content-store
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/content-store

--- a/services/content-tagger/docker-compose.yml
+++ b/services/content-tagger/docker-compose.yml
@@ -6,7 +6,7 @@ x-content-tagger: &content-tagger
     dockerfile: services/content-tagger/Dockerfile
   image: content-tagger
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/content-tagger

--- a/services/email-alert-api/docker-compose.yml
+++ b/services/email-alert-api/docker-compose.yml
@@ -6,7 +6,7 @@ x-email-alert-api: &email-alert-api
     dockerfile: services/email-alert-api/Dockerfile
   image: email-alert-api
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
   working_dir: /govuk/email-alert-api
 

--- a/services/government-frontend/docker-compose.yml
+++ b/services/government-frontend/docker-compose.yml
@@ -6,7 +6,7 @@ x-government-frontend: &government-frontend
     dockerfile: services/government-frontend/Dockerfile
   image: government-frontend
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
   working_dir: /govuk/government-frontend
 
@@ -15,7 +15,7 @@ services:
     <<: *government-frontend
     privileged: true
     volumes:
-      - ..:/govuk:delegated
+      - $GOVUK_ROOT_DIR:/govuk:delegated
       - bundle:/usr/local/bundle
 
   government-frontend-app: &government-frontend-app

--- a/services/govspeak/docker-compose.yml
+++ b/services/govspeak/docker-compose.yml
@@ -6,7 +6,7 @@ x-govuk_publisher_components: &govspeak
     dockerfile: services/govspeak/Dockerfile
   image: govspeak
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/govspeak

--- a/services/govuk-content-schemas/docker-compose.yml
+++ b/services/govuk-content-schemas/docker-compose.yml
@@ -6,7 +6,7 @@ x-govuk-content-schemas: &govuk-content-schemas
     dockerfile: services/govuk-content-schemas/Dockerfile
   image: govuk-content-schemas
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/govuk-content-schemas

--- a/services/govuk-developer-docs/docker-compose.yml
+++ b/services/govuk-developer-docs/docker-compose.yml
@@ -6,7 +6,7 @@ x-govuk-developer-docs: &govuk-developer-docs
     dockerfile: services/govuk-developer-docs/Dockerfile
   image: govuk-developer-docs
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/govuk-developer-docs

--- a/services/govuk-lint/docker-compose.yml
+++ b/services/govuk-lint/docker-compose.yml
@@ -6,7 +6,7 @@ x-govuk-lint: &govuk-lint
     dockerfile: services/govuk-lint/Dockerfile
   image: govuk-lint
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/govuk-lint

--- a/services/govuk_app_config/docker-compose.yml
+++ b/services/govuk_app_config/docker-compose.yml
@@ -6,7 +6,7 @@ x-govuk_app_config: &govuk_app_config
     dockerfile: services/govuk_app_config/Dockerfile
   image: govuk_app_config
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/govuk_app_config

--- a/services/govuk_publishing_components/docker-compose.yml
+++ b/services/govuk_publishing_components/docker-compose.yml
@@ -6,7 +6,7 @@ x-govuk_publishing_components: &govuk_publishing_components
     dockerfile: services/govuk_publishing_components/Dockerfile
   image: govuk_publishing_components
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/govuk_publishing_components

--- a/services/info-frontend/docker-compose.yml
+++ b/services/info-frontend/docker-compose.yml
@@ -6,7 +6,7 @@ x-tmp: &info-frontend-base
     dockerfile: services/info-frontend/Dockerfile
   image: info-frontend
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
   working_dir: /govuk/info-frontend
 
@@ -14,7 +14,7 @@ services:
   info-frontend-lite:
     <<: *info-frontend-base
     volumes:
-      - ..:/govuk:delegated
+      - $GOVUK_ROOT_DIR:/govuk:delegated
       - bundle:/usr/local/bundle
 
   info-frontend-app:

--- a/services/link-checker-api/docker-compose.yml
+++ b/services/link-checker-api/docker-compose.yml
@@ -6,7 +6,7 @@ x-link-checker-api: &link-checker-api
     dockerfile: services/link-checker-api/Dockerfile
   image: link-checker-api
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/link-checker-api

--- a/services/miller-columns-element/docker-compose.yml
+++ b/services/miller-columns-element/docker-compose.yml
@@ -6,7 +6,7 @@ x-miller-columns-element: &miller-columns-element
     dockerfile: services/miller-columns-element/Dockerfile
   image: miller-columns-element
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
   working_dir: /govuk/miller-columns-element
 
 services:

--- a/services/plek/docker-compose.yml
+++ b/services/plek/docker-compose.yml
@@ -6,7 +6,7 @@ x-plek: &plek
     dockerfile: services/plek/Dockerfile
   image: plek
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/plek

--- a/services/publisher/docker-compose.yml
+++ b/services/publisher/docker-compose.yml
@@ -6,7 +6,7 @@ x-publisher: &publisher
     dockerfile: services/publisher/Dockerfile
   image: publisher
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/publisher

--- a/services/publishing-api/docker-compose.yml
+++ b/services/publishing-api/docker-compose.yml
@@ -6,7 +6,7 @@ x-publishing-api: &publishing-api
     dockerfile: services/publishing-api/Dockerfile
   image: publishing-api
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/publishing-api

--- a/services/router-api/docker-compose.yml
+++ b/services/router-api/docker-compose.yml
@@ -6,7 +6,7 @@ x-router-api: &router-api
     dockerfile: services/router-api/Dockerfile
   image: router-api
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/router-api

--- a/services/search-api/docker-compose.yml
+++ b/services/search-api/docker-compose.yml
@@ -6,7 +6,7 @@ x-search-api: &search-api
     dockerfile: services/search-api/Dockerfile
   image: search-api
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/search-api

--- a/services/service-manual-frontend/docker-compose.yml
+++ b/services/service-manual-frontend/docker-compose.yml
@@ -6,7 +6,7 @@ x-service-manual-frontend: &service-manual-frontend-base
     dockerfile: services/service-manual-frontend/Dockerfile
   image: service-manual-frontend
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
   working_dir: /govuk/service-manual-frontend
 
@@ -14,7 +14,7 @@ services:
   service-manual-frontend-lite:
     <<: *service-manual-frontend-base
     volumes:
-      - ..:/govuk:delegated
+      - $GOVUK_ROOT_DIR:/govuk:delegated
       - bundle:/usr/local/bundle
 
   service-manual-frontend-app: &service-manual-frontend-app

--- a/services/signon/docker-compose.yml
+++ b/services/signon/docker-compose.yml
@@ -6,7 +6,7 @@ x-signon: &signon
     dockerfile: services/signon/Dockerfile
   image: signon
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/signon

--- a/services/smart-answers/docker-compose.yml
+++ b/services/smart-answers/docker-compose.yml
@@ -6,7 +6,7 @@ x-smart-answers: &smart-answers
     dockerfile: services/smart-answers/Dockerfile
   image: smart-answers
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/smart-answers

--- a/services/specialist-publisher/docker-compose.yml
+++ b/services/specialist-publisher/docker-compose.yml
@@ -6,7 +6,7 @@ x-specialist-publisher: &specialist-publisher
     dockerfile: services/specialist-publisher/Dockerfile
   image: specialist-publisher
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/specialist-publisher

--- a/services/static/docker-compose.yml
+++ b/services/static/docker-compose.yml
@@ -6,7 +6,7 @@ x-static: &static
     dockerfile: services/static/Dockerfile
   image: static
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
   working_dir: /govuk/static
 

--- a/services/support-api/docker-compose.yml
+++ b/services/support-api/docker-compose.yml
@@ -6,7 +6,7 @@ x-support-api: &support-api
     dockerfile: services/support-api/Dockerfile
   image: support-api
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/support-api

--- a/services/support/docker-compose.yml
+++ b/services/support/docker-compose.yml
@@ -6,7 +6,7 @@ x-support: &support
     dockerfile: services/support/Dockerfile
   image: support
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/support

--- a/services/travel-advice-publisher/docker-compose.yml
+++ b/services/travel-advice-publisher/docker-compose.yml
@@ -6,7 +6,7 @@ x-travel-advice-publisher: &travel-advice-publisher
     dockerfile: services/travel-advice-publisher/Dockerfile
   image: travel-advice-publisher
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/travel-advice-publisher

--- a/services/whitehall/docker-compose.yml
+++ b/services/whitehall/docker-compose.yml
@@ -6,7 +6,7 @@ x-whitehall: &whitehall
     dockerfile: services/whitehall/Dockerfile
   image: whitehall
   volumes:
-    - ..:/govuk:delegated
+    - $GOVUK_ROOT_DIR:/govuk:delegated
     - bundle:/usr/local/bundle
     - home:/home/build
   working_dir: /govuk/whitehall


### PR DESCRIPTION
This lets govuk-docker be cloned to a different place than the apps.

    $ ls /tmp/govuk

    $ GOVUK_ROOT_DIR=/tmp/govuk govuk-docker run --service calendars bash
    docker-compose -f [...] run --rm --service-ports calendars-lite env bash
    build@151add87c579:/govuk/calendars$ ls
    build@151add87c579:/govuk/calendars$ ls /govuk
    calendars
    build@151add87c579:/govuk/calendars$ exit

    $ ls /tmp/govuk
    calendars

    $ govuk-docker run --service calendars bash
    docker-compose -f [...] run --rm --service-ports calendars-lite env bash

    build@8ac5a1c45885:/govuk/calendars$ ls
    Dockerfile  Gemfile  Gemfile.lock  Jenkinsfile  LICENCE.txt Procfile
    README.md  Rakefile  app  app.json  bin  config  config.ru coverage
    docs  lib  log  manifest.yml  public  startup.sh startup_heroku.sh
    test  tmp  vendor