### PR TITLE
Fix draft static referring to live static assets

### DIFF
--- a/services/government-frontend/docker-compose.yml
+++ b/services/government-frontend/docker-compose.yml
@@ -35,7 +35,6 @@ services:
       - router-app-draft
       - content-store-app-draft
       - static-app-draft
-      - static-app
     environment:
       GOVUK_ASSET_ROOT: draft-government-frontend.dev.gov.uk
       VIRTUAL_HOST: draft-government-frontend.dev.gov.uk

--- a/services/static/docker-compose.yml
+++ b/services/static/docker-compose.yml
@@ -33,5 +33,6 @@ services:
       - redis
     environment:
       REDIS_URL: redis://redis
+      GOVUK_ASSET_ROOT: draft-static.dev.gov.uk
       VIRTUAL_HOST: draft-static.dev.gov.uk
       HOST: 0.0.0.0


### PR DESCRIPTION
It makes me sad this wasn't spotted in all the other frontends we added...

Previously we depended on both the draft (draft-static.dev.gov.uk) and
app (static.dev.gov.uk) stacks of static when starting government-frontend,
since some of the network requests looked like they were hard-coded to use
the app stack. Further investigation shows this assumption was incorrect,
and that the draft stack of the static app can be corrected to correctly
refer to itself for asset URLs in the templates it renders.