### PR TITLE
Remove Elasticsearch 5 from Docker builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ volumes:
   mysql:
   mongo:
   go:
-  elasticsearch5:
   elasticsearch6:
 
 services:
@@ -43,16 +42,6 @@ services:
     image: rabbitmq
     volumes:
       - rabbitmq:/var/lib/rabbitmq
-
-  elasticsearch5:
-    image: elasticsearch:5.6.14
-    environment:
-      - http.host=0.0.0.0
-      - transport.host=127.0.0.1
-      - xpack.security.enabled=false
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
-    volumes:
-      - elasticsearch5:/usr/share/elasticsearch/data
 
   elasticsearch6:
     image: elasticsearch:6.7.0

--- a/services/search-api/docker-compose.yml
+++ b/services/search-api/docker-compose.yml
@@ -24,7 +24,6 @@ services:
     depends_on:
       - redis
       - rabbitmq
-      - elasticsearch5
       - elasticsearch6
 
   search-api-app: &search-api-app
@@ -32,7 +31,6 @@ services:
     depends_on:
       - nginx-proxy-app
       - redis
-      - elasticsearch5
       - elasticsearch6
     environment:
       REDIS_HOST: redis
@@ -54,7 +52,6 @@ services:
     depends_on:
       - redis
       - rabbitmq
-      - elasticsearch5
       - elasticsearch6
     command: bundle exec sidekiq -C ./config/sidekiq.yml
 
@@ -81,7 +78,6 @@ services:
     depends_on:
       - nginx-proxy-app
       - redis
-      - elasticsearch5
       - elasticsearch6
       - search-api-worker
       - search-api-listener-publishing-queue


### PR DESCRIPTION
As we're no longer relying on ES5 for our backend, running it in
Docker is an added weight we do not need. This removes the
requirement to run ES5 when running anything relying on
Search API in Docker.

Trello card: https://trello.com/c/zDmQgHQp/1039-remove-es5-from-govuk-docker-publishing-e2e-tests-and-ci