### PR TITLE
Update Makefile

### DIFF
--- a/services/finder-frontend/Makefile
+++ b/services/finder-frontend/Makefile
@@ -1,6 +1,1 @@
-finder-frontend: $(GOVUK_ROOT_DIR)/finder-frontend content-store static govuk-content-schemas search-api router
-	$(GOVUK_DOCKER) compose build $@-lite
-	$(GOVUK_DOCKER) compose run $@-lite rbenv install -s
-	$(GOVUK_DOCKER) compose run $@-lite gem install --conservative bundler -v "~>1.0"
-	$(GOVUK_DOCKER) compose run $@-lite bundle
-	$(GOVUK_DOCKER) compose run $@-lite yarn
+finder-frontend: bundle-finder-frontend content-store static govuk-content-schemas search-api router


### PR DESCRIPTION
The finder-frontend service has the outdated version of the makefile. This PR amends that.

ref: https://github.com/alphagov/govuk-docker/pull/136

Tests pass but there is still an error when running `govuk-docker build --service finder-frontend` as logged here https://trello.com/c/a07iwFyw/94-starting-finder-frontend-weird-error-from-publishing-api