### PR TITLE
Add nginx-proxy to static

### DIFF
--- a/services/static/docker-compose.yml
+++ b/services/static/docker-compose.yml
@@ -18,6 +18,7 @@ services:
     <<: *static
     depends_on:
       - redis
+      - nginx-proxy-app
     environment:
       REDIS_URL: redis://redis
       GOVUK_ASSET_ROOT: static.dev.gov.uk
@@ -31,6 +32,7 @@ services:
     <<: *static-app
     depends_on:
       - redis
+      - nginx-proxy-app
     environment:
       REDIS_URL: redis://redis
       GOVUK_ASSET_ROOT: draft-static.dev.gov.uk


### PR DESCRIPTION
If running static as a standalone service for debugging, it needs to
have nginx-proxy.