### PR TITLE
Add setup troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The aim of govuk-docker is to make it easy to develop any GOV.UK app. It achieve
 
 ## Usage
 
+Clone your desired [service](#compatibility) into your `~/govuk` folder, e.g. collections-publisher.
+
 Do this to run the tests for a service:
 
 ```sh
@@ -52,6 +54,7 @@ govuk-docker has the following dependencies:
 - [brew](https://brew.sh/). (If you don't use a Mac, you'll need to dig into the `govuk-docker setup` command and manually install the things referenced).
 - [git](https://git-scm.com)
 - Ruby (whatever version is specified in [.ruby-version](https://github.com/alphagov/govuk-docker/blob/master/.ruby-version))
+  - Follow these [instructions to update Ruby using brew](#how-to-update-ruby)
 - A directory `~/govuk` in your home directory
 
 All other dependencies will be installed for you automatically.
@@ -83,7 +86,7 @@ bundle install
 govuk-docker setup
 ```
 
-You can now [clone and setup the apps you need](#Usage), after which you can do things like run tests and startup the app in your browser. If this doesn't work for whatever reason, follow the [instructions to set up Dnsmasq manually](#how-to-set-up-dnsmasq-manually).
+You can now [clone and setup the apps you need](#Usage), after which you can do things like run tests and startup the app in your browser. If this doesn't work for whatever reason, follow the [instructions on how to resolve setup issues](#how-to-resolve-setup-issues).
 
 ### Environment variables
 
@@ -238,7 +241,86 @@ govuk-docker prune
 
 You should then be able to `govuk-docker build` your service and have confidence you're not suffering from configuration drift.
 
-### How to: set up Dnsmasq manually
+### How to: resolve setup issues
+
+The following sections resolve common installation issues.
+
+#### How to: install/update Ruby
+
+Follow the instructions to install [rbenv](https://github.com/rbenv/rbenv#installation) using [brew](https://brew.sh/). 
+
+Then install the correct version of Ruby listed in [.ruby-version](https://github.com/alphagov/govuk-docker/blob/master/.ruby-version) - *note* you need to clone this repository (govuk-docker) into `~/govuk` first!
+
+```
+cd ~/govuk/govuk-docker
+rbenv install
+```
+
+Now, when you are in the `~/govuk/govuk-docker` folder, rbenv will automatically switch to the correct version of Ruby - check this by running `ruby -v`.
+
+#### How to: install bundler
+
+To install [bundler](https://bundler.io/), first find out the required version (in X.Y.Z format) from [Gemfile.lock](https://github.com/alphagov/govuk-docker/blob/master/Gemfile.lock) - it will be listed as:
+
+```
+BUNDLED WITH
+    X.Y.Z
+```
+
+Install the correct version of bundler; you may have to overwrite existing bundle and bundler executable conflicts.
+
+```
+gem install bundler:X.Y.Z
+```
+
+#### How to: resolve issues caused by an existing docker install 
+
+During `govuk-docker setup`, if you get the following errors when pouring `docker-compose`:
+
+```
+Error: The `brew link` step did not complete successfully
+The formula built, but is not symlinked into /usr/local
+Could not symlink bin/docker-compose
+Target /usr/local/bin/docker-compose
+already exists. You may want to remove it:
+  rm '/usr/local/bin/docker-compose'
+
+To force the link and overwrite all conflicting files:
+  brew link --overwrite docker-compose
+
+To list all files that would be deleted:
+  brew link --overwrite --dry-run docker-compose
+
+Possible conflicting files are:
+/usr/local/bin/docker-compose -> /Applications/Docker.app/Contents/Resources/bin/docker-compose
+```
+
+and when pouring `docker`:
+
+```
+Error: It seems there is already an App at '/Applications/Docker.app'.
+```
+
+Then uninstall your existing docker, and restart the `govuk-docker setup` process to install a new version of docker using brew.
+
+#### How to: resolve `No such file or directory` errors for `dev.gov.uk`
+
+If you get the following error during `govuk-docker setup`:
+
+```
+No such file or directory @ rb_sysopen - /etc/resolver/dev.gov.uk (Errno::ENOENT)
+```
+
+Create the `resolver` folder in `etc`.
+
+```
+sudo mkdir /etc/resolver/
+```
+
+Then follow the [instructions to set up Dnsmasq manually](#how-to-set-up-dnsmasq-manually).
+
+
+#### How to: set up Dnsmasq manually
 
 If the [installation instructions](#setup) above didn't work for you, you may need to do some things manually as outlined below.
 
@@ -249,10 +331,10 @@ of  `/etc/resolver/dev.gov.uk`.
 cp /etc/resolver/dev.gov.uk ~/dev.gov.uk
 ```
 
-Then create or update `/etc/resolver/dev.gov.uk`. If you've been using the vagrant based dev VM, you'll need to replace `/etc/resolver/dev.gov.uk`
+Then create or update `/etc/resolver/dev.gov.uk`; you can create a copy directly from [dnsmasq.conf](https://github.com/alphagov/govuk-docker/blob/master/config/dnsmasq.conf). If you've been using the vagrant based dev VM, you'll need to replace `/etc/resolver/dev.gov.uk`. 
 
 ```
-nameserver 127.0.0.1
+sudo cp ~/govuk/govuk-docker/config/dnsmasq.conf /etc/resolver/dev.gov.uk
 ```
 
 To check if the new config has been applied, you can run `scutil --dns` to check that `dev.gov.uk` appears in the list.


### PR DESCRIPTION
Add How to guides for installation/setup issues, mainly for new
machines. Amend Dnsmasq manual setup instructions to reflect
error messages shown if file is out-of-date.