### PR TITLE
Add short-url-manager to services

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ The following apps are supported by govuk-docker to some extent.
    - ⚠  search-api
       * Tests fail as they run against [both Elasticsearch instances](https://github.com/alphagov/search-api/pull/1618)
    - ✅ service-manual-frontend
+   - ✅ short-url-manager
    - ✅ signon
    - ✅ smart-answers
    - ✅ specialist-publisher

--- a/services/nginx-proxy/docker-compose.yml
+++ b/services/nginx-proxy/docker-compose.yml
@@ -49,6 +49,7 @@ services:
           - search-api.dev.gov.uk
           - search.dev.gov.uk
           - service-manual-frontend.dev.gov.uk
+          - short-url-manager.dev.gov.uk
           - signon.dev.gov.uk
           - smart-answers.dev.gov.uk
           - specialist-publisher.dev.gov.uk

--- a/services/short-url-manager/Makefile
+++ b/services/short-url-manager/Makefile
@@ -1,0 +1,1 @@
+short-url-manager: bundle-short-url-manager publishing-api govuk-content-schemas

--- a/services/short-url-manager/docker-compose.yml
+++ b/services/short-url-manager/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.7'
+
+x-short-url-manager: &short-url-manager
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: short-url-manager
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - home:/home/build
+  working_dir: /govuk/short-url-manager
+
+services:
+  short-url-manager-lite:
+    <<: *short-url-manager
+    privileged: true
+    depends_on:
+      - redis
+      - mongo
+    environment:
+      MONGODB_URI: "mongodb://mongo/short-url-manager"
+      TEST_MONGODB_URI: "mongodb://mongo/short-url-manager-test"
+      REDIS_HOST: redis
+
+  short-url-manager-app: &short-url-manager-app
+    <<: *short-url-manager
+    depends_on:
+      - redis
+      - mongo
+      - nginx-proxy-app
+      - publishing-api-app
+    environment:
+      MONGODB_URI: "mongodb://mongo/short-url-manager"
+      REDIS_URL: redis
+      VIRTUAL_HOST: short-url-manager.dev.gov.uk
+      HOST: 0.0.0.0
+    ports:
+      - "3000"
+    command: bin/rails s -P /tmp/rails.pid


### PR DESCRIPTION
~Depends on: https://github.com/alphagov/short-url-manager/pull/390~

This service hadn't made the list last time. Short URL Manager uses an
unconventional approach of creating a user in an initializer so doesn't
require the regular seed or User.create approach.