### PR TITLE
Add authenticating-proxy to services

### DIFF
--- a/services/authenticating-proxy/Makefile
+++ b/services/authenticating-proxy/Makefile
@@ -1,0 +1,2 @@
+authenticating-proxy: bundle-authenticating-proxy router
+	$(GOVUK_DOCKER) compose run $@-lite bin/rails runner 'User.first || User.create'

--- a/services/authenticating-proxy/docker-compose.yml
+++ b/services/authenticating-proxy/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.7'
+
+x-authenticating-proxy: &authenticating-proxy
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: authenticating-proxy
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - home:/home/build
+  working_dir: /govuk/authenticating-proxy
+
+services:
+  authenticating-proxy-lite:
+    <<: *authenticating-proxy
+    depends_on:
+      - mongo
+    environment:
+      GOVUK_UPSTREAM_URI: http://draft-origin.dev.gov.uk
+      MONGODB_URI: "mongodb://mongo/authenticating-proxy"
+      TEST_MONGODB_URI: "mongodb://mongo/authenticating-proxy-test"
+
+  authenticating-proxy-app: &authenticating-proxy-app
+    <<: *authenticating-proxy
+    depends_on:
+      - mongo
+      - nginx-proxy-app
+      - router-app-draft
+    environment:
+      GOVUK_UPSTREAM_URI: http://draft-origin.dev.gov.uk
+      MONGODB_URI: "mongodb://mongo/authenticating-proxy"
+      VIRTUAL_HOST: authenticating-proxy.dev.gov.uk
+      HOST: 0.0.0.0
+    ports:
+      - "3000"
+    command: bin/rails s --restart

--- a/services/nginx-proxy/docker-compose.yml
+++ b/services/nginx-proxy/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       default:
         aliases:
           - asset-manager.dev.gov.uk
+          - authenticating-proxy.dev.gov.uk
           - calculators.dev.gov.uk
           - calendars.dev.gov.uk
           - collections-publisher.dev.gov.uk


### PR DESCRIPTION
Depends on https://github.com/alphagov/authenticating-proxy/pull/167

This adds the authenticating-proxy app which can run in front of draft-router.
In order to run it against frontend apps they'll also need to be started
up as draft router doesn't have dependencies on them.

This resolves running authenticating-proxy in the default GDS SSO "mock"
mode. In order to run this with GDS SSO in "real" mode there needs to be
co-ordination between this authenticating-proxy and signon to share
oauth data, which was out of the scope of this change.