### PR TITLE
Remove dubious 'clean' task in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,14 @@ GOVUK_DOCKER     ?= $(GOVUK_DOCKER_DIR)/bin/govuk-docker
 APPS ?= $(shell ls ${GOVUK_DOCKER_DIR}/services/*/Makefile | xargs -L 1 dirname | xargs -L 1 basename)
 
 # This is a Makefile best practice to say that these are not file
-# names.  For example, if you were to create a file called "clean",
-# then `make clean` should still invoke the rule, it shouldn't do
+# names.  For example, if you were to create a file called "clone",
+# then `make clone` should still invoke the rule, it shouldn't do
 # this:
 #
-#     $ touch clean
-#     $ make clean
-#     make: `clean' is up to date.
-.PHONY: clone pull clean test all-apps
+#     $ touch clone
+#     $ make clone
+#     make: `clone' is up to date.
+.PHONY: clone pull test all-apps
 
 default:
 	@echo "Run 'make APP-NAME' to set up an app and its dependencies."
@@ -24,10 +24,6 @@ clone: $(addprefix $(GOVUK_ROOT_DIR)/,$(APPS))
 
 pull:
 	echo $(APPS) | cut -d/ -f3 | xargs -P8 -n1 ./bin/update-git-repo.sh
-
-clean:
-	bin/govuk-docker compose stop
-	bin/govuk-docker prune
 
 test:
 	# Linting
@@ -42,7 +38,7 @@ test:
 
 # This will be slow and may repeat work, so generally you don't want
 # to run this.
-all-apps: $(APPS) clean
+all-apps: $(APPS)
 
 # Clone an app, for example:
 #


### PR DESCRIPTION
https://trello.com/c/2XWgdfo7/5-%F0%9F%92%A5-make-setup-super-fast-and-easy

This removes the 'clean' rule from the Makefile, which was only used in
the infrequent 'all-apps' rule and is an artefact from when making all
apps was the primary setup method. It's not clear in general that we
want to destroy all containers as part of any setup step.