### PR TITLE
Create directory before writing file as sudo

### DIFF
--- a/lib/govuk_docker/setup/dnsmasq.rb
+++ b/lib/govuk_docker/setup/dnsmasq.rb
@@ -30,6 +30,22 @@ private
     shell.yes?("Are you sure you want to continue?")
   end
 
+  def check_continue_as_sudo
+    puts
+    puts "🚨 This script needs to write to the following as sudo:"
+    puts "- /etc/resolver/dev.gov.uk"
+    puts
+    puts "You will be asked for your password if you continue."
+    puts
+    puts "If this makes you uncomfortable, you should manually"
+    puts "create the file and its contents after the rest of the script finishes."
+    puts " echo \"nameserver 127.0.0.1\" >> /etc/resolver/dev.gov.uk"
+    puts "should do the trick."
+    puts
+
+    shell.yes?("Are you sure you want to allow the script to create /etc/resolver/dev.gov.uk as sudo?")
+  end
+
   def install_dnsmasq
     return if GovukDocker::Doctor::Checkup.new(
       service_name: "dnsmasq",
@@ -44,7 +60,8 @@ private
   def configure_etc_resolver_devgovuk
     write_file(
       "/etc/resolver/dev.gov.uk",
-      "nameserver 127.0.0.1"
+      "nameserver 127.0.0.1",
+      true
     )
   end
 
@@ -73,11 +90,22 @@ private
     false
   end
 
-  def write_file(path, contents)
+  def write_file(path, contents, as_sudo = false)
     return if file_configured?(path, contents)
 
+    if as_sudo
+      return unless check_continue_as_sudo
+    end
+
+    ensure_directory_exists(path, as_sudo)
+
     puts "⏳ Writing #{path}"
-    File.write(path, "#{contents}\n")
+
+    if as_sudo
+      system("echo \"#{contents}\n\" | sudo tee #{path}")
+    else
+      File.write(path, "#{contents}\n")
+    end
   end
 
   def append_file(path, contents)
@@ -86,6 +114,19 @@ private
     puts "⏳ Appending #{path}"
     File.open(path, 'a') do |file|
       file.write("\n#{contents}\n")
+    end
+  end
+
+  def ensure_directory_exists(path, as_sudo = false)
+    dir = File.dirname(path)
+    return if Dir.exist?(dir)
+
+    puts "⏳ Creating directory #{dir}, you may need to enter your root password"
+
+    if as_sudo
+      system "sudo mkdir #{dir}"
+    else
+      Dir.mkdir(dir) unless as_sudo
     end
   end
 end

--- a/spec/setup/dnsmasq_spec.rb
+++ b/spec/setup/dnsmasq_spec.rb
@@ -24,6 +24,9 @@ describe GovukDocker::Setup::Dnsmasq do
       allow(GovukDocker::Doctor::Checkup).to receive(:new).with(service_name: "dnsmasq", checkups: %i(installed), messages: {}).and_return(double(installed?: false))
       allow(subject).to receive(:system).with("brew install dnsmasq")
       allow(subject).to receive(:puts)
+      allow(subject).to receive(:system).with("echo \"nameserver 127.0.0.1\n\" | sudo tee /etc/resolver/dev.gov.uk")
+      allow(subject).to receive(:system).with("sudo mkdir /etc/resolver")
+      allow(subject).to receive(:ensure_directory_exists).with("/usr/local/etc/", false).and_return(true)
       allow(File).to receive(:read).with("/etc/resolver/dev.gov.uk").and_return("")
       allow(File).to receive(:read).with("/usr/local/etc/dnsmasq.conf").and_return("")
       allow(File).to receive(:read).with("/usr/local/etc/dnsmasq.d/development.conf").and_return("")
@@ -41,8 +44,7 @@ describe GovukDocker::Setup::Dnsmasq do
 
     it "writes to the various files" do
       expect(subject).to receive(:puts).with(/Writing/)
-      expect(File).to receive(:write)
-        .with("/etc/resolver/dev.gov.uk", "nameserver 127.0.0.1\n")
+      expect(subject).to receive(:system).with("echo \"nameserver 127.0.0.1\n\" | sudo tee /etc/resolver/dev.gov.uk")
       expect(File).to receive(:write)
         .with("/usr/local/etc/dnsmasq.d/development.conf", "address=/dev.gov.uk/127.0.0.1\n")
       file_double = double
@@ -52,9 +54,54 @@ describe GovukDocker::Setup::Dnsmasq do
       subject.call
     end
 
+    it "creates /etc/resolver directory as sudo if it does not yet exist" do
+      expect(File).to receive(:dirname)
+        .with("/etc/resolver/dev.gov.uk")
+        .and_return("/etc/resolver")
+      expect(Dir).to receive(:exist?)
+        .with("/etc/resolver")
+        .and_return(false)
+
+      allow(File).to receive(:dirname)
+        .with("/usr/local/etc/dnsmasq.d/development.conf")
+        .and_return("/usr/local/etc/dnsmasq.d")
+      allow(Dir).to receive(:exist?)
+        .with("/usr/local/etc/dnsmasq.d")
+        .and_return(true)
+
+      expect(subject).to receive(:puts).with(/Creating directory/)
+      expect(subject).to receive(:system).with("sudo mkdir /etc/resolver")
+      expect(subject).to receive(:system).with("echo \"nameserver 127.0.0.1\n\" | sudo tee /etc/resolver/dev.gov.uk")
+
+      subject.call
+    end
+
+    it "creates /usr/local/etc/dnsmasq.d if the directory does not exist" do
+      expect(File).to receive(:dirname)
+        .with("/usr/local/etc/dnsmasq.d/development.conf")
+        .and_return("/usr/local/etc/dnsmasq.d")
+      expect(Dir).to receive(:exist?)
+        .with("/usr/local/etc/dnsmasq.d")
+        .and_return(false)
+
+      allow(File).to receive(:dirname)
+        .with("/etc/resolver/dev.gov.uk")
+        .and_return("/etc/resolver")
+      allow(Dir).to receive(:exist?)
+        .with("/etc/resolver")
+        .and_return(true)
+
+      expect(subject).to receive(:puts).with(/Creating directory/)
+      allow(subject).to receive(:system).with("echo \"nameserver 127.0.0.1\n\" | sudo tee /etc/resolver/dev.gov.uk")
+      expect(Dir).to receive(:mkdir).with("/usr/local/etc/dnsmasq.d")
+
+      subject.call
+    end
+
     it "restarts dnsmasq" do
       expect(subject).to receive(:puts).with(/Restarting/)
       expect(subject).to receive(:system).with("sudo brew services restart dnsmasq")
+      expect(subject).to receive(:system).with("echo \"nameserver 127.0.0.1\n\" | sudo tee /etc/resolver/dev.gov.uk")
       subject.call
     end
 


### PR DESCRIPTION
If a directory does not exist before writing a file, setup will error
out.

Add function to create the directory if it does not yet exist.

Since one of the directories we need to create is /etc/resolver we need
to allow for creating the directory as `sudo`. To allow for this, add
`as_sudo` as a parameter to existing `write_file`. This defaults to
false.

We also need to create the file (/etc/resolver/dev.gov.uk) as sudo, so 
adapt the code to take that into account.