### PR TITLE
Warn users about unsupported functionality in collections-publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ cd ~/govuk/content-publisher
 govuk-docker startup e2e
 ```
 
+### Interoperability of stacks
+
+Even if an e2e stack is started, functionality won't necessarily work as expected "end to end" as govuk-docker doesn't mimick the routing we have on GOV.UK. For example, publishing apps that link to draft-origin.dev.gov.uk frontends will see a server error, as draft-origin isn't a service in govuk-docker.
+
+In these cases, you can swap out the URL for the relevant frontend (such as draft-collections.dev.gov.uk). It's also worth noting that this frontend will need to be started separately, as publishing apps don't define frontend apps in their Docker service dependencies; a publishing app doesn't need its corresponding frontend in order to be able to publish.
+
 ## How to's
 
 ### How to: troubleshoot your installation


### PR DESCRIPTION
Some parts of the collections-publisher app do not work seamlessly
(if at all). As the govuk-docker README is the centralised source of
truth on this, I think it's worth highlighting here.