### PR TITLE
Swallow 'Errno::ECONNREFUSED' errors on startup

### DIFF
--- a/lib/govuk_docker/commands/startup.rb
+++ b/lib/govuk_docker/commands/startup.rb
@@ -71,7 +71,7 @@ private
     else
       false
     end
-  rescue Errno::EHOSTDOWN
+  rescue Errno::EHOSTDOWN, Errno::ECONNREFUSED
     false
   end
 end


### PR DESCRIPTION
It looks like this is another kind of error that can occur if the
service isn't ready yet.