### PR TITLE
Sync elasticsearch data [WIP]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,12 @@
 source "https://rubygems.org"
 
+gem "aws-sdk-s3", "~> 1"
 gem "climate_control"
 gem "colorize"
+gem "elasticsearch", "~> 6"
 gem "govuk-lint"
+gem "highline"
 gem "pry"
 gem "rspec"
+gem "ruby-progressbar"
 gem "thor"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,18 +2,48 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
+    aws-eventstream (1.0.3)
+    aws-partitions (1.214.0)
+    aws-sdk-core (3.68.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.24.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.48.0)
+      aws-sdk-core (~> 3, >= 3.61.1)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.1.0)
+      aws-eventstream (~> 1.0, >= 1.0.2)
     climate_control (0.2.0)
     coderay (1.1.2)
     colorize (0.8.1)
     diff-lcs (1.3)
+    elasticsearch (6.8.0)
+      elasticsearch-api (= 6.8.0)
+      elasticsearch-transport (= 6.8.0)
+    elasticsearch-api (6.8.0)
+      multi_json
+    elasticsearch-transport (6.8.0)
+      faraday
+      multi_json
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     ffi (1.11.1)
     govuk-lint (4.0.0)
       rubocop (~> 0.72)
       rubocop-rails (~> 2)
       rubocop-rspec (~> 1.28)
       scss_lint
+    highline (2.0.2)
     jaro_winkler (1.5.3)
+    jmespath (1.4.0)
     method_source (0.9.2)
+    multi_json (1.13.1)
+    multipart-post (2.1.1)
     parallel (1.17.0)
     parser (2.6.4.1)
       ast (~> 2.4.0)
@@ -67,11 +97,15 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3 (~> 1)
   climate_control
   colorize
+  elasticsearch (~> 6)
   govuk-lint
+  highline
   pry
   rspec
+  ruby-progressbar
   thor
 
 BUNDLED WITH

--- a/elasticsearch_import.yml
+++ b/elasticsearch_import.yml
@@ -1,0 +1,4 @@
+cluster.name: 'docker-cluster'
+network.host: 0.0.0.0
+discovery.zen.minimum_master_nodes: 1
+path.repo: ['/replication']

--- a/lib/govuk_docker/aws/client.rb
+++ b/lib/govuk_docker/aws/client.rb
@@ -1,0 +1,55 @@
+require "aws-sdk-s3"
+require "ruby-progressbar"
+
+module GovukDocker
+  module Aws
+    class Client
+      def initialize(mfa_token)
+        @client = ::Aws::S3::Client.new(credentials: role_credentials(mfa_token))
+      end
+
+      def download_bucket(bucket_name:, dest_path:)
+        FileUtils.mkdir_p dest_path
+        bucket = ::Aws::S3::Resource.new(client: client).bucket(bucket_name)
+        progress_bar = ProgressBar.create(title: "Downloading bucket from S3", total: bucket.objects.count)
+
+        bucket.objects.each do |content|
+          download_object(content: content, bucket_name: bucket_name, dest_path: dest_path)
+          progress_bar.increment
+        end
+      end
+
+    private
+
+      attr_reader :client, :config_hash
+
+      def download_object(content:, bucket_name:, dest_path:)
+        full_path = File.join(dest_path, content.key)
+        dirname = File.dirname(full_path)
+        FileUtils.mkdir_p dirname
+        File.open(full_path, "wb") do |file|
+          client.get_object(bucket: bucket_name, key: content.key) do |chunk|
+            file.write(chunk)
+          end
+        end
+      end
+
+      def role_credentials(mfa_token)
+        config_hash = ::Aws::IniParser.ini_parse(File.read(File.join(ENV["HOME"], "/.aws/config")))
+        ::Aws::AssumeRoleCredentials.new(client: sts_client,
+                                         role_arn: config_hash.dig("govuk-integration", "role_arn"),
+                                         role_session_name: role_session_name,
+                                         serial_number: config_hash.dig("govuk-integration", "mfa_serial"),
+                                         token_code: mfa_token)
+      end
+
+      def sts_client(profile: "gds", region: "eu-west-1")
+        ::Aws::STS::Client.new(profile: profile, region: region)
+      end
+
+      def role_session_name
+        "#{ENV['USER']}-#{Time.now.strftime('%d-%m-%y_%H-%M')}"
+      end
+    end
+  end
+end

--- a/lib/govuk_docker/commands/data_sync/elasticsearch.rb
+++ b/lib/govuk_docker/commands/data_sync/elasticsearch.rb
@@ -1,0 +1,95 @@
+require "forwardable"
+require "highline"
+require_relative "../../../../lib/govuk_docker/aws/client"
+require_relative "../../../../lib/govuk_docker/elasticsearch/client"
+
+module GovukDocker
+  module Commands
+    module DataSync
+      class Elasticsearch < GovukDocker::Commands::Base
+        extend Forwardable
+
+        def_delegators :@govuk_elasticsearch_client, :start_elasticsearch, :wait_for_elasticsearch, :snapshot
+
+        def initialize(snapshot_directory:,
+                       service:,
+                       skip_download:,
+                       skip_restore:,
+                       keep_download:)
+          @service = service
+          @skip_download = skip_download
+          @keep_download = keep_download
+          @skip_restore = skip_restore
+          @snapshot_directory = snapshot_directory
+          @bucket_name = "govuk-integration-#{service}-manual-snapshots"
+          @govuk_elasticsearch_client = GovukDocker::Elasticsearch::Client.new(snapshot_directory: snapshot_directory,
+                                                                               service: service)
+        end
+
+        def sync_data
+          validate!
+          fetch_s3_client
+          stop_all_containers
+          start_elasticsearch
+          wait_for_elasticsearch
+          download_bucket
+          restore snapshot
+          remove_snapshot
+          stop_elasticsearch
+          remove_snapshot_directory
+        end
+
+      private
+
+        attr_reader :govuk_s3_client, :govuk_elasticsearch_client, :keep_download, :skip_download,
+                    :skip_restore, :snapshot_directory, :bucket_name, :service
+
+        def validate!
+          raise "Not a valid elasticsearch service" unless service.start_with?("elasticsearch")
+        end
+
+        def fetch_s3_client
+          return if skip_download
+
+          mfa_token = HighLine.new.ask("Enter your AWS Mfa token: ") { |q| q.echo = "." }
+          @govuk_s3_client = GovukDocker::Aws::Client.new(mfa_token)
+        end
+
+        def stop_all_containers
+          puts "stopping all containers"
+          GovukDocker::Commands::Compose.new.call(%w[stop])
+        end
+
+        def restore(snapshot_name)
+          return if skip_restore
+
+          @govuk_elasticsearch_client.restore snapshot_name
+        end
+
+        def download_bucket
+          return if skip_download
+
+          govuk_s3_client.download_bucket(bucket_name: bucket_name, dest_path: snapshot_directory)
+        end
+
+        def stop_elasticsearch
+          puts "stop elastic"
+          system_command("docker stop `docker-compose ps -q #{service}`", raise_on_error: true)
+        end
+
+        def remove_snapshot
+          return if skip_restore
+
+          puts "remove repository"
+          govuk_elasticsearch_client.remove_snapshot
+        end
+
+        def remove_snapshot_directory
+          return if keep_download
+
+          FileUtils.rm_rf(snapshot_directory)
+        end
+      end
+    end
+  end
+end

--- a/lib/govuk_docker/elasticsearch/client.rb
+++ b/lib/govuk_docker/elasticsearch/client.rb
@@ -1,0 +1,77 @@
+require "elasticsearch-ruby"
+require_relative "../../../lib/govuk_docker"
+require_relative "../../../lib/govuk_docker/cli"
+
+module GovukDocker
+  module Elasticsearch
+    class Client
+      def initialize(snapshot_directory:,
+                     service:)
+        @snapshot_directory = snapshot_directory
+        @service = service
+        @elasticsearch_client = ::Elasticsearch::Client.new transport_options: { request: { timeout: 20 * 60 } }
+      end
+
+      def wait_for_elasticsearch
+        print "starting elasticsearch"
+        begin
+          elasticsearch_client.cat.health
+          puts; puts "elasticsearch is up and running"
+        rescue StandardError
+          retries ||= 0
+          print "."
+          sleep 2
+          retry if (retries += 1) < 20
+          puts "elasticsearch cannot be reached"
+        end
+      end
+
+      def start_elasticsearch
+        FileUtils.mkdir_p snapshot_directory
+        GovukDocker::Commands::Compose.new.call(
+          [
+            "run",
+            "-d",
+            "--rm",
+            "-p", "9200:9200",
+            "-v",
+            "#{File.join(File.dirname(__FILE__), '../../../elasticsearch_import.yml')}:/usr/share/elasticsearch/config/elasticsearch.yml",
+            "-v",
+            "#{snapshot_directory}:/replication",
+            service
+          ],
+        )
+      end
+
+      def restore(snapshot_name)
+        puts "restoring snapshot..."
+        elasticsearch_client.indices.delete(index: "_all")
+        elasticsearch_client.snapshot.restore(repository: "snapshots", snapshot: snapshot_name, wait_for_completion: true)
+        elasticsearch_client.indices.put_settings body: { index: { number_of_replicas: 0 } }
+      end
+
+      def snapshot
+        elasticsearch_client.snapshot.create_repository(repository: "snapshots",
+                                                        body: {
+                                                          type: "fs",
+                                                          settings: {
+                                                            location: "/replication",
+                                                            compress: true,
+                                                            readonly: true,
+                                                          },
+                                                        })
+        all_snapshots = elasticsearch_client.snapshot.get(repository: "snapshots", snapshot: "_all")
+        all_snapshots.fetch("snapshots").map { |s| s.fetch("snapshot") }.max
+      end
+
+      def remove_snapshot
+        elasticsearch_client.snapshot.delete_repository repository: "snapshots"
+      end
+
+    private
+
+      attr_reader :environment, :snapshot_directory, :service,
+                  :skip_download, :skip_remove_download, :elasticsearch_client
+    end
+  end
+end


### PR DESCRIPTION
Add a 'sync' command to govuk-docker to populate services with data

This will download the current Elasticsearch snapshot from S3 and
import it into the local docker setup

Currently only Elasticsearch is supported.

Example:
govuk-docker sync --elasticsearch_service=elasticsearch5 --keep_download

Full help: govuk-docker help sync

Trello link: https://trello.com/c/tVQV1SMi/1025-enable-govuk-docker-to-import-elasticsearch-data-from-s3-bucket

TODO: 
- docs