### PR TITLE
Strip end of file newline when comparing content

### DIFF
--- a/lib/govuk_docker/doctor/checkup.rb
+++ b/lib/govuk_docker/doctor/checkup.rb
@@ -85,7 +85,7 @@ module GovukDocker::Doctor
     end
 
     def dnsmasq_resolver?
-      File.read("/etc/resolver/dev.gov.uk") == File.read(GovukDocker::Paths.dnsmasq_conf)
+      File.read("/etc/resolver/dev.gov.uk").strip == File.read(GovukDocker::Paths.dnsmasq_conf).strip
     end
 
     def dnsmasq_resolver_message


### PR DESCRIPTION
The content of `/etc/resolver/dev.gov.uk` and
`~/govuk/govuk-docker/config/dnsmasq.conf` should be the same.
The `bin/doctor` script has a check for that:
```
def dnsmasq_resolver?
  File.read("/etc/resolver/dev.gov.uk") ==
File.read(GovukDocker::Paths.dnsmasq_conf)
end
```

Unfortunately, `/etc/resolver/dev.gov.uk` ends with a newline while
`~/govuk/govuk-docker/config/dnsmasq.conf` doesn't, making this check
fail even though the actual content of the two files is the same.

As a newline at the end of the file doesn't really make any difference
in this case, we can safely strip it.