### PR TITLE
Specify port in /etc/resolver/dev.gov.uk

### DIFF
--- a/lib/govuk_docker/doctor/checkup.rb
+++ b/lib/govuk_docker/doctor/checkup.rb
@@ -87,7 +87,7 @@ module GovukDocker::Doctor
     end
 
     def dnsmasq_resolver?
-      File.read('/etc/resolver/dev.gov.uk').strip == "nameserver 127.0.0.1"
+      File.read('/etc/resolver/dev.gov.uk').strip == "nameserver 127.0.0.1\nport 53"
     end
 
     def dnsmasq_resolver_message

--- a/lib/govuk_docker/doctor/doctor.rb
+++ b/lib/govuk_docker/doctor/doctor.rb
@@ -70,6 +70,7 @@ module GovukDocker::Doctor
         ❌ Something else (possibly Vagrant-dns) is configured to resolve DNS requests for dev.gov.uk.
           The /etc/resolver/dev.gov.uk file needs to be updated to only contain
           nameserver 127.0.0.1
+          port 53
       HEREDOC
     }
   end

--- a/lib/govuk_docker/setup/dnsmasq.rb
+++ b/lib/govuk_docker/setup/dnsmasq.rb
@@ -44,7 +44,7 @@ private
   def configure_etc_resolver_devgovuk
     write_file(
       "/etc/resolver/dev.gov.uk",
-      "nameserver 127.0.0.1"
+      "nameserver 127.0.0.1\nport 53"
     )
   end
 

--- a/spec/doctor/checkup_spec.rb
+++ b/spec/doctor/checkup_spec.rb
@@ -180,7 +180,7 @@ describe GovukDocker::Doctor::Checkup do
         messages: messages
       )
 
-      allow(File).to receive(:read).with("/etc/resolver/dev.gov.uk").and_return("nameserver 127.0.0.1")
+      allow(File).to receive(:read).with("/etc/resolver/dev.gov.uk").and_return("nameserver 127.0.0.1\nport 53")
 
       expect(subject.call).to eq("fake_service is resolving your dns")
     end

--- a/spec/setup/dnsmasq_spec.rb
+++ b/spec/setup/dnsmasq_spec.rb
@@ -42,7 +42,7 @@ describe GovukDocker::Setup::Dnsmasq do
     it "writes to the various files" do
       expect(subject).to receive(:puts).with(/Writing/)
       expect(File).to receive(:write)
-        .with("/etc/resolver/dev.gov.uk", "nameserver 127.0.0.1\n")
+        .with("/etc/resolver/dev.gov.uk", "nameserver 127.0.0.1\nport 53\n")
       expect(File).to receive(:write)
         .with("/usr/local/etc/dnsmasq.d/development.conf", "address=/dev.gov.uk/127.0.0.1\n")
       file_double = double


### PR DESCRIPTION
    Previously we only encouraged people to have a /etc/resolver/dev.gov.uk
    file with a single 'namespace' line. Just specifying 'namespace' seems
    to cause problems for people moving from a 'vagrant dns' setup, where an
    additional 'port 5300' line was also present. Simply removing this line
    doesn't seem to be enough to make the OS notice the file has changed, so
    this explicitly specifies 'port 53', even though 53 is the default DNS
    port, to avoid people having to restart their machine to get the changes.