### PR TITLE
Document how to remove Docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,17 @@ Sometimes it's useful to get all changes for all repos e.g. to support finding t
 make pull
 ```
 
+### How to: clear your Docker containers
+
+Sometimes a service just doesn't work as expected, and the easiest thing to do is to start over. This command stops and removes all local govuk Docker containers:
+
+```
+govuk-docker compose stop
+govuk-docker prune
+```
+
+You should then be able to `govuk-docker build` your service and have confidence you're not suffering from configuration drift.
+
 ### How to: set up Dnsmasq manually
 
 If the [installation instructions](#setup) above didn't work for you, you may need to do some things manually as outlined below.


### PR DESCRIPTION
Myself and a few members of the step by step team have had to resort to this a few times
when working with collections-publisher, which would sometimes get in a painful state trying
to interact with publishing-api or link-checker-api.  It did not appear to be fixable through the
normal methods of updating and rebuilding individual services, running in an `e2e` stack or
restarting Docker itself.

The most reliable way to fix some of the more obscure problems has been to clear all
containers and rebuild them. The commands are not very intuitive or easy to remember, so they
are worth documenting in the README.