### PR TITLE
Fix premature interpolation for build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ all-apps: $(APPS)
 bundle-%: clone-%
 	$(GOVUK_DOCKER) compose build $*-lite
 	$(GOVUK_DOCKER) compose run $*-lite rbenv install -s
-	$(GOVUK_DOCKER) compose run $*-lite gem install --conservative bundler -v $$(grep -A1 "BUNDLED WITH" Gemfile.lock | tail -1)
+	$(GOVUK_DOCKER) compose run $*-lite sh -c 'gem install --conservative bundler -v $$(grep -A1 "BUNDLED WITH" Gemfile.lock | tail -1)'
 	$(GOVUK_DOCKER) compose run $*-lite bundle
 
 clone-%:


### PR DESCRIPTION
Previously part of the 'gem install' command for the bundle-<app-name>
rule was executing on the host machine instead of the container. This
fixes the command to ensure its run in its entirety on the container.