### PR TITLE
Ignore `docker volume rm $(...)` failing

### DIFF
--- a/lib/govuk_docker/commands/prune.rb
+++ b/lib/govuk_docker/commands/prune.rb
@@ -10,7 +10,7 @@ private
   def commands
     [
       "docker container prune -f",
-      "docker volume rm $(docker volume ls -q -f 'dangling=true' | grep -x '.\{64,\}') 2> /dev/null",
+      "docker volume rm $(docker volume ls -q -f 'dangling=true' | grep -x '.\{64,\}') 2> /dev/null || true",
       "docker image prune -f"
     ]
   end

--- a/spec/commands/prune_spec.rb
+++ b/spec/commands/prune_spec.rb
@@ -15,7 +15,7 @@ describe GovukDocker::Commands::Prune do
   end
 
   it "removes temporary anonymous volumes" do
-    expect(subject).to receive(:system).with("docker volume rm $(docker volume ls -q -f 'dangling=true' | grep -x '.{64,}') 2> /dev/null")
+    expect(subject).to receive(:system).with("docker volume rm $(docker volume ls -q -f 'dangling=true' | grep -x '.{64,}') 2> /dev/null || true")
     subject.call
   end
 


### PR DESCRIPTION
This will fail if there are no dangling volumes.  That's not an error
condition, it's a reasonable thing to happen.