### PR TITLE
Support services installed in /usr/local/sbin

### DIFF
--- a/lib/govuk_docker/doctor/checkup.rb
+++ b/lib/govuk_docker/doctor/checkup.rb
@@ -28,7 +28,9 @@ module GovukDocker::Doctor
     end
 
     def installed?
-      @installed ||= system "which #{service_name} 1>/dev/null"
+      # some people don't have /usr/local/sbin in their PATH
+      @installed ||= system("which #{service_name} 1>/dev/null") \
+                       || File.exist?("/usr/local/sbin/#{service_name}")
     end
 
     def running?

--- a/spec/doctor/checkup_spec.rb
+++ b/spec/doctor/checkup_spec.rb
@@ -70,6 +70,25 @@ describe GovukDocker::Doctor::Checkup do
     end
   end
 
+  context "when a service is installed to /usr/local/sbin" do
+    subject do
+      described_class.new(
+        service_name: service_name,
+        checkups: %i(installed),
+        messages: messages
+      )
+    end
+
+    before do
+      expect(subject).to receive(:system).with("which fake_service 1>/dev/null").and_return(false)
+      expect(File).to receive(:exist?).with("/usr/local/sbin/fake_service").and_return(true)
+    end
+
+    it "should report that it is installed" do
+      expect(subject.call).to eq("fake_service is installed")
+    end
+  end
+
   context "when a service is not installed" do
     it "should report that it needs to be installed" do
       subject = described_class.new(


### PR DESCRIPTION
Some services, such as dnsmasq, are installed into /usr/local/sbin which isn't always in a users `$PATH`. However, the service can still start in this case because it is configured and run as root. So we shouldn't report to the user that it isn't installed.

Closes #140.