### PR TITLE
Remove ELASTICSEARCH_B_URI variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,7 @@ The following apps are supported by govuk-docker to some extent.
    - ✅ router
    - ✅ router-api
    - ✅ search-admin
-   - ⚠  search-api
-      * Tests fail as they run against [both Elasticsearch instances](https://github.com/alphagov/search-api/pull/1618)
+   - ✅ search-api
    - ✅ service-manual-frontend
    - ✅ short-url-manager
    - ✅ signon

--- a/services/search-api/docker-compose.yml
+++ b/services/search-api/docker-compose.yml
@@ -15,8 +15,7 @@ x-search-api: &search-api
     RABBITMQ_USER: guest
     RABBITMQ_PASSWORD: guest
     REDIS_HOST: redis
-    ELASTICSEARCH_URI: http://elasticsearch5:9200
-    ELASTICSEARCH_B_URI: http://elasticsearch6:9200
+    ELASTICSEARCH_URI: http://elasticsearch6:9200
 
 services:
   search-api-lite:
@@ -34,8 +33,7 @@ services:
       - elasticsearch6
     environment:
       REDIS_HOST: redis
-      ELASTICSEARCH_URI: http://elasticsearch5:9200
-      ELASTICSEARCH_B_URI: http://elasticsearch6:9200
+      ELASTICSEARCH_URI: http://elasticsearch6:9200
       VIRTUAL_HOST: search-api.dev.gov.uk, search.dev.gov.uk
       HOST: 0.0.0.0
     ports:


### PR DESCRIPTION
[Trello card](https://trello.com/c/KhQTxJz7/1040-tidy-the-mess-caused-by-retiring-es5)