### PR TITLE
Remove auto-env feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,14 @@ govuk-docker compose up -d mongo
 govuk-docker compose run mongo mongorestore --drop --db content-store /import/var/lib/mongodb/backup/mongodump/content_store_production/
 ```
 
+### How to: set environment variables
+
+While most environment variables should be set in the config for a service, sometimes it's necessary to set assign one or more variables at the point of running a command, such as a Rake task. This can be done using `env` e.g.
+
+```
+govuk-docker run content-publisher-lite env MY_VAR=my_val bundle exec rake my_task
+```
+
 ## Licence
 
 [MIT License](LICENCE)

--- a/lib/govuk_docker/commands/run.rb
+++ b/lib/govuk_docker/commands/run.rb
@@ -9,7 +9,7 @@ class GovukDocker::Commands::Run < GovukDocker::Commands::Base
     GovukDocker::Commands::Compose
       .new(config_directory: config_directory, service: service, stack: stack, verbose: verbose)
       .call(
-        ["run", "--rm", "--service-ports", container_name] + docker_compose_args(args),
+        ["run", "--rm", "--service-ports", container_name] + args,
       )
   end
 
@@ -19,12 +19,5 @@ private
 
   def container_name
     "#{service}-#{stack}"
-  end
-
-  def docker_compose_args(args)
-    return [] if args.empty?
-    return args if args.first == "env"
-
-    %w[env] + args
   end
 end

--- a/spec/commands/run_spec.rb
+++ b/spec/commands/run_spec.rb
@@ -35,20 +35,9 @@ describe GovukDocker::Commands::Run do
     context "with some extra arguments" do
       let(:args) { %w[bundle exec rake lint] }
 
-      it "should run docker compose using the `env` command" do
+      it "should run docker compose" do
         expect(compose_command).to receive(:call).with(
-          ["run", "--rm", "--service-ports", "example-service-lite", "env", "bundle", "exec", "rake", "lint"],
-        )
-        subject.call(args)
-      end
-    end
-
-    context "with an env command" do
-      let(:args) { %w[env bundle exec rake lint] }
-
-      it "should run docker compose without duplicating `env`" do
-        expect(compose_command).to receive(:call).with(
-          ["run", "--rm", "--service-ports", "example-service-lite", "env", "bundle", "exec", "rake", "lint"],
+          ["run", "--rm", "--service-ports", "example-service-lite", "bundle", "exec", "rake", "lint"],
         )
         subject.call(args)
       end


### PR DESCRIPTION
https://trello.com/c/Ql2qx0Qm/107-investigate-going-back-to-a-thin-wrapper-for-day-to-day-commands

Previously each 'run' command allowed the user to assign environment
variables by automatically wrapping user command in 'env'. This replaces
the automated use of 'env' with a how-to article, so that the technique
is better documented, while having a lower code footprint for the
limited number of occasions when it is actually used.