### PR TITLE
Add required frontend dependency for Whitehall

### DIFF
--- a/services/content-tagger/Makefile
+++ b/services/content-tagger/Makefile
@@ -1,2 +1,2 @@
-content-tagger: bundle-content-tagger publishing-api
+content-tagger: bundle-content-tagger publishing-api frontend
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/whitehall/Makefile
+++ b/services/whitehall/Makefile
@@ -1,4 +1,4 @@
-whitehall: bundle-whitehall asset-manager publishing-api static
+whitehall: bundle-whitehall asset-manager publishing-api static frontend
 	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
 	$(GOVUK_DOCKER) compose run $@-lite bin/rake shared_mustache:compile
 	$(GOVUK_DOCKER) compose run $@-app-e2e bin/rake taxonomy:populate_end_to_end_test_data


### PR DESCRIPTION
Previously we could not run the E2E setup task for Whitehall since the
homepage content item that it relies on did not exist. This adds a
dependency on the frontend app, which includes a setup task to publish
special routes/content, which includes the homepage.

This also adds the 'frontend' app as a dependency for Content Tagger,
since it too relies on the existence of the homepage content item.