### PR TITLE
Increase MySQL max_allowed_packet size to 1GB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       - mysql:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: root
+      max_allowed_packet: 1073741824
 
   redis:
     image: redis


### PR DESCRIPTION
The default max_allowed_packet size is 64MB, which is too small for importing Whitehall's database.

Reference: https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet