### PR TITLE
Run shellcheck in `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 GOVUK_ROOT_DIR   ?= $(HOME)/govuk
 GOVUK_DOCKER_DIR ?= $(GOVUK_ROOT_DIR)/govuk-docker
 GOVUK_DOCKER     ?= $(GOVUK_DOCKER_DIR)/bin/govuk-docker
+SHELLCHECK       ?= shellcheck
 
 APPS ?= $(shell ls ${GOVUK_DOCKER_DIR}/services/*/Makefile | xargs -L 1 dirname | xargs -L 1 basename)
 
@@ -26,6 +27,9 @@ test:
 	# Test that the docker-compose config is valid. This will error if there are errors
 	# in the YAML files, or incompatible features are used.
 	$(GOVUK_DOCKER) compose config > /dev/null
+
+	# Validate shell scripts
+	$(SHELLCHECK) $(shell ls ${GOVUK_DOCKER_DIR}/bin/*.sh)
 
 # This will be slow and may repeat work, so generally you don't want
 # to run this.

--- a/bin/update-git-repo.sh
+++ b/bin/update-git-repo.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 
@@ -13,14 +13,15 @@ truncate () {
   local len="$1"
   local str="$2"
   if [ "${#str}" -gt "$len" ]; then
-    printf "$str" | awk "{ s=substr(\$0, 1, $len-3); print s \"...\"; }"
+    printf "%s" "$str" | awk "{ s=substr(\$0, 1, $len-3); print s \"...\"; }"
   else
-    printf "$str"
+    printf "%s" "$str"
   fi
 }
 
 catch_errors () {
-  out=$(mktemp -t update-git.XXXXXX)
+  local out=$(mktemp -t update-git.XXXXXX)
+  # shellcheck disable=SC2064
   trap "rm -f '$out'" EXIT
 
   if ! "$@" >"$out" 2>&1; then
@@ -42,17 +43,17 @@ start () {
 
 ok () {
   start "$REPO" "$BRANCH"
-  echo "${ANSI_GREEN}${@}${ANSI_RESET}" >&2
+  echo -e "${ANSI_GREEN}${*}${ANSI_RESET}" >&2
 }
 
 warn () {
   start "$REPO" "$BRANCH"
-  echo "${ANSI_YELLOW}${@}${ANSI_RESET}" >&2
+  echo -e "${ANSI_YELLOW}${*}${ANSI_RESET}" >&2
 }
 
 error () {
   start "$REPO" "$BRANCH"
-  echo "${ANSI_RED}${@}${ANSI_RESET}" >&2
+  echo -e "${ANSI_RED}${*}${ANSI_RESET}" >&2
 }
 
 if [ "$#" -ne "1" ]; then


### PR DESCRIPTION
[shellcheck](https://www.shellcheck.net/) is a static analyser / linter for shell scripts.

We currently have one shellscript in this repo, #220 adds a bunch for data replication, and #216 replaces `govuk-docker` with another.  That feels to me like enough shell that we should be linting it.  We have some precedent for running shellcheck in CI - eg, in [govuk-puppet](https://github.com/alphagov/govuk-puppet/blob/master/Jenkinsfile#L30).