### PR TITLE
Fix incompatible 'restart' flag for Whitehall

### DIFF
--- a/services/whitehall/docker-compose.yml
+++ b/services/whitehall/docker-compose.yml
@@ -39,7 +39,8 @@ services:
       HOST: 0.0.0.0
     ports:
       - "3000"
-    command: bin/rails s --restart
+    # Change to 'bin/rails --restart' when rails >= 5.2
+    command: /bin/sh -c "rm -f tmp/pids/server.pid && rails s"
 
   whitehall-app-e2e:
     <<: *whitehall-app


### PR DESCRIPTION
Previously we began using the 'restart' flag with rails, to ensure rails
would clean up any previous pidfile when a container exits prematurely.
This replaces the 'restart' flag with a hacky workaround for Whitehall,
since it's currently on rails 5.1.7 and the 'restart' flag was only
introduced in version 5.2.