### PR TITLE
Auto-cleanup pidfile when rails starts

### DIFF
--- a/services/asset-manager/docker-compose.yml
+++ b/services/asset-manager/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   asset-manager-app-e2e:
     <<: *asset-manager-app

--- a/services/calculators/docker-compose.yml
+++ b/services/calculators/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       HOST: 0.0.0.0
 
   calculators-app-live:
-    <<: *calculators
+    <<: *calculators-app
     depends_on:
       - nginx-proxy-app
     environment:
@@ -52,6 +52,3 @@ services:
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: calculators.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
-      - "3000"
-    command: bin/rails s -P /tmp/rails.pid

--- a/services/calculators/docker-compose.yml
+++ b/services/calculators/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   calculators-app-draft:
     <<: *calculators-app

--- a/services/calendars/docker-compose.yml
+++ b/services/calendars/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   calendars-app-draft:
     <<: *calendars-app

--- a/services/calendars/docker-compose.yml
+++ b/services/calendars/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - publishing-api-app-e2e
 
   calendars-app-live:
-    <<: *calendars
+    <<: *calendars-app
     depends_on:
       - nginx-proxy-app
     environment:
@@ -57,4 +57,3 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid

--- a/services/collections-publisher/docker-compose.yml
+++ b/services/collections-publisher/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   collections-publisher-worker:
     <<: *collections-publisher

--- a/services/collections/docker-compose.yml
+++ b/services/collections/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       HOST: 0.0.0.0
 
   collections-app-live:
-    <<: *collections
+    <<: *collections-app
     depends_on:
       - nginx-proxy-app
     environment:
@@ -54,6 +54,3 @@ services:
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: collections.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
-      - "3000"
-    command: bin/rails s -P /tmp/rails.pid

--- a/services/collections/docker-compose.yml
+++ b/services/collections/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   # TODO: this doesn't work yet because collections also relies on search-api
   collections-app-draft:

--- a/services/content-publisher/docker-compose.yml
+++ b/services/content-publisher/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   content-publisher-app-e2e:
     <<: *content-publisher-app

--- a/services/content-store/docker-compose.yml
+++ b/services/content-store/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   content-store-app-draft:
     <<: *content-store-app

--- a/services/content-tagger/docker-compose.yml
+++ b/services/content-tagger/docker-compose.yml
@@ -35,4 +35,4 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart

--- a/services/email-alert-api/docker-compose.yml
+++ b/services/email-alert-api/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   email-alert-api-worker:
     <<: *email-alert-api

--- a/services/email-alert-frontend/docker-compose.yml
+++ b/services/email-alert-frontend/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   email-alert-frontend-app-live:
     <<: *email-alert-frontend-app

--- a/services/finder-frontend/docker-compose.yml
+++ b/services/finder-frontend/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       MEMCACHE_SERVERS: memcached
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   finder-frontend-app-live:
     <<: *finder-frontend-app

--- a/services/frontend/docker-compose.yml
+++ b/services/frontend/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   frontend-setup:
     <<: *frontend

--- a/services/government-frontend/docker-compose.yml
+++ b/services/government-frontend/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       HOST: 0.0.0.0
 
   government-frontend-app-live:
-    <<: *government-frontend
+    <<: *government-frontend-app
     depends_on:
       - nginx-proxy-app
     environment:
@@ -51,6 +51,3 @@ services:
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: government-frontend.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
-      - "3000"
-    command: bin/rails s -P /tmp/rails.pid

--- a/services/government-frontend/docker-compose.yml
+++ b/services/government-frontend/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   government-frontend-app-draft:
     <<: *government-frontend-app

--- a/services/info-frontend/docker-compose.yml
+++ b/services/info-frontend/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.7'
 
-x-tmp: &info-frontend-base
+x-tmp: &info-frontend
   build:
     context: .
     dockerfile: Dockerfile.govuk-base
@@ -12,10 +12,10 @@ x-tmp: &info-frontend-base
 
 services:
   info-frontend-lite:
-    <<: *info-frontend-base
+    <<: *info-frontend
 
-  info-frontend-app:
-    <<: *info-frontend-base
+  info-frontend-app: &info-frontend-app
+    <<: *info-frontend
     depends_on:
       - router-app
       - content-store-app
@@ -29,7 +29,7 @@ services:
     command: bin/rails s -P /tmp/rails.pid
 
   info-frontend-app-live:
-    <<: *info-frontend-base
+    <<: *info-frontend-app
     depends_on:
       - nginx-proxy-app
     environment:
@@ -38,6 +38,3 @@ services:
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: info-frontend.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
-      - "3000"
-    command: bin/rails s -P /tmp/rails.pid

--- a/services/link-checker-api/docker-compose.yml
+++ b/services/link-checker-api/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   link-checker-api-worker:
     <<: *link-checker-api

--- a/services/manuals-frontend/docker-compose.yml
+++ b/services/manuals-frontend/docker-compose.yml
@@ -27,10 +27,10 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   manuals-frontend-app-draft:
-    <<: *manuals-frontend
+    <<: *manuals-frontend-app
     depends_on:
       - router-app-draft
       - content-store-app-draft
@@ -40,12 +40,9 @@ services:
       VIRTUAL_HOST: draft-manuals-frontend.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"
       HOST: 0.0.0.0
-    ports:
-      - "3000"
-    command: bin/rails s -P /tmp/rails.pid
 
   manuals-frontend-app-live:
-    <<: *manuals-frontend
+    <<: *manuals-frontend-app
     depends_on:
       - nginx-proxy-app
     environment:
@@ -54,6 +51,3 @@ services:
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: manuals-frontend.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
-      - "3000"
-    command: bin/rails s -P /tmp/rails.pid

--- a/services/publisher/docker-compose.yml
+++ b/services/publisher/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   publisher-app-e2e:
     <<: *publisher-app

--- a/services/publishing-api/docker-compose.yml
+++ b/services/publishing-api/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   publishing-api-app-e2e:
     <<: *publishing-api-app

--- a/services/router-api/docker-compose.yml
+++ b/services/router-api/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   router-api-app-draft:
     <<: *router-api-app

--- a/services/search-admin/docker-compose.yml
+++ b/services/search-admin/docker-compose.yml
@@ -37,4 +37,4 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart

--- a/services/service-manual-frontend/docker-compose.yml
+++ b/services/service-manual-frontend/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   service-manual-frontend-app-draft:
     <<: *service-manual-frontend-app

--- a/services/service-manual-frontend/docker-compose.yml
+++ b/services/service-manual-frontend/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.7'
 
-x-service-manual-frontend: &service-manual-frontend-base
+x-service-manual-frontend: &service-manual-frontend
   build:
     context: .
     dockerfile: Dockerfile.govuk-base
@@ -12,10 +12,10 @@ x-service-manual-frontend: &service-manual-frontend-base
 
 services:
   service-manual-frontend-lite:
-    <<: *service-manual-frontend-base
+    <<: *service-manual-frontend
 
   service-manual-frontend-app: &service-manual-frontend-app
-    <<: *service-manual-frontend-base
+    <<: *service-manual-frontend
     depends_on:
       - router-app
       - content-store-app
@@ -41,7 +41,7 @@ services:
       HOST: 0.0.0.0
 
   service-manual-frontend-app-live:
-    <<: *service-manual-frontend-base
+    <<: *service-manual-frontend-app
     depends_on:
       - nginx-proxy-app
     environment:
@@ -50,6 +50,3 @@ services:
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: service-manual-frontend.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
-      - "3000"
-    command: bin/rails s -P /tmp/rails.pid

--- a/services/short-url-manager/docker-compose.yml
+++ b/services/short-url-manager/docker-compose.yml
@@ -36,4 +36,4 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart

--- a/services/signon/docker-compose.yml
+++ b/services/signon/docker-compose.yml
@@ -35,4 +35,4 @@ services:
       REDIS_HOST: redis
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart

--- a/services/smart-answers/docker-compose.yml
+++ b/services/smart-answers/docker-compose.yml
@@ -28,4 +28,4 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart

--- a/services/specialist-publisher/docker-compose.yml
+++ b/services/specialist-publisher/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   specialist-publisher-app-e2e:
     <<: *specialist-publisher-app

--- a/services/static/docker-compose.yml
+++ b/services/static/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   static-app-draft:
     <<: *static-app

--- a/services/support-api/docker-compose.yml
+++ b/services/support-api/docker-compose.yml
@@ -34,4 +34,4 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart

--- a/services/support/docker-compose.yml
+++ b/services/support/docker-compose.yml
@@ -30,4 +30,4 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart

--- a/services/travel-advice-publisher/docker-compose.yml
+++ b/services/travel-advice-publisher/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   travel-advice-publisher-app-e2e:
     <<: *travel-advice-publisher

--- a/services/whitehall/docker-compose.yml
+++ b/services/whitehall/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s -P /tmp/rails.pid
+    command: bin/rails s --restart
 
   whitehall-app-e2e:
     <<: *whitehall-app


### PR DESCRIPTION
https://trello.com/c/Ql2qx0Qm/107-investigate-going-back-to-a-thin-wrapper-for-day-to-day-commands

Previously we tried to use the container's /tmp directory to auto cleanup
the Puma pidfile when each app quits. Ideally Puma would be able to cleanup
the file itself, but sometimes the Docker process exits too quickly for
this to happen, which can cause future attempts to start the server to
error with 'A server is already running.'.

Switching to the docker-compose 'up' command has caused the '/tmp'
technique to stop working, since the web app container is no longer
destroyed when the process quits. This replaces the '/tmp' technique with
the rails server '--restart' flag, which does the necessary actions to
cleanup the pidfile before the server tries to start.

The '--restart' flag is primarily intended for use with the 'rake restart'
task, which touches 'tmp/restart.txt', which causes Puma to invoke 'rails
server' with this '--restart' flag. When a container fails to exit cleanly,
it seems reasonable to treat a subsequent attempt to start it again as a
restart, since it never truly stopped.