### PR TITLE
Make cloning check look for .git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ bundle-%: clone-%
 	$(GOVUK_DOCKER) run $*-lite bundle
 
 clone-%:
-	@if [ ! -d "${GOVUK_ROOT_DIR}/$*" ]; then \
+	@if [ ! -d "${GOVUK_ROOT_DIR}/$*/.git" ]; then \
 		echo "$*" && git clone "git@github.com:alphagov/$*.git" "${GOVUK_ROOT_DIR}/$*"; \
 	fi
 


### PR DESCRIPTION
https://github.com/alphagov/govuk-docker/issues/237

Previously we only checked for the existence of the top-level directory
before cloning a repo. This fixes an issue where the existence of an
empty directory causes the clone to be skipped.