### PR TITLE
Fix typos: MacOS => macOS and overwriten => overwritten

### DIFF
--- a/lib/govuk_docker/setup/dnsmasq.rb
+++ b/lib/govuk_docker/setup/dnsmasq.rb
@@ -16,14 +16,14 @@ class GovukDocker::Setup::Dnsmasq < GovukDocker::Setup::Base
 private
 
   def check_continue
-    puts "Any local changes in these files may get overwriten by this script:"
+    puts "Any local changes in these files may get overwritten by this script:"
     puts "- /etc/resolver/dev.gov.uk"
     puts "- /usr/local/etc/dnsmasq.conf"
     puts "- /usr/local/etc/dnsmasq.d/development.conf"
     puts
 
     unless %x[uname -a].include?("Darwin")
-      puts "This script is designed to run on MacOS."
+      puts "This script is designed to run on macOS."
       puts
     end
 

--- a/lib/govuk_docker/setup/repo.rb
+++ b/lib/govuk_docker/setup/repo.rb
@@ -30,7 +30,7 @@ private
 
   def check_continue
     puts "This will clone/pull `#{path}`."
-    puts "Any local changes may be overwriten."
+    puts "Any local changes may be overwritten."
     puts
 
     shell.yes?("Are you sure you want to continue?")


### PR DESCRIPTION
- I was reading the code and trying to run `setup` after this was linked
  from one of RE's docs for thoughts on how to do local dev.