### PR TITLE
Add MySQL command to increase max allowed packet size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,9 @@ services:
       test: "mysql --user=root --password=root -e 'SELECT 1'"
     volumes:
       - mysql:/var/lib/mysql
+    command: --max_allowed_packet=1073741824
     environment:
       MYSQL_ROOT_PASSWORD: root
-      max_allowed_packet: 1073741824
 
   redis:
     image: redis


### PR DESCRIPTION
Importing replicated data into Whitehall's database has proved problematic as
the default max_allowed_packet value for MySQL isn't large enough. Previously
we tried adding max_allowed_packet as an environment variable but this didn't
work. Instead we are passing it as a command argument, noting that the
entrypoint file for MySQL looks for this argument and prepends it with
"mysqld".