### PR TITLE
Add details on increasing Docker resource settings (to help with Whitehall import)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,12 +267,12 @@ app.dev.gov.uk.		0	IN	A	127.0.0.1
 Provide a local gem path relative to the location of the Gemfile you're editing:
 
 ```ruby
-gem 'govuk_publishing_components', path: '../govuk_publishing_components' 
+gem 'govuk_publishing_components', path: '../govuk_publishing_components'
 ```
 
 ### How to: replicate data locally
 
-There may be times when a full database is required locally.  The following sections give examples of how to replicate this data from integration.  All examples reqire pv, which can be installed on a Mac using Brew (`brew install pv`).
+There may be times when a full database is required locally.  The following sections give examples of how to replicate this data from integration.  All examples require pv, which can be installed on a Mac using Brew (`brew install pv`).
 
 #### MySQL
 
@@ -291,6 +291,16 @@ govuk-docker compose run mysql mysql -h mysql -u root --password=root -e "CREATE
 ```
 pv whitehall_production.dump.gz | gunzip | govuk-docker compose run mysql mysql -h mysql -u root --password=root whitehall_development
 ```
+
+*For Whitehall*
+
+In order to ensure that Whitehall runs smoothly, your Docker settings may need to be changed in order to handle Whitehall. By default, Docker defaults to using 2 CPU cores and 2GB of RAM, and this is simply not enough to render Whitehall in a Docker container.
+
+You should set it to use at least 4 CPU cores and 8GB of RAM - 6 CPUs and 8 GB of RAM seems to work ok. Open the Docker dropdown via the whale icon in the OSX menu bar and selecting the `Advanced` option.
+
+You should also increase the Docker disk image size to the maximum.
+
+We have found no tangible improvement in increasing swap space size compared to CPU, RAM and disk allocation.
 
 #### PostgreSQL
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,19 @@ govuk-docker has the following dependencies:
 
 All other dependencies will be installed for you automatically.
 
+#### Docker settings
+These need to be changed in order to handle intensive apps like Whitehall. Docker defaults to using 2 CPU cores and 2GB of RAM. Open the Docker dropdown via the Docker whale icon in the macOS menu bar, and select the `Advanced` option.
+
+Change to ideally:
+
+* 6 CPUs
+* 12 GB RAM
+* Docker disk image size default is 64GB under the Disk tab
+  * depending on how much free space you have
+  * the minimum should be > 50GB
+
+We have found no tangible improvement in increasing swap space size compared to CPU, RAM and disk allocation.
+
 ### Setup
 
 Start with the following in your bash config.
@@ -291,16 +304,6 @@ govuk-docker compose run mysql mysql -h mysql -u root --password=root -e "CREATE
 ```
 pv whitehall_production.dump.gz | gunzip | govuk-docker compose run mysql mysql -h mysql -u root --password=root whitehall_development
 ```
-
-*For Whitehall*
-
-In order to ensure that Whitehall runs smoothly, your Docker settings may need to be changed in order to handle Whitehall. By default, Docker defaults to using 2 CPU cores and 2GB of RAM, and this is simply not enough to render Whitehall in a Docker container.
-
-You should set it to use at least 4 CPU cores and 8GB of RAM - 6 CPUs and 8 GB of RAM seems to work ok. Open the Docker dropdown via the whale icon in the macOS menu bar and selecting the `Advanced` option.
-
-You should also increase the Docker disk image size to the maximum.
-
-We have found no tangible improvement in increasing swap space size compared to CPU, RAM and disk allocation.
 
 #### PostgreSQL
 

--- a/README.md
+++ b/README.md
@@ -59,17 +59,14 @@ govuk-docker has the following dependencies:
 All other dependencies will be installed for you automatically.
 
 #### Docker settings
-These need to be changed in order to handle intensive apps like Whitehall. Docker defaults to using 2 CPU cores and 2GB of RAM. Open the Docker dropdown via the Docker whale icon in the macOS menu bar, and select the `Advanced` option.
+Running GOV.UK applications can be resource intensive and will easily exceed the default configuration of Docker for Mac. To change settings open the Docker dropdown via the Docker whale icon in the macOS menu bar, and select the preferences option.
 
-Change to ideally:
+In `Advanced` settings you should update CPU and RAM resources. These should be at least:
 
 * 6 CPUs
 * 12 GB RAM
-* Docker disk image size default is 64GB under the Disk tab
-  * depending on how much free space you have
-  * the minimum should be > 50GB
 
-We have found no tangible improvement in increasing swap space size compared to CPU, RAM and disk allocation.
+In `Disk` you should ensure there is a high amount of disk space to allow replicating GOV.UK data. 64GB should be sufficient for most usages but you may need > 100GB to clone all GOV.UK integration data.
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ pv whitehall_production.dump.gz | gunzip | govuk-docker compose run mysql mysql 
 
 In order to ensure that Whitehall runs smoothly, your Docker settings may need to be changed in order to handle Whitehall. By default, Docker defaults to using 2 CPU cores and 2GB of RAM, and this is simply not enough to render Whitehall in a Docker container.
 
-You should set it to use at least 4 CPU cores and 8GB of RAM - 6 CPUs and 8 GB of RAM seems to work ok. Open the Docker dropdown via the whale icon in the OSX menu bar and selecting the `Advanced` option.
+You should set it to use at least 4 CPU cores and 8GB of RAM - 6 CPUs and 8 GB of RAM seems to work ok. Open the Docker dropdown via the whale icon in the macOS menu bar and selecting the `Advanced` option.
 
 You should also increase the Docker disk image size to the maximum.
 


### PR DESCRIPTION
Local data is required for rendering pages that Whitehall Frontend
serves directly. But as the app is so intense, Docker needs to be
beefed up to cope.