### PR TITLE
Fix links

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,7 +39,7 @@ bundle install
 govuk-docker setup
 ```
 
-You can now [clone and setup the apps you need](#Usage), after which you can do things like run tests and startup the app in your browser. If this doesn't work for whatever reason, follow the [instructions on how to resolve setup issues](#how-to-resolve-setup-issues).
+You can now [clone and setup the apps you need](../README.md#Usage), after which you can do things like run tests and startup the app in your browser. If this doesn't work for whatever reason, follow the [instructions on how to resolve setup issues](#how-tos).
 
 ## Environment variables
 


### PR DESCRIPTION
A couple of links were pointing to the wrong place since migrating
out of the README file.