### PR TITLE
NPM install govuk_publishing_components

### DIFF
--- a/services/govuk_publishing_components/Makefile
+++ b/services/govuk_publishing_components/Makefile
@@ -1,1 +1,2 @@
 govuk_publishing_components: bundle-govuk_publishing_components
+	$(GOVUK_DOCKER) compose run $@-lite npm install


### PR DESCRIPTION
This is a build step required to use this application.