### PR TITLE
Clarifies that command removes all containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ make pull
 
 ### How to: clear your Docker containers
 
-Sometimes a service just doesn't work as expected, and the easiest thing to do is to start over. This command stops and removes all local govuk Docker containers:
+Sometimes a service just doesn't work as expected, and the easiest thing to do is to start over. This command stops and removes **all** local Docker containers:
 
 ```
 govuk-docker compose rm -sv


### PR DESCRIPTION
Edit to clarify that `govuk-docker compose rm -sv` removes all Docker containers, not just `govuk-docker` containers.