### PR TITLE
Add missing deps for collections-publisher-e2e

### DIFF
--- a/services/collections-publisher/docker-compose.yml
+++ b/services/collections-publisher/docker-compose.yml
@@ -55,4 +55,9 @@ services:
   collections-publisher-app-e2e:
     <<: *collections-publisher-app
     depends_on:
+      - redis
+      - mysql
+      - content-store-app
+      - link-checker-api-app
+      - nginx-proxy-app
       - collections-publisher-worker


### PR DESCRIPTION
Previously we overwrote the collections-publisher-app dependencies with
just 'collections-publisher-worker', missing out a couple of necessary
services that are included with the 'app' stack. This adds the missing
dependencies that aren't already provided by 'publishing-api-e2e'.