### PR TITLE
Add license-finder service

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -42,7 +42,7 @@ The following apps are supported by govuk-docker to some extent.
    - ❌ hmrc-manuals-api
    - ❌ imminence
    - ✅ info-frontend
-   - ❌ licence-finder
+   - ✅ licence-finder
    - ⚠ link-checker-api
       * Works in isolation but not in other services' `e2e` stacks, so must be run in a separate process.
         See https://github.com/alphagov/govuk-docker/issues/174 for details.

--- a/services/licence-finder/Makefile
+++ b/services/licence-finder/Makefile
@@ -1,0 +1,2 @@
+licence-finder: bundle-licence-finder static content-store
+	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/licence-finder/docker-compose.yml
+++ b/services/licence-finder/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.7'
+
+x-licence-finder: &licence-finder
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: licence-finder
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - home:/home/build
+  working_dir: /govuk/licence-finder
+
+services:
+  licence-finder-lite: &licence-finder-lite
+    <<: *licence-finder
+    privileged: true
+    depends_on:
+      - mongo
+      - elasticsearch6
+    environment:
+      MONGODB_URI: "mongodb://mongo/licence-finder_development"
+      ELASTICSEARCH_URI: http://elasticsearch6:9200
+
+  licence-finder-app:
+    <<: *licence-finder
+    depends_on:
+      - mongo
+      - redis
+      - static-app
+      - elasticsearch6
+      - content-store-app
+      - nginx-proxy-app
+    environment:
+      REDIS_URL: redis://redis
+      VIRTUAL_HOST: licence-finder.dev.gov.uk
+      MONGODB_URI: "mongodb://mongo/licence-finder_development"
+      ELASTICSEARCH_URI: http://elasticsearch6:9200
+      PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
+      HOST: 0.0.0.0
+    ports:
+      - "3000"
+    command: bin/rails s --restart

--- a/services/licence-finder/docker-compose.yml
+++ b/services/licence-finder/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - mongo
       - elasticsearch6
     environment:
-      MONGODB_URI: "mongodb://mongo/licence-finder_development"
+      MONGODB_URI: "mongodb://mongo/licence-finder_test"
       ELASTICSEARCH_URI: http://elasticsearch6:9200
 
   licence-finder-app:

--- a/services/licence-finder/docker-compose.yml
+++ b/services/licence-finder/docker-compose.yml
@@ -18,7 +18,8 @@ services:
       - mongo
       - elasticsearch6
     environment:
-      MONGODB_URI: "mongodb://mongo/licence-finder_test"
+      MONGODB_URI: "mongodb://mongo/licence-finder_development"
+      TEST_MONGODB_URI: "mongodb://mongo/licence-finder_test"
       ELASTICSEARCH_URI: http://elasticsearch6:9200
 
   licence-finder-app:

--- a/services/nginx-proxy/docker-compose.yml
+++ b/services/nginx-proxy/docker-compose.yml
@@ -40,6 +40,7 @@ services:
           - govuk-developer-docs.dev.gov.uk
           - govuk-publishing-components.dev.gov.uk
           - info-frontend.dev.gov.uk
+          - licence-finder.dev.gov.uk
           - link-checker-api.dev.gov.uk
           - manuals-frontend.dev.gov.uk
           - publisher.dev.gov.uk


### PR DESCRIPTION
The app needs the govuk_publishing_components updated and
was not added as a service before, hampering local development.

![licence-finder dev gov uk_licence-finder_sectors (1)](https://user-images.githubusercontent.com/424772/68054331-f3d45500-fce5-11e9-9bc0-e2f2a5e950f7.png)

## Trello cards

* https://trello.com/c/hL2TREil
* https://trello.com/c/auN1ZBy2