### PR TITLE
Don't show a stacktrace for command errors

### DIFF
--- a/lib/govuk_docker/commands/base.rb
+++ b/lib/govuk_docker/commands/base.rb
@@ -13,7 +13,7 @@ module GovukDocker::Commands
     end
 
     def system_command(*args, raise_on_error: true)
-      system(*args) || raise_on_error && raise("Non-zero exit code")
+      system(*args) || raise_on_error && raise(Thor::Error.new("Command failed with non-zero exit code"))
     end
 
     def service_exists?

--- a/spec/commands/base_spec.rb
+++ b/spec/commands/base_spec.rb
@@ -12,7 +12,7 @@ describe GovukDocker::Commands::Base do
 
     it "raises for non-zero exit codes" do
       allow(subject).to receive(:system)
-      expect { subject.system_command }.to raise_error("Non-zero exit code")
+      expect { subject.system_command }.to raise_error(Thor::Error)
     end
 
     it "does not raise if told not to" do


### PR DESCRIPTION
When a system command fails, it's not useful to see the stack trace since it's always the same. This removes the stack trace by using the built-in Thor error class, which only prints the error message.

## Before

<img width="1289" alt="Screen Shot 2019-07-09 at 14 45 32" src="https://user-images.githubusercontent.com/233676/60893135-4205aa00-a258-11e9-816d-d996db37e0cd.png">

## After

<img width="1289" alt="Screen Shot 2019-07-09 at 14 45 18" src="https://user-images.githubusercontent.com/233676/60893149-4a5de500-a258-11e9-81f7-5c157b49b9cb.png">
