### PR TITLE
Remove redundant 'bundle' volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: '3.7'
 
 volumes:
   home:
-  bundle:
   rabbitmq:
   postgres:
   mysql:


### PR DESCRIPTION
This is no longer in use since we transitioned to rbenv, which has
its files in the 'home' volume (among its other uses).