### PR TITLE
Extract compatibility list into a separate doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,18 @@ The GOV.UK website uses a microservice architecture. Developing in this ecosyste
 
 The aim of govuk-docker is to make it easy to develop any GOV.UK app. It achieves this by providing a variety of environments or _stacks_ for each app, in which you can run tests, start a debugger, publish a document end-to-end.
 
+See [here](docs/compatibility.md) for a list of which services work with govuk-docker.
+
 ## Background
 
 [RFC 106: Use Docker for local development](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-106-docker-for-local-development.md) describes the background for choosing Docker.
 
 ## Usage
 
-Clone your desired [service](#compatibility) into your `~/govuk` folder, e.g. collections-publisher.
-
 Do this to run the tests for a service:
 
 ```sh
+# You may need to clone the service first
 cd ~/govuk/collections-publisher
 
 # You only need to do this once per service
@@ -95,67 +96,6 @@ Both govuk-docker and the Makefile respect the following environment variables:
 - `$GOVUK_ROOT_DIR` - directory where app repositories live, defaults to `$HOME/govuk`
 - `$GOVUK_DOCKER_DIR` - directory where the govuk-docker repository lives, defaults to `$GOVUK_ROOT_DIR/govuk-docker`
 - `$GOVUK_DOCKER` - path of the govuk-docker script, defaults to `$GOVUK_DOCKER_DIR/bin/govuk-docker`
-
-## Compatibility
-
-The following apps are supported by govuk-docker to some extent.
-
-   - ✅ asset-manager
-   - ⚠ cache-clearing-service
-      * Tests pass
-      * Queues are not set-up, so cache-clearing-service can't be run locally
-   - ⚠ calculators
-      * Web UI doesn't work without the content item being present in the content-store.
-   - ✅ calendars
-   - ⚠  collections
-      * You will need to [populate the Content Store database](#mongodb) or run the live stack in order for it to work locally.
-      * To view topic pages locally you still need to use the live stack as they rely on Elasticsearch data which we are yet to be able to import.
-   - ✅ collections-publisher
-   - ⚠ content-data-admin
-      * **TODO: Missing support for a webserver stack**
-   - ✅ content-publisher
-   - ✅ content-store
-   - ✅ content-tagger
-   - ✅ email-alert-api
-   - ✅ email-alert-frontend
-   - ✅ finder-frontend
-   - ❌ frontend
-   - ✅ government-frontend
-   - ✅ govspeak
-   - ✅ govuk_app_config
-   - ✅ govuk_publishing_components
-   - ✅ govuk-cdn-config
-   - ❓ govuk-content-schemas
-      * Service exists in govuk-docker but is untested
-   - ✅ govuk-developer-docs
-   - ✅ govuk-lint
-   - ✅ info-frontend
-   - ⚠ link-checker-api
-      * Works in isolation but not in other services' `e2e` stacks, so must be run in a separate process.
-        See https://github.com/alphagov/govuk-docker/issues/174 for details.
-   - ✅ manuals-frontend
-   - ✅ miller-columns-element
-   - ✅ plek
-   - ✅ publisher
-   - ✅ publishing-api
-   - ✅ router
-   - ✅ router-api
-   - ✅ search-admin
-   - ✅ search-api
-   - ✅ service-manual-frontend
-   - ✅ short-url-manager
-   - ✅ signon
-   - ✅ smart-answers
-   - ✅ specialist-publisher
-   - ⚠ static
-      * JavaScript 404 errors when previewing pages, possibly [related to analytics](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/init.js.erb#L28)
-   - ✅ support
-   - ✅ support-api
-   - ✅ travel-advice-publisher
-   - ⚠ whitehall
-      * Who knows, really - several tests are failing, lots pass ;-)
-      * Rake task to [create a test taxon](https://github.com/alphagov/whitehall/blob/master/lib/tasks/taxonomy.rake#L11) for publishing is not idempotent
-      * Placeholder images don't work as missing proxy for [/government/assets](https://github.com/alphagov/whitehall/blob/master/app/presenters/publishing_api/news_article_presenter.rb#L133)
 
 ## Stacks
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,60 @@
+# Compatibility
+
+The following apps are supported by govuk-docker to some extent.
+
+   - ✅ asset-manager
+   - ⚠ cache-clearing-service
+      * Tests pass
+      * Queues are not set-up, so cache-clearing-service can't be run locally
+   - ⚠ calculators
+      * Web UI doesn't work without the content item being present in the content-store.
+   - ✅ calendars
+   - ⚠  collections
+      * You will need to [populate the Content Store database](#mongodb) or run the live stack in order for it to work locally.
+      * To view topic pages locally you still need to use the live stack as they rely on Elasticsearch data which we are yet to be able to import.
+   - ✅ collections-publisher
+   - ⚠ content-data-admin
+      * **TODO: Missing support for a webserver stack**
+   - ✅ content-publisher
+   - ✅ content-store
+   - ✅ content-tagger
+   - ✅ email-alert-api
+   - ✅ email-alert-frontend
+   - ✅ finder-frontend
+   - ❌ frontend
+   - ✅ government-frontend
+   - ✅ govspeak
+   - ✅ govuk_app_config
+   - ✅ govuk_publishing_components
+   - ✅ govuk-cdn-config
+   - ❓ govuk-content-schemas
+      * Service exists in govuk-docker but is untested
+   - ✅ govuk-developer-docs
+   - ✅ govuk-lint
+   - ✅ info-frontend
+   - ⚠ link-checker-api
+      * Works in isolation but not in other services' `e2e` stacks, so must be run in a separate process.
+        See https://github.com/alphagov/govuk-docker/issues/174 for details.
+   - ✅ manuals-frontend
+   - ✅ miller-columns-element
+   - ✅ plek
+   - ✅ publisher
+   - ✅ publishing-api
+   - ✅ router
+   - ✅ router-api
+   - ✅ search-admin
+   - ✅ search-api
+   - ✅ service-manual-frontend
+   - ✅ short-url-manager
+   - ✅ signon
+   - ✅ smart-answers
+   - ✅ specialist-publisher
+   - ⚠ static
+      * JavaScript 404 errors when previewing pages, possibly [related to analytics](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/init.js.erb#L28)
+   - ✅ support
+   - ✅ support-api
+   - ✅ travel-advice-publisher
+   - ⚠ whitehall
+      * Who knows, really - several tests are failing, lots pass ;-)
+      * Rake task to [create a test taxon](https://github.com/alphagov/whitehall/blob/master/lib/tasks/taxonomy.rake#L11) for publishing is not idempotent
+      * Placeholder images don't work as missing proxy for [/government/assets](https://github.com/alphagov/whitehall/blob/master/app/presenters/publishing_api/news_article_presenter.rb#L133)


### PR DESCRIPTION
I'm finding the length of the README is now quite daunting - it actually
takes some effort to scroll from top-to-bottom! This extracts one of the
long sections - a list of service compatibility - into a separate doc,
with the assumption/hope that it's not vital, day-to-day information.