### PR TITLE
Fix missing use of rake binstub in Makefiles

### DIFF
--- a/services/collections-publisher/Makefile
+++ b/services/collections-publisher/Makefile
@@ -1,3 +1,3 @@
 collections-publisher: bundle-collections-publisher publishing-api content-store link-checker-api
-	$(GOVUK_DOCKER) run $@-lite sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/services/publisher/Makefile
+++ b/services/publisher/Makefile
@@ -1,2 +1,2 @@
 publisher: bundle-publisher publishing-api calendars link-checker-api
-	$(GOVUK_DOCKER) run $@-lite sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/search-admin/Makefile
+++ b/services/search-admin/Makefile
@@ -1,3 +1,3 @@
 search-admin: bundle-search-admin publishing-api search-api
-	$(GOVUK_DOCKER) run $@-lite sh -c 'rake db:migrate 2>/dev/null || rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'


### PR DESCRIPTION
https://github.com/alphagov/govuk-docker/issues/237

This fixes some Makefiles that weren't using a binstub for 'rake', which
means they weren't running with the bundled version of the gems.