### PR TITLE
Replace historical documents with PRs/ADRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ The aim of govuk-docker is to make it easy to develop any GOV.UK app. It achieve
 
 [RFC 106: Use Docker for local development](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-106-docker-for-local-development.md) describes the background for choosing Docker.
 
-To guide development we [have documented the user needs](docs/NEEDS.md) and [associated decisions](docs/DECISIONS.md) in this repo.
-
 ## Usage
 
 Do this to run the tests for a service:

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,26 @@
+[NEEDS]: 0001/NEEDS.md
+[DECISIONS]: 0001/DECISIONS.md
+
+# 1. Record architecture decisions
+
+Date: 2019-09-19
+
+## Context
+
+We need to record the architectural decisions made on this project.
+
+The [original govuk-docker repo](https://github.com/benthorner/govuk-docker) was written outside of GOV.UK. Major architectural decisions, as well as more minor decisions, were written as [documentation in the repo][DECISIONS], together with their associated user [NEEDS]. While these documents have historical value, they are not being maintained and increasingly differ from the current state of the repo. As part of adopting an ADR approach, we should clearly deprecate these historical documents to avoid confusion.
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard in this article: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+
+## Status
+
+Accepted
+
+## Consequences
+
+See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's _adr-tools_ at https://github.com/npryce/adr-tools.
+
+We will deprecate the historical [DECISIONS] and [NEEDS] documents, by writing a deprecation notice at the top of each document, and by moving them into the assets for this ADR.

--- a/docs/adr/0001/DECISIONS.md
+++ b/docs/adr/0001/DECISIONS.md
@@ -1,5 +1,7 @@
 # Decisions
 
+**DEPRECATED: much of what follows was written before we adopted a PR/ADR mechanism for making changes in this repo. Decisions may have changed since they were written here, so what follows should only be used to provide historical context.**
+
 This is a record of decisions in the design of govuk-docker, to support the various needs people have when developing in the GOV.UK ecosystem. Each decision has a reference anchor so it can be linked from its associated need(s).
 
 ## Make

--- a/docs/adr/0001/NEEDS.md
+++ b/docs/adr/0001/NEEDS.md
@@ -3,6 +3,8 @@
 
 # Needs
 
+**DEPRECATED: much of what follows was written before we adopted a PR/ADR mechanism for making changes in this repo. Needs may have changed since they were written here, so what follows should only be used to provide historical context.**
+
 The aim of govuk-docker is to meet the following primary need.
 
 > **As a** developer on GOV.UK apps <br/>


### PR DESCRIPTION
https://trello.com/c/qWKi5qKZ/78-adr-about-needs-decisions

The main goal here is to hide away the historical DECISIONS and NEEDS 
documents to avoid confusion. Happy to talk about this more if we think 
that should be a separate change to the introduction of ADRs.