### PR TITLE
Revert prune to use 'system' directly

### DIFF
--- a/lib/govuk_docker/commands/base.rb
+++ b/lib/govuk_docker/commands/base.rb
@@ -12,8 +12,8 @@ module GovukDocker::Commands
       @verbose = options[:verbose] || default_verbose
     end
 
-    def system_command(*args)
-      system(*args) || raise("Non-zero exit code")
+    def system_command(*args, raise_on_error: true)
+      system(*args) || raise_on_error && raise("Non-zero exit code")
     end
 
     def service_exists?

--- a/lib/govuk_docker/commands/prune.rb
+++ b/lib/govuk_docker/commands/prune.rb
@@ -2,7 +2,7 @@ require_relative './base'
 
 class GovukDocker::Commands::Prune < GovukDocker::Commands::Base
   def call
-    commands.each { |command| system_command command }
+    commands.each { |command| system_command(command, raise_on_error: false) }
   end
 
 private

--- a/spec/commands/base_spec.rb
+++ b/spec/commands/base_spec.rb
@@ -14,5 +14,10 @@ describe GovukDocker::Commands::Base do
       allow(subject).to receive(:system)
       expect { subject.system_command }.to raise_error("Non-zero exit code")
     end
+
+    it "does not raise if told not to" do
+      allow(subject).to receive(:system)
+      expect { subject.system_command(raise_on_error: false) }.to_not raise_error
+    end
   end
 end


### PR DESCRIPTION
https://trello.com/c/akpi3nt3/2-%F0%9F%92%AA-optimise-day-to-day-development

This fixes an issue where we expect the return codes of the prune
commands to be non-zero.