### PR TITLE
Use publishing-api-app-e2e in collections-publisher

### DIFF
--- a/services/collections-publisher/docker-compose.yml
+++ b/services/collections-publisher/docker-compose.yml
@@ -32,7 +32,6 @@ services:
       - link-checker-api-app
       - nginx-proxy-app
       - publishing-api-app
-      - collections-publisher-worker
     environment:
       DATABASE_URL: "mysql2://root:root@mysql/collections_publisher_development"
       REDIS_URL: redis://redis
@@ -47,8 +46,13 @@ services:
     depends_on:
       - redis
       - mysql
-      - publishing-api-app
+      - publishing-api-app-e2e
     environment:
       DATABASE_URL: "mysql2://root:root@mysql/collections_publisher_development"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  collections-publisher-app-e2e:
+    <<: *collections-publisher-app
+    depends_on:
+      - collections-publisher-worker


### PR DESCRIPTION
We need publishing-api-app-e2e so that the worker is started and we can test
pushing updates to publishing-api