### PR TITLE
Revert "finder-frontend: depends_on publishing-api"

### DIFF
--- a/services/finder-frontend/docker-compose.yml
+++ b/services/finder-frontend/docker-compose.yml
@@ -24,7 +24,6 @@ services:
     depends_on:
       - router-app
       - content-store-app
-      - publishing-api-app
       - static-app
       - search-api-app-e2e
       - memcached


### PR DESCRIPTION
Reverts alphagov/govuk-docker#226

See https://github.com/alphagov/govuk-docker/pull/226#pullrequestreview-306466817 for context.