### PR TITLE
Support 'GOVUK_ROOT_DIR' variable for router

### DIFF
--- a/services/router/docker-compose.yml
+++ b/services/router/docker-compose.yml
@@ -7,7 +7,7 @@ x-router: &router
   image: router
   volumes:
     - go:/go
-    - ../router:/go/src/github.com/alphagov/router:delegated
+    - ${GOVUK_ROOT_DIR:-~/govuk}/router:/go/src/github.com/alphagov/router:delegated
     - home:/home/build
   working_dir: /go/src/github.com/alphagov/router
 


### PR DESCRIPTION
Previously this was hard-coded to assume the CLI was being called from
the directory of the cloned router repo. This fixes the bind-mount to be
consistent with other projects, except that we don't mount the entire
'govuk' directory for this standalone GO project.