### PR TITLE
Add psql to the base Dockerfile

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -30,6 +30,9 @@ RUN git clone https://github.com/sstephenson/ruby-build.git /rbenv/plugins/ruby-
 RUN /rbenv/plugins/ruby-build/install.sh
 ENV PATH /rbenv/bin:$PATH
 
+# Install psql for 'rails dbconsole'
+RUN apt-get install -y postgresql-client
+
 RUN useradd -m build
 ENV PATH /home/build/.rbenv/shims:${PATH}
 USER build


### PR DESCRIPTION
This is required in order to run 'rails dbconsole', which applies to a large number of apps around GOV.UK that have a PostgreSQL DB.

https://trello.com/c/6bylw9OJ/101-get-dbconsole-working-on-apps