### PR TITLE
Fix `govuk-docker doctor` false positive

### DIFF
--- a/lib/govuk_docker/doctor/checkup.rb
+++ b/lib/govuk_docker/doctor/checkup.rb
@@ -24,7 +24,7 @@ module GovukDocker::Doctor
     end
 
     def up_to_date?
-      @up_to_date ||= !(system "git -C #{GovukDocker::Paths.govuk_docker_dir} diff master origin/master | cat 1>/dev/null")
+      @up_to_date ||= system "git -C #{GovukDocker::Paths.govuk_docker_dir} diff master origin/master --exit-code --quiet"
     end
 
     def installed?

--- a/spec/doctor/checkup_spec.rb
+++ b/spec/doctor/checkup_spec.rb
@@ -27,7 +27,10 @@ describe GovukDocker::Doctor::Checkup do
       )
 
       ClimateControl.modify GOVUK_DOCKER_DIR: "/some/directory" do
-        allow(subject).to receive(:system).with("git -C /some/directory diff master origin/master | cat 1>/dev/null").and_return(false)
+        allow(subject)
+          .to receive(:system)
+          .with("git -C /some/directory diff master origin/master --exit-code --quiet")
+          .and_return(true)
 
         expect(subject.call).to eq("fake_service is up-to-date")
       end
@@ -43,7 +46,10 @@ describe GovukDocker::Doctor::Checkup do
       )
 
       ClimateControl.modify GOVUK_DOCKER_DIR: "/some/directory" do
-        allow(subject).to receive(:system).with("git -C /some/directory diff master origin/master | cat 1>/dev/null").and_return(true)
+        allow(subject)
+          .to receive(:system)
+          .with("git -C /some/directory diff master origin/master --exit-code --quiet")
+          .and_return(false)
 
         expect(subject.call).to eq("fake_service is outdated")
       end


### PR DESCRIPTION
I initially thought that
`system "git diff master origin/master | cat 1>/dev/null"`
returned false if there were no differences and true if there were,
so I wrote the `up_to_date?` method accordingly. This is not true.
The tests passed because they were written under this assumption.

What we can use instead is the `--exit-code` flag that makes the program
exit with 0 if there are no differences and 1 if there are differences.

The `--quite` flag must be used instead of `| cat 1>/dev/null` to ensure
that the return code is the correct one and not the `cat`'s return code.

I know that `--quiet` implies `--exit-code` but I think that having both
is clearer and more explicit.