### PR TITLE
Remove hostname printer

### DIFF
--- a/lib/govuk_docker/commands/startup.rb
+++ b/lib/govuk_docker/commands/startup.rb
@@ -1,7 +1,3 @@
-require "colorize"
-require "net/http"
-require "timeout"
-
 require_relative "./base"
 require_relative "./run"
 
@@ -9,69 +5,8 @@ class GovukDocker::Commands::Startup < GovukDocker::Commands::Base
   def call(variation = nil)
     stack = variation ? "app-#{variation}" : "app"
 
-    print_live_hostname
-
     GovukDocker::Commands::Run
       .new(config_directory: config_directory, service: service, stack: stack, verbose: verbose)
       .call
-  end
-
-private
-
-  def print_live_hostname
-    return unless hostname
-
-    Thread.new do
-      url = "http://#{hostname}"
-
-      Timeout::timeout(30) do
-        wait_until_can_visit?(url)
-
-        puts
-        puts "Application is available at: #{url}".blue
-        puts "\n\r"
-      end
-    rescue Timeout::Error
-      puts
-      puts "Warning: Unable to communicate with application within 30 seconds.".red
-      puts "\n\r"
-    end
-  end
-
-  def possible_hostnames
-    path = File.join(config_directory, "services", "nginx-proxy", "docker-compose.yml")
-    docker_compose = YAML.load_file(path)
-    docker_compose["services"]["nginx-proxy-app"]["networks"]["default"]["aliases"]
-  end
-
-  def find_hostname
-    search_hostname = "#{service.tr('_-', '')}.dev.gov.uk"
-    possible_hostnames.each do |hostname|
-      return hostname if hostname.tr("_-", "") == search_hostname
-    end
-
-    nil
-  end
-
-  def hostname
-    @hostname ||= find_hostname
-  end
-
-  def wait_until_can_visit?(url)
-    loop do
-      sleep(1)
-      break if can_visit?(url)
-    end
-  end
-
-  def can_visit?(url)
-    case Net::HTTP.get_response(URI(url))
-    when Net::HTTPSuccess, Net::HTTPRedirection
-      true
-    else
-      false
-    end
-  rescue Errno::EHOSTDOWN, Errno::ECONNREFUSED
-    false
   end
 end

--- a/spec/commands/startup_spec.rb
+++ b/spec/commands/startup_spec.rb
@@ -10,8 +10,6 @@ describe GovukDocker::Commands::Startup do
   before { allow(run_double).to receive(:call) }
 
   before do
-    allow(Thread).to receive(:new).and_yield # to run the thread in the current context
-    allow(subject).to receive(:wait_until_can_visit?).and_return(true)
     allow(subject).to receive(:puts)
   end
 
@@ -27,12 +25,5 @@ describe GovukDocker::Commands::Startup do
       expect(GovukDocker::Commands::Run).to receive(:new).with(a_hash_including(stack: "app-e2e")).and_return(run_double)
       subject.call("e2e")
     end
-  end
-
-  it "prints the URL of the app" do
-    expect(GovukDocker::Commands::Run).to receive(:new).with(a_hash_including(stack: "app")).and_return(run_double)
-    expect(subject).to receive(:wait_until_can_visit?).and_return(true)
-    expect(subject).to receive(:puts).with("\e[0;34;49mApplication is available at: http://example_service.dev.gov.uk\e[0m")
-    subject.call
   end
 end


### PR DESCRIPTION
https://trello.com/c/Ql2qx0Qm/107-investigate-going-back-to-a-thin-wrapper-for-day-to-day-commands

Previously we added a helper thread to indicate where a started app
would be available. Initially the output from this thread confused me,
as it looked like it was coming from the app itself, as opposed to
govuk-docker. Despite rescuing an increasing number of exceptions,
it also still seems to error for me, or print output prematurely.
This removes the helper thread, on the basis that most domains should be
intuitive if the user has previously visited one for another app.