### PR TITLE
Align better with docker-compose for startup cmd

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ For a full list of govuk-docker commands, run `govuk-docker help`.
 ## Stacks
 
 Each service provides a number of different 'stacks' which you can use to run
-the app. To provide consistency we have a convention for these names:
+the app. You can see the stacks for a service in its [config file](services/content-publisher/docker-compose.yml).
+To provide consistency we have a convention for these names:
 
 - **lite**: This stack provides only the minimum number of dependencies to run
   the application code. This is useful for running the tests, or a Rails

--- a/lib/govuk_docker/commands/run.rb
+++ b/lib/govuk_docker/commands/run.rb
@@ -9,7 +9,7 @@ class GovukDocker::Commands::Run < GovukDocker::Commands::Base
     GovukDocker::Commands::Compose
       .new(config_directory: config_directory, service: service, stack: stack, verbose: verbose)
       .call(
-        ["run", "--rm", "--service-ports", container_name] + args,
+        ["run", "--rm", container_name] + args,
       )
   end
 

--- a/lib/govuk_docker/commands/startup.rb
+++ b/lib/govuk_docker/commands/startup.rb
@@ -4,9 +4,10 @@ require_relative "./run"
 class GovukDocker::Commands::Startup < GovukDocker::Commands::Base
   def call(variation = nil)
     stack = variation ? "app-#{variation}" : "app"
+    container_name = "#{service}-#{stack}"
 
-    GovukDocker::Commands::Run
+    GovukDocker::Commands::Compose
       .new(config_directory: config_directory, service: service, stack: stack, verbose: verbose)
-      .call
+      .call(["up", container_name])
   end
 end

--- a/spec/commands/run_spec.rb
+++ b/spec/commands/run_spec.rb
@@ -26,7 +26,7 @@ describe GovukDocker::Commands::Run do
 
       it "should run docker compose" do
         expect(compose_command).to receive(:call).with(
-          ["run", "--rm", "--service-ports", "example-service-lite"],
+          ["run", "--rm", "example-service-lite"],
         )
         subject.call(args)
       end
@@ -37,7 +37,7 @@ describe GovukDocker::Commands::Run do
 
       it "should run docker compose" do
         expect(compose_command).to receive(:call).with(
-          ["run", "--rm", "--service-ports", "example-service-lite", "bundle", "exec", "rake", "lint"],
+          ["run", "--rm", "example-service-lite", "bundle", "exec", "rake", "lint"],
         )
         subject.call(args)
       end

--- a/spec/commands/startup_spec.rb
+++ b/spec/commands/startup_spec.rb
@@ -6,23 +6,25 @@ describe GovukDocker::Commands::Startup do
 
   subject { described_class.new(config_directory: config_directory, service: "example-service") }
 
-  let(:run_double) { instance_double(GovukDocker::Commands::Run) }
-  before { allow(run_double).to receive(:call) }
+  let(:compose_command) { double }
 
   before do
     allow(subject).to receive(:puts)
+
+    expect(GovukDocker::Commands::Compose).to receive(:new)
+      .with(a_hash_including(config_directory: config_directory)).and_return(compose_command)
   end
 
   context "without a variation" do
     it "calls `Run` in the correct stack" do
-      expect(GovukDocker::Commands::Run).to receive(:new).with(a_hash_including(stack: "app")).and_return(run_double)
+      expect(compose_command).to receive(:call).with(%w[up example-service-app])
       subject.call
     end
   end
 
   context "with a variation" do
     it "calls `Run` in the correct stack" do
-      expect(GovukDocker::Commands::Run).to receive(:new).with(a_hash_including(stack: "app-e2e")).and_return(run_double)
+      expect(compose_command).to receive(:call).with(%w[up example-service-app-e2e])
       subject.call("e2e")
     end
   end


### PR DESCRIPTION
https://trello.com/c/Ql2qx0Qm/107-investigate-going-back-to-a-thin-wrapper-for-day-to-day-commands

Previously we delegated to 'docker-compose run' when attempting to
'startup' an app, which is at odds with the conventional use of the
'docker-compose up' command for this purpose. Our over-use of 'run'
lead to some confusion:

   - 'run' recommends out the 'lite' stack when invoked via 'startup'
with a typoed variant
   - 'run' has a '--service-ports' flag, which only applies when
invoked via 'startup'

This switches the 'startup' command to do a 'docker-compose up',
which removes the need for the (now implicit) '--service-ports' flag,
and the point of confusion around recommending a 'lite' stack for
startup. Instead, the documentation now has more explanation.