### PR TITLE
Fix shellcheck error for update-git-repo script

### DIFF
--- a/bin/update-git-repo.sh
+++ b/bin/update-git-repo.sh
@@ -20,9 +20,9 @@ truncate () {
 }
 
 catch_errors () {
-  local out=$(mktemp -t update-git.XXXXXX)
-  # shellcheck disable=SC2064
-  trap "rm -f '$out'" EXIT
+  local out
+  out=$(mktemp -t update-git.XXXXXX)
+  trap 'rm -f "$out"' EXIT
 
   if ! "$@" >"$out" 2>&1; then
     error "FAILED, with output:"


### PR DESCRIPTION
This declares the local 'out' variable before assigning it, as well
removing the trap/rm lines, since the 'rm' functionality should be
handled automatically by our use of 'mktemp'.