### PR TITLE
Add spec to sync Makefile rules with compose

### DIFF
--- a/services/calculators/Makefile
+++ b/services/calculators/Makefile
@@ -1,1 +1,1 @@
-calculators: bundle-calculators
+calculators: bundle-calculators static content-store router

--- a/services/calendars/Makefile
+++ b/services/calendars/Makefile
@@ -1,2 +1,2 @@
-calendars: bundle-calendars publishing-api
+calendars: bundle-calendars publishing-api router content-store static
 	$(GOVUK_DOCKER) run $@-setup bin/rake publishing_api:publish

--- a/services/collections/Makefile
+++ b/services/collections/Makefile
@@ -1,1 +1,1 @@
-collections: bundle-collections
+collections: bundle-collections content-store router static

--- a/services/content-publisher/Makefile
+++ b/services/content-publisher/Makefile
@@ -1,3 +1,3 @@
-content-publisher: bundle-content-publisher asset-manager publishing-api
+content-publisher: bundle-content-publisher asset-manager publishing-api content-store
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/services/content-tagger/Makefile
+++ b/services/content-tagger/Makefile
@@ -1,2 +1,2 @@
-content-tagger: bundle-content-tagger publishing-api frontend
+content-tagger: bundle-content-tagger publishing-api
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/email-alert-frontend/Makefile
+++ b/services/email-alert-frontend/Makefile
@@ -1,4 +1,4 @@
-email-alert-frontend: bundle-email-alert-frontend email-alert-api
+email-alert-frontend: bundle-email-alert-frontend email-alert-api content-store static publishing-api router
 	$(GOVUK_DOCKER) run $@-setup bin/rake publishing_api:publish_email_signup_page
 	$(GOVUK_DOCKER) run $@-setup bin/rake publishing_api:publish_email_unsubscribe_prefix
 	$(GOVUK_DOCKER) run $@-setup bin/rake publishing_api:publish_email_subscriptions_prefix

--- a/services/email-alert-frontend/docker-compose.yml
+++ b/services/email-alert-frontend/docker-compose.yml
@@ -47,4 +47,3 @@ services:
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: email-alert-frontend.dev.gov.uk
       HOST: 0.0.0.0
-

--- a/services/finder-frontend/Makefile
+++ b/services/finder-frontend/Makefile
@@ -1,1 +1,1 @@
-finder-frontend: bundle-finder-frontend content-store static govuk-content-schemas search-api router
+finder-frontend: bundle-finder-frontend content-store static search-api router

--- a/services/finder-frontend/docker-compose.yml
+++ b/services/finder-frontend/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - router-app
       - content-store-app
       - static-app
-      - search-api-app-e2e
+      - search-api-app
       - memcached
     environment:
       GOVUK_ASSET_ROOT: finder-frontend.dev.gov.uk

--- a/services/frontend/Makefile
+++ b/services/frontend/Makefile
@@ -1,2 +1,2 @@
-frontend: bundle-frontend content-store router static govuk-content-schemas publishing-api
+frontend: bundle-frontend content-store router static publishing-api
 	$(GOVUK_DOCKER) run $@-setup bin/rake publishing_api:publish_special_routes

--- a/services/government-frontend/Makefile
+++ b/services/government-frontend/Makefile
@@ -1,1 +1,1 @@
-government-frontend: bundle-government-frontend content-store router static govuk-content-schemas
+government-frontend: bundle-government-frontend content-store router static

--- a/services/info-frontend/Makefile
+++ b/services/info-frontend/Makefile
@@ -1,1 +1,1 @@
-info-frontend: bundle-info-frontend
+info-frontend: bundle-info-frontend router content-store static

--- a/services/manuals-frontend/Makefile
+++ b/services/manuals-frontend/Makefile
@@ -1,1 +1,1 @@
-manuals-frontend: bundle-manuals-frontend content-store router static govuk-content-schemas
+manuals-frontend: bundle-manuals-frontend content-store router static

--- a/services/service-manual-frontend/Makefile
+++ b/services/service-manual-frontend/Makefile
@@ -1,1 +1,1 @@
-service-manual-frontend: bundle-service-manual-frontend
+service-manual-frontend: bundle-service-manual-frontend static content-store router

--- a/services/short-url-manager/Makefile
+++ b/services/short-url-manager/Makefile
@@ -1,1 +1,1 @@
-short-url-manager: bundle-short-url-manager publishing-api govuk-content-schemas
+short-url-manager: bundle-short-url-manager publishing-api

--- a/services/smart-answers/Makefile
+++ b/services/smart-answers/Makefile
@@ -1,1 +1,1 @@
-smart-answers: bundle-smart-answers asset-manager publishing-api static
+smart-answers: bundle-smart-answers publishing-api content-store static

--- a/services/smart-answers/docker-compose.yml
+++ b/services/smart-answers/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     depends_on:
       - nginx-proxy-app
       - publishing-api-app
-      - asset-manager-app
       - static-app
       - content-store-app
     environment:

--- a/services/specialist-publisher/Makefile
+++ b/services/specialist-publisher/Makefile
@@ -1,2 +1,2 @@
-specialist-publisher: bundle-specialist-publisher asset-manager publishing-api
+specialist-publisher: bundle-specialist-publisher asset-manager publishing-api email-alert-api
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/services/whitehall/Makefile
+++ b/services/whitehall/Makefile
@@ -1,4 +1,4 @@
-whitehall: bundle-whitehall asset-manager publishing-api static frontend
+whitehall: bundle-whitehall asset-manager publishing-api static
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
 	$(GOVUK_DOCKER) run $@-lite bin/rake shared_mustache:compile
 	$(GOVUK_DOCKER) run $@-app-e2e bin/rake taxonomy:populate_end_to_end_test_data

--- a/spec/make_spec.rb
+++ b/spec/make_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+
+RSpec.describe "Docker make files" do
+  Dir.glob("*", base: "services").each do |service_name|
+    it "mirrors docker-compose.yml for #{service_name}" do
+      expect(compose_dependencies(service_name))
+        .to match_array(makefile_dependencies(service_name))
+    end
+  end
+
+  def compose_dependencies(service_name)
+    filename = compose_file(service_name)
+    service_stacks = YAML.load_file(filename)["services"].values
+    dependencies = service_stacks.flat_map { |s| s["depends_on"].to_a }
+    dependencies = compose_remove_stack_from_service_name(dependencies)
+    (dependencies & makeable_app_services) - [service_name]
+  end
+
+  def makefile_dependencies(service_name)
+    filename = make_file(service_name)
+    return [] unless File.exist?(filename)
+
+    targets = File.readlines(filename).first.scan(/[\w\-_]+/)
+    (targets & makeable_app_services) - [service_name]
+  end
+
+  def compose_remove_stack_from_service_name(dependencies)
+    dependencies.map { |d| d.sub(/\-\w+$/, "").sub(/-app$/, "") }
+  end
+
+  def makeable_app_services
+    @makeable_app_services ||= service_names.select do |service_name|
+      File.exist?(make_file(service_name)) &&
+        File.read(compose_file(service_name)) =~ /#{service_name}-app/
+    end
+  end
+
+  def service_names
+    @service_names ||= Dir.glob("*", base: "services")
+  end
+
+  def compose_file(service_name)
+    File.join("services", service_name, "docker-compose.yml")
+  end
+
+  def make_file(service_name)
+    File.join("services", service_name, "Makefile")
+  end
+end


### PR DESCRIPTION
https://github.com/alphagov/govuk-docker/issues/237

Previously we relied on people manually listing Makefile prerequisites to
match the dependencies in the compose file for that service. This has lead
to some Makefiles being out-of-sync. This adds a spec to help bring the
Makefiles back in sync with compose for app dependencies.