### PR TITLE
Fix makefile dependencies and bundler versioning

### DIFF
--- a/services/asset-manager/Makefile
+++ b/services/asset-manager/Makefile
@@ -1,6 +1,7 @@
-asset-manager: $(GOVUK_ROOT_DIR)/$@
+asset-manager: $(GOVUK_ROOT_DIR)/asset-manager
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
 	$(GOVUK_DOCKER) compose run $@-lite bin/rails runner 'User.first || User.create'

--- a/services/calculators/Makefile
+++ b/services/calculators/Makefile
@@ -1,4 +1,5 @@
-calculators: $(GOVUK_ROOT_DIR)/$@
+calculators: $(GOVUK_ROOT_DIR)/calculators
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/calendars/Makefile
+++ b/services/calendars/Makefile
@@ -1,5 +1,6 @@
-calendars: $(GOVUK_ROOT_DIR)/$@
+calendars: $(GOVUK_ROOT_DIR)/calendars publishing-api
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-setup bin/rake publishing_api:publish

--- a/services/collections-publisher/Makefile
+++ b/services/collections-publisher/Makefile
@@ -1,5 +1,6 @@
-collections-publisher: $(GOVUK_ROOT_DIR)/$@ publishing-api content-store link-checker-api
+collections-publisher: $(GOVUK_ROOT_DIR)/collections-publisher publishing-api content-store link-checker-api
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/services/collections/Makefile
+++ b/services/collections/Makefile
@@ -1,4 +1,5 @@
-collections: $(GOVUK_ROOT_DIR)/$@
+collections: $(GOVUK_ROOT_DIR)/collections
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/content-data-admin/Makefile
+++ b/services/content-data-admin/Makefile
@@ -1,5 +1,6 @@
-content-data-admin: $(GOVUK_ROOT_DIR)/$@
+content-data-admin: $(GOVUK_ROOT_DIR)/content-data-admin
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/content-publisher/Makefile
+++ b/services/content-publisher/Makefile
@@ -1,6 +1,7 @@
-content-publisher: $(GOVUK_ROOT_DIR)/$@ asset-manager publishing-api
+content-publisher: $(GOVUK_ROOT_DIR)/content-publisher asset-manager publishing-api
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
 	$(GOVUK_DOCKER) compose run $@-lite yarn

--- a/services/content-store/Makefile
+++ b/services/content-store/Makefile
@@ -1,6 +1,7 @@
-content-store: $(GOVUK_ROOT_DIR)/$@ router-api govuk-content-schemas
+content-store: $(GOVUK_ROOT_DIR)/content-store router-api govuk-content-schemas
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-lite bin/rake db:create
 	$(GOVUK_DOCKER) compose run $@-lite bin/rails runner 'User.first || User.create'

--- a/services/content-tagger/Makefile
+++ b/services/content-tagger/Makefile
@@ -1,5 +1,6 @@
-content-tagger: $(GOVUK_ROOT_DIR)/$@ publishing-api
+content-tagger: $(GOVUK_ROOT_DIR)/content-tagger publishing-api
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/email-alert-api/Makefile
+++ b/services/email-alert-api/Makefile
@@ -1,5 +1,6 @@
-email-alert-api: $(GOVUK_ROOT_DIR)/$@
+email-alert-api: $(GOVUK_ROOT_DIR)/email-alert-api
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/government-frontend/Makefile
+++ b/services/government-frontend/Makefile
@@ -1,4 +1,5 @@
-government-frontend: $(GOVUK_ROOT_DIR)/$@ content-store router static govuk-content-schemas
+government-frontend: $(GOVUK_ROOT_DIR)/government-frontend content-store router static govuk-content-schemas
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/govspeak/Makefile
+++ b/services/govspeak/Makefile
@@ -1,4 +1,5 @@
-govspeak: $(GOVUK_ROOT_DIR)/$@
+govspeak: $(GOVUK_ROOT_DIR)/govspeak
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/govuk-content-schemas/Makefile
+++ b/services/govuk-content-schemas/Makefile
@@ -1,4 +1,5 @@
-govuk-content-schemas: $(GOVUK_ROOT_DIR)/$@
+govuk-content-schemas: $(GOVUK_ROOT_DIR)/govuk-content-schemas
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/govuk-developer-docs/Makefile
+++ b/services/govuk-developer-docs/Makefile
@@ -1,4 +1,5 @@
-govuk-developer-docs: $(GOVUK_ROOT_DIR)/$@
+govuk-developer-docs: $(GOVUK_ROOT_DIR)/govuk-developer-docs
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/govuk-lint/Makefile
+++ b/services/govuk-lint/Makefile
@@ -1,4 +1,5 @@
-govuk-lint: $(GOVUK_ROOT_DIR)/$@
+govuk-lint: $(GOVUK_ROOT_DIR)/govuk-lint
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>2.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/govuk_app_config/Makefile
+++ b/services/govuk_app_config/Makefile
@@ -1,4 +1,5 @@
-govuk_app_config: $(GOVUK_ROOT_DIR)/$@
+govuk_app_config: $(GOVUK_ROOT_DIR)/govuk_app_config
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/govuk_publishing_components/Makefile
+++ b/services/govuk_publishing_components/Makefile
@@ -1,4 +1,5 @@
-govuk_publishing_components: $(GOVUK_ROOT_DIR)/$@
+govuk_publishing_components: $(GOVUK_ROOT_DIR)/govuk_publishing_components
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/info-frontend/Makefile
+++ b/services/info-frontend/Makefile
@@ -1,4 +1,5 @@
-info-frontend: $(GOVUK_ROOT_DIR)/$@
+info-frontend: $(GOVUK_ROOT_DIR)/info-frontend
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/link-checker-api/Makefile
+++ b/services/link-checker-api/Makefile
@@ -1,5 +1,6 @@
-link-checker-api: $(GOVUK_ROOT_DIR)/$@
+link-checker-api: $(GOVUK_ROOT_DIR)/link-checker-api
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/manuals-frontend/Makefile
+++ b/services/manuals-frontend/Makefile
@@ -1,3 +1,5 @@
-manuals-frontend: $(GOVUK_ROOT_DIR)/$@ content-store router static govuk-content-schemas
+manuals-frontend: $(GOVUK_ROOT_DIR)/manuals-frontend content-store router static govuk-content-schemas
 	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/miller-columns-element/Makefile
+++ b/services/miller-columns-element/Makefile
@@ -1,4 +1,5 @@
-miller-columns-element: $(GOVUK_ROOT_DIR)/$@
+miller-columns-element: $(GOVUK_ROOT_DIR)/miller-columns-element
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite npm install

--- a/services/plek/Makefile
+++ b/services/plek/Makefile
@@ -1,4 +1,5 @@
-plek: $(GOVUK_ROOT_DIR)/$@
+plek: $(GOVUK_ROOT_DIR)/plek
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/publisher/Makefile
+++ b/services/publisher/Makefile
@@ -1,3 +1,6 @@
 publisher: $(GOVUK_ROOT_DIR)/publisher publishing-api calendars link-checker-api
-	$(COMPOSE_RUN) publisher-lite bundle
-	$(COMPOSE_RUN) publisher-lite sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
+	$(GOVUK_DOCKER) compose run $@-lite bundle
+	$(GOVUK_DOCKER) compose run $@-lite sh -c 'rake db:migrate 2>/dev/null || rake db:setup'

--- a/services/publishing-api/Makefile
+++ b/services/publishing-api/Makefile
@@ -1,6 +1,7 @@
-publishing-api: $(GOVUK_ROOT_DIR)/$@ content-store govuk-content-schemas
+publishing-api: $(GOVUK_ROOT_DIR)/publishing-api content-store govuk-content-schemas
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
 	$(GOVUK_DOCKER) compose run $@-lite bin/rails runner 'User.first || User.create'

--- a/services/router-api/Makefile
+++ b/services/router-api/Makefile
@@ -1,4 +1,5 @@
-router-api: $(GOVUK_ROOT_DIR)/$@ router
+router-api: $(GOVUK_ROOT_DIR)/router-api router
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/search-api/Makefile
+++ b/services/search-api/Makefile
@@ -1,6 +1,8 @@
-search-api: $(GOVUK_ROOT_DIR)/$@ publishing-api
+search-api: $(GOVUK_ROOT_DIR)/search-api publishing-api
+	$(GOVUK_DOCKER) compose build $@-lite
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
 	$(GOVUK_DOCKER) compose run $@-lite env SEARCH_INDEX=all bundle exec rake search:create_all_indices
 	$(GOVUK_DOCKER) compose run $@-lite bundle exec rake message_queue:create_queues
 

--- a/services/service-manual-frontend/Makefile
+++ b/services/service-manual-frontend/Makefile
@@ -1,4 +1,5 @@
-service-manual-frontend: $(GOVUK_ROOT_DIR)/$@
+service-manual-frontend: $(GOVUK_ROOT_DIR)/service-manual-frontend
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/signon/Makefile
+++ b/services/signon/Makefile
@@ -1,5 +1,6 @@
-signon: $(GOVUK_ROOT_DIR)/$@
+signon: $(GOVUK_ROOT_DIR)/signon
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/smart-answers/Makefile
+++ b/services/smart-answers/Makefile
@@ -1,4 +1,5 @@
-smart-answers: $(GOVUK_ROOT_DIR)/$@ asset-manager publishing-api static
+smart-answers: $(GOVUK_ROOT_DIR)/smart-answers asset-manager publishing-api static
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/specialist-publisher/Makefile
+++ b/services/specialist-publisher/Makefile
@@ -1,5 +1,6 @@
-specialist-publisher: $(GOVUK_ROOT_DIR)/$@ asset-manager publishing-api
+specialist-publisher: $(GOVUK_ROOT_DIR)/specialist-publisher asset-manager publishing-api
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/static/Makefile
+++ b/services/static/Makefile
@@ -1,4 +1,5 @@
-static: $(GOVUK_ROOT_DIR)/$@
+static: $(GOVUK_ROOT_DIR)/static
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/support-api/Makefile
+++ b/services/support-api/Makefile
@@ -1,4 +1,5 @@
-support-api: $(GOVUK_ROOT_DIR)/$@
+support-api: $(GOVUK_ROOT_DIR)/support-api
 	$(GOVUK_DOCKER) compose run $@-lite bundle
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/support/Makefile
+++ b/services/support/Makefile
@@ -1,4 +1,5 @@
-support: $(GOVUK_ROOT_DIR)/$@ support-api
+support: $(GOVUK_ROOT_DIR)/support support-api
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle

--- a/services/travel-advice-publisher/Makefile
+++ b/services/travel-advice-publisher/Makefile
@@ -1,5 +1,6 @@
-travel-advice-publisher: $(GOVUK_ROOT_DIR)/$@ asset-manager content-store publishing-api
+travel-advice-publisher: $(GOVUK_ROOT_DIR)/travel-advice-publisher asset-manager content-store publishing-api
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/whitehall/Makefile
+++ b/services/whitehall/Makefile
@@ -1,6 +1,7 @@
-whitehall: $(GOVUK_ROOT_DIR)/$@ asset-manager publishing-api static
+whitehall: $(GOVUK_ROOT_DIR)/whitehall asset-manager publishing-api static
 	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s && gem install --conservative bundler
+	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
+	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
 	$(GOVUK_DOCKER) compose run $@-lite bundle
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
 	$(GOVUK_DOCKER) compose run $@-lite bin/rake shared_mustache:compile


### PR DESCRIPTION
https://trello.com/c/2XWgdfo7/5-%F0%9F%92%A5-make-setup-super-fast-and-easy

Previously we installed bundler without a version restriction, which
caused problems since Bundler 2.0 is not compatible with most of our
repos. We may also need to cope with installing specific versions of
bundler for certain services. This splits the installation step for
bundler and ensures the major version is consistent with each service.

Previously we used '$@' in the target list for each service, which is
not valid (it can only be used within the recipe). This reverts the use
of '$@' back to the service name in each service Makefile.