### PR TITLE
Add missing email-alert-frontend route

### DIFF
--- a/services/email-alert-frontend/Makefile
+++ b/services/email-alert-frontend/Makefile
@@ -3,3 +3,4 @@ email-alert-frontend: bundle-email-alert-frontend email-alert-api
 	$(GOVUK_DOCKER) compose run $@-setup bin/rake publishing_api:publish_email_unsubscribe_prefix
 	$(GOVUK_DOCKER) compose run $@-setup bin/rake publishing_api:publish_email_subscriptions_prefix
 	$(GOVUK_DOCKER) compose run $@-setup bin/rake publishing_api:publish_email_authenticate_prefix
+	$(GOVUK_DOCKER) compose run $@-setup bin/rake publishing_api:publish_email_manage_prefix


### PR DESCRIPTION
This got missed the first time around.