### PR TITLE
Improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,42 @@ To guide development we [have documented the user needs](docs/NEEDS.md) and [ass
 
 ## Usage
 
+To run a GOV.UK application, `govuk-docker build` it first (you only need to do this once per application). We'll use collections-publisher as an example:
+
+```sh
+cd ~/govuk/collections-publisher
+govuk-docker build
+```
+
+Then you run it with `govuk-docker startup`:
+
+```sh
+# Start collections-publisher including dependencies. Visit it at collections-publisher.dev.gov.uk
+govuk-docker startup
+```
+
+govuk-docker knows which application we're running based on the name of the current directory, matching it with the [corresponding docker-compose.yml in govuk-docker/services](https://github.com/alphagov/govuk-docker/blob/master/services/content-tagger/docker-compose.yml)). Alternatively, you can build and run applications from any directory by specifying a `service` CLI parameter:
+
+```sh
+govuk-docker build --service collections-publisher
+govuk-docker startup --service collections-publisher
+```
+
+`govuk-docker startup` runs the application on the `app` [stack](#stacks) by default, but you can override the stack by passing an unnamed parameter which will be taken as the stack name, with an `app-` prefix. Example:
+
+```sh
+# Start content-publisher plus the "app-e2e" (end-to-end) stack
+govuk-docker startup --service content-publisher e2e
+```
+
+Another useful govuk-docker command is `run`:
+
 ```sh
 # Run a Rake task on Whitehall
-whitehall$ govuk-docker run bundle exec rake -T
-
-# Start content-tagger including dependencies. Visit it at content-tagger.dev.gov.uk
-content-tagger$ govuk-docker startup
-
-# Start content-publisher plus an "end-to-end" stack
-content-publisher$ govuk-docker startup e2e
+cd ~/govuk/whitehall && govuk-docker run bundle exec rake -T
 ```
+
+For a full list of govuk-docker commands, run `govuk-docker help`.
 
 ## Installation
 
@@ -206,6 +232,8 @@ make pull
 ```
 
 ### How to: set up Dnsmasq manually
+
+If the [installation instructions](#setup) above didn't work for you, you may need to do some things manually as outlined below.
 
 If you have been using the vagrant based dev vm, take a backup
 of  `/etc/resolver/dev.gov.uk`.

--- a/README.md
+++ b/README.md
@@ -219,19 +219,23 @@ Then create or update `/etc/resolver/dev.gov.uk`. If you've been using the vagra
 ```
 nameserver 127.0.0.1
 ```
+
 To check if the new config has been applied, you can run `scutil --dns` to check that `dev.gov.uk` appears in the list.
 
-Then append the following to the bottom of `/usr/local/etc/dnsmasq.conf`
+Then append the following to the bottom of `/usr/local/etc/dnsmasq.conf`:
+
 ```
 conf-dir=/usr/local/etc/dnsmasq.d,*.conf
 ```
 
-Then create or append to `/usr/local/etc/dnsmasq.d/development.conf`
+Then create or append to `/usr/local/etc/dnsmasq.d/development.conf`:
+
 ```
 address=/dev.gov.uk/127.0.0.1
 ```
 
 Once you've updated those files, restart dnsmasq:
+
 ```
 sudo brew services restart dnsmasq
 ```

--- a/README.md
+++ b/README.md
@@ -57,12 +57,14 @@ For a full list of govuk-docker commands, run `govuk-docker help`.
 
 ### Prerequisites
 
-First make sure the following are installed on your system:
+govuk-docker has the following dependencies:
 
-- [dnsmasq](http://www.thekelleys.org.uk/dnsmasq/doc.html) to make *$app-name.dev.gov.uk* work. You can install this using `brew install dnsmasq`.
-- [docker](https://hub.docker.com/) and [docker-compose](https://docs.docker.com/compose/install/)
-- [git](https://git-scm.com) if you're setting everything up from scratch
+- [brew](https://brew.sh/). (If you don't use a Mac, you'll need to dig into the `govuk-docker setup` command and manually install the things referenced).
+- [git](https://git-scm.com)
+- Ruby (whatever version is specified in [.ruby-version](https://github.com/alphagov/govuk-docker/blob/master/.ruby-version))
 - A directory `~/govuk` in your home directory
+
+All other dependencies will be installed for you automatically.
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -52,59 +52,22 @@ Now in the `~/govuk` directory, run the following commands.
 git clone git@github.com:alphagov/govuk-docker.git
 cd govuk-docker
 bundle install
-```
-
-You can now clone and setup the apps you need with `make APP-NAME`,
-for example:
-
-```
-make content-publisher government-frontend
-```
-
-The govuk-docker command can configure Dnsmasq for you:
-
-```
 govuk-docker setup
 ```
 
-If this doesn't work for whatever reason, follow the instructions below to
-install manually:
-
-If you have been using the vagrant based dev vm, take a backup
-of  `/etc/resolver/dev.gov.uk`.
+You can now clone and setup the apps you need:
 
 ```
-cp /etc/resolver/dev.gov.uk ~/dev.gov.uk
+govuk-docker build --service content-publisher
 ```
 
-Then create or update `/etc/resolver/dev.gov.uk`. If you've been using the vagrant based dev VM, you'll need to replace `/etc/resolver/dev.gov.uk`
+To test it out:
 
 ```
-nameserver 127.0.0.1
-```
-To check if the new config has been applied, you can run `scutil --dns` to check that `dev.gov.uk` appears in the list.
-
-Then append the following to the bottom of `/usr/local/etc/dnsmasq.conf`
-```
-conf-dir=/usr/local/etc/dnsmasq.d,*.conf
+govuk-docker startup --service content-publisher
 ```
 
-Then create or append to `/usr/local/etc/dnsmasq.d/development.conf`
-```
-address=/dev.gov.uk/127.0.0.1
-```
-
-Once you've updated those files, restart dnsmasq:
-```
-sudo brew services restart dnsmasq
-```
-
-To check whether dnsmasq name server at 127.0.0.1 can resolve subdomains of dev.gov.uk run `dig app.dev.gov.uk @127.0.0.1`. The response has to include the following answer section:
-
-```
-;; ANSWER SECTION:
-app.dev.gov.uk.		0	IN	A	127.0.0.1
-```
+If this doesn't work for whatever reason, follow the [instructions to set up Dnsmasq manually](#how-to-set-up-dnsmasq-manually).
 
 ### Environment variables
 
@@ -240,6 +203,44 @@ Sometimes it's useful to get all changes for all repos e.g. to support finding t
 
 ```
 make pull
+```
+
+### How to: set up Dnsmasq manually
+
+If you have been using the vagrant based dev vm, take a backup
+of  `/etc/resolver/dev.gov.uk`.
+
+```
+cp /etc/resolver/dev.gov.uk ~/dev.gov.uk
+```
+
+Then create or update `/etc/resolver/dev.gov.uk`. If you've been using the vagrant based dev VM, you'll need to replace `/etc/resolver/dev.gov.uk`
+
+```
+nameserver 127.0.0.1
+```
+To check if the new config has been applied, you can run `scutil --dns` to check that `dev.gov.uk` appears in the list.
+
+Then append the following to the bottom of `/usr/local/etc/dnsmasq.conf`
+```
+conf-dir=/usr/local/etc/dnsmasq.d,*.conf
+```
+
+Then create or append to `/usr/local/etc/dnsmasq.d/development.conf`
+```
+address=/dev.gov.uk/127.0.0.1
+```
+
+Once you've updated those files, restart dnsmasq:
+```
+sudo brew services restart dnsmasq
+```
+
+To check whether dnsmasq name server at 127.0.0.1 can resolve subdomains of dev.gov.uk run `dig app.dev.gov.uk @127.0.0.1`. The response has to include the following answer section:
+
+```
+;; ANSWER SECTION:
+app.dev.gov.uk.		0	IN	A	127.0.0.1
 ```
 
 ## Licence


### PR DESCRIPTION
1. Move manual Dnsmasq instructions into standalone section
In a best case scenario, devs shouldn't need to follow these instructions,
so let's move them out of the main Installation section and into the How
To section.

2. Clarify command parameters (especially `govuk-docker startup`)

3. Simplify setup instructions.
