### PR TITLE
Add healthchecks for backing services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,16 @@ volumes:
   elasticsearch5:
   elasticsearch6:
 
+x-default-healthcheck: &default-healthcheck
+  interval: 10s
+  timeout: 20s
+
 services:
   postgres:
     image: postgres:9.6
+    healthcheck:
+      << : *default-healthcheck
+      test: "psql --username 'postgres' -c 'SELECT 1'"
     volumes:
       - postgres:/var/lib/postgresql/data
 
@@ -22,6 +29,9 @@ services:
 
   mongo:
     image: mongo:2.4
+    healthcheck:
+      << : *default-healthcheck
+      test: "echo 'db.stats().ok' | mongo localhost:27017/test --quiet"
     volumes:
       - mongo:/data/db
     ports:
@@ -30,6 +40,9 @@ services:
 
   mysql:
     image: mysql:5.5.58
+    healthcheck:
+      << : *default-healthcheck
+      test: "mysql --user=root --password=root -e 'SELECT 1'"
     volumes:
       - mysql:/var/lib/mysql
     environment:
@@ -37,14 +50,23 @@ services:
 
   redis:
     image: redis
+    healthcheck:
+      << : *default-healthcheck
+      test: "redis-cli ping"
 
   rabbitmq:
     image: rabbitmq
+    healthcheck:
+      << : *default-healthcheck
+      test: "rabbitmqctl node_health_check"
     volumes:
       - rabbitmq:/var/lib/rabbitmq
 
   elasticsearch5:
     image: elasticsearch:5.6.14
+    healthcheck:
+      << : *default-healthcheck
+      test: "curl --silent --fail localhost:9200/_cluster/health || exit 1"
     environment:
       - http.host=0.0.0.0
       - transport.host=127.0.0.1
@@ -55,6 +77,9 @@ services:
 
   elasticsearch6:
     image: elasticsearch:6.7.0
+    healthcheck:
+      << : *default-healthcheck
+      test: "curl --silent --fail localhost:9200/_cluster/health || exit 1"
     environment:
       - http.host=0.0.0.0
       - transport.host=127.0.0.1


### PR DESCRIPTION
By adding a healthcheck we ensure that containers which rely on these
services don't come up until the service reports a healthy state.
e.g. search-api won't be available to do things before elasticsearch
is running.  This is useful because at the moment there is a race
condition in commands like this:

    GOVUK_DOCKER_SERVICE=search-api \
    govuk-docker run curl -XDELETE http://elasticsearch5:9200/_all

As the containers are started at the same time, without waiting, there
is a good chance the `curl` will happen before Elasticsearch is able
to respond to requests.  A healthcheck fixes this.

These checks were copied from the e2e tests.