### PR TITLE
Add SSH command

### DIFF
--- a/lib/govuk_docker/cli.rb
+++ b/lib/govuk_docker/cli.rb
@@ -4,6 +4,7 @@ require_relative "./commands/build"
 require_relative "./commands/compose"
 require_relative "./commands/prune"
 require_relative "./commands/run"
+require_relative "./commands/ssh"
 require_relative "./commands/startup"
 require_relative "./doctor/doctor"
 require_relative "./doctor/checkup"
@@ -97,6 +98,20 @@ class GovukDocker::CLI < Thor
   LONGDESC
   def run(*args)
     GovukDocker::Commands::Run.new(options).call(args)
+  end
+
+  desc "ssh [VARIATION]", "ssh into a running container for a service"
+  long_desc <<~LONGDESC
+    By default, it opens a shell for the service in the `app` stack
+
+    It can run a different stack if specified (e.g. `govuk-docker ssh lite`).
+
+    Examples
+
+    cd ~/govuk/search-api; govuk-docker ssh draft
+  LONGDESC
+  def ssh(variation = nil)
+    GovukDocker::Commands::Ssh.new(options).call(variation)
   end
 
   desc "setup", "Configures and installs the various dependencies necessary to run `govuk-docker` successfully"

--- a/lib/govuk_docker/commands/ssh.rb
+++ b/lib/govuk_docker/commands/ssh.rb
@@ -1,0 +1,13 @@
+require_relative "./base"
+require_relative "./run"
+
+class GovukDocker::Commands::Ssh < GovukDocker::Commands::Base
+  def call(variation = nil)
+    stack = variation || "app"
+    container_name = "#{service}-#{stack}"
+
+    GovukDocker::Commands::Compose
+      .new(config_directory: config_directory, service: service, stack: stack, verbose: verbose)
+      .call(["exec", container_name, "/bin/bash"])
+  end
+end

--- a/spec/commands/ssh_spec.rb
+++ b/spec/commands/ssh_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+require_relative "../../lib/govuk_docker/commands/startup"
+
+describe GovukDocker::Commands::Ssh do
+  let(:config_directory) { "spec/fixtures" }
+
+  subject { described_class.new(config_directory: config_directory, service: "example-service") }
+
+  let(:compose_command) { double }
+
+  before do
+    allow(subject).to receive(:puts)
+
+    expect(GovukDocker::Commands::Compose).to receive(:new)
+      .with(a_hash_including(config_directory: config_directory)).and_return(compose_command)
+  end
+
+  context "without a variation" do
+    it "ssh's into the correct stack" do
+      expect(compose_command).to receive(:call).with(%w[exec example-service-app /bin/bash])
+      subject.call
+    end
+  end
+
+  context "with a variation" do
+    it "ssh's into the specified stack" do
+      expect(compose_command).to receive(:call).with(%w[exec example-service-e2e /bin/bash])
+      subject.call("e2e")
+    end
+  end
+end


### PR DESCRIPTION
This enables users to open a shell in a running container in a given stack.

The use case is that one would like to do various things in a running container. There is the run command but it is nicer to have a shell to work in directly.

Usage:

```
govuk-docker ssh
```

This will start up a bash shell in the running container.

https://trello.com/c/bEEvYDFc/110-ssh-command