### PR TITLE
Add 'static-app' as a dependency to collections frontend draft stack

### DIFF
--- a/services/collections/docker-compose.yml
+++ b/services/collections/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - router-app-draft
       - content-store-app-draft
       - static-app-draft
+      - static-app
     environment:
       GOVUK_ASSET_ROOT: draft-collections.dev.gov.uk
       VIRTUAL_HOST: draft-collections.dev.gov.uk


### PR DESCRIPTION
Collections frontend draft stack relies on both static-app-draft and
static-app. Without static-app, some styles are missing and the page
looks broken.

CC'ing @benthorner who helped me find the fix.