### PR TITLE
Add mapit

### DIFF
--- a/services/mapit/Dockerfile
+++ b/services/mapit/Dockerfile
@@ -1,35 +1,12 @@
-FROM python:2.7-alpine3.10
+FROM python:2.7-buster
 
-RUN apk add --no-cache tzdata \
-        curl \
-        git \
-        gettext \
-        postgresql-client \
-        python \
-        bash
-
-RUN apk add --virtual .build-deps --no-cache --upgrade $PACKAGES \
-   	&& echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" > /etc/apk/repositories \
-   	&& echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
-   	&& echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories  \
-    && apk add \
-        gdal-dev \
-        geos-dev
-
-RUN apk add --no-cache \
-        gcc \
-        libc-dev \
-        && pip install shapely
-
-RUN apk update && \
-    apk add --virtual build-deps python-dev musl-dev && \
-    apk add postgresql-dev
+RUN apt-get update -qq && apt-get install -y gettext \
+        postgresql-client libgdal-dev libgeos-dev musl-dev
 
 RUN git clone https://github.com/alphagov/mapit.git
 
 WORKDIR /mapit
 
-RUN pip install psycopg2
-
+RUN pip install shapely
 RUN pip install --upgrade pip wheel setuptools
 RUN pip install -r requirements.txt

--- a/services/mapit/Dockerfile
+++ b/services/mapit/Dockerfile
@@ -1,0 +1,35 @@
+FROM python:2.7-alpine3.10
+
+RUN apk add --no-cache tzdata \
+        curl \
+        git \
+        gettext \
+        postgresql-client \
+        python \
+        bash
+
+RUN apk add --virtual .build-deps --no-cache --upgrade $PACKAGES \
+   	&& echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" > /etc/apk/repositories \
+   	&& echo "http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
+   	&& echo "http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories  \
+    && apk add \
+        gdal-dev \
+        geos-dev
+
+RUN apk add --no-cache \
+        gcc \
+        libc-dev \
+        && pip install shapely
+
+RUN apk update && \
+    apk add --virtual build-deps python-dev musl-dev && \
+    apk add postgresql-dev
+
+RUN git clone https://github.com/alphagov/mapit.git
+
+WORKDIR /mapit
+
+RUN pip install psycopg2
+
+RUN pip install --upgrade pip wheel setuptools
+RUN pip install -r requirements.txt

--- a/services/mapit/Makefile
+++ b/services/mapit/Makefile
@@ -1,4 +1,3 @@
-
 mapit: 
 	- $(GOVUK_DOCKER) run $@ sh -c 'createuser -U postgres mapit'
 	- $(GOVUK_DOCKER) run $@ sh -c 'createdb -U postgres --owner mapit mapit'

--- a/services/mapit/Makefile
+++ b/services/mapit/Makefile
@@ -1,5 +1,5 @@
 mapit: 
-	- $(GOVUK_DOCKER) run $@ sh -c 'createuser -U postgres mapit'
-	- $(GOVUK_DOCKER) run $@ sh -c 'createdb -U postgres --owner mapit mapit'
-	- $(GOVUK_DOCKER) run $@ sh -c 'psql -U postgres -c "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;" mapit'
-	- $(GOVUK_DOCKER) run $@ sh -c 'bash -c "python ./manage.py migrate -v 0"'
+	- $(GOVUK_DOCKER) run $@-app sh -c 'createuser -U postgres mapit'
+	- $(GOVUK_DOCKER) run $@-app sh -c 'createdb -U postgres --owner mapit mapit'
+	- $(GOVUK_DOCKER) run $@-app sh -c 'psql -U postgres -c "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;" mapit'
+	- $(GOVUK_DOCKER) run $@-app sh -c 'bash -c "python ./manage.py migrate -v 0"'

--- a/services/mapit/Makefile
+++ b/services/mapit/Makefile
@@ -1,0 +1,6 @@
+
+mapit: 
+	- $(GOVUK_DOCKER) run $@ sh -c 'createuser -U postgres mapit'
+	- $(GOVUK_DOCKER) run $@ sh -c 'createdb -U postgres --owner mapit mapit'
+	- $(GOVUK_DOCKER) run $@ sh -c 'psql -U postgres -c "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;" mapit'
+	- $(GOVUK_DOCKER) run $@ sh -c 'bash -c "python ./manage.py migrate -v 0"'

--- a/services/mapit/docker-compose.yml
+++ b/services/mapit/docker-compose.yml
@@ -8,6 +8,9 @@ x-mapit: &mapit
     context: .
     dockerfile: services/mapit/Dockerfile
   image: mapit
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - home:/home/build
   working_dir: /mapit
 
 services:
@@ -16,13 +19,11 @@ services:
     volumes:
       - mapit-pg:/var/lib/postgresql/data
 
-  mapit:
+  mapit-app: &mapit-app
     <<: *mapit
-    volumes:
-        - ~/govuk/mapit:/mapit
     depends_on:
       - mapit-pg
-      - nginx-proxy-app
+      - nginx-proxy
     environment:
       GOVUK_ENV: development
       DJANGO_SECRET_KEY: 'secret'
@@ -30,6 +31,6 @@ services:
       PGHOST: "mapit-pg"
       VIRTUAL_HOST: mapit.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
-      - "3108:3108"
-    command: bash -c "python ./manage.py runserver 0.0.0.0:3108"
+    expose:
+      - "3108"
+    command: bash -c "python ./manage.py runserver"

--- a/services/mapit/docker-compose.yml
+++ b/services/mapit/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.7'
+  
+volumes:
+  mapit-pg:
+
+x-mapit: &mapit
+  build:
+    context: .
+    dockerfile: services/mapit/Dockerfile
+  image: mapit
+  working_dir: /mapit
+
+services:
+  mapit-pg:
+    image: mdillon/postgis:9.6-alpine
+    volumes:
+      - mapit-pg:/var/lib/postgresql/data
+
+  mapit:
+    <<: *mapit
+    volumes:
+        - ~/govuk/mapit:/mapit
+    depends_on:
+      - mapit-pg
+      - nginx-proxy-app
+    working_dir: /mapit
+    environment:
+      MAPIT_DB_PASS: ''
+      DJANGO_SECRET_KEY: 'secret'
+      MAPIT_DB_HOST: 'mapit-pg'
+      PGHOST: "mapit-pg"
+      VIRTUAL_HOST: mapit.dev.gov.uk
+      HOST: 0.0.0.0
+    ports:
+      - "3108:3108"
+    command: bash -c "python ./manage.py runserver 0.0.0.0:3108"

--- a/services/mapit/docker-compose.yml
+++ b/services/mapit/docker-compose.yml
@@ -23,9 +23,8 @@ services:
     depends_on:
       - mapit-pg
       - nginx-proxy-app
-    working_dir: /mapit
     environment:
-      MAPIT_DB_PASS: ''
+      GOVUK_ENV: development
       DJANGO_SECRET_KEY: 'secret'
       MAPIT_DB_HOST: 'mapit-pg'
       PGHOST: "mapit-pg"

--- a/services/nginx-proxy/docker-compose.yml
+++ b/services/nginx-proxy/docker-compose.yml
@@ -43,6 +43,7 @@ services:
           - licence-finder.dev.gov.uk
           - link-checker-api.dev.gov.uk
           - manuals-frontend.dev.gov.uk
+          - mapit.dev.gov.uk
           - publisher.dev.gov.uk
           - publishing-api.dev.gov.uk
           - router-api.dev.gov.uk

--- a/spec/integration/compose/rails_debugger_spec.rb
+++ b/spec/integration/compose/rails_debugger_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 RSpec.describe "Compose rails debugger" do
   compose_files = Dir.glob("services/**/docker-compose.yml")
+  compose_files.delete_if { |app| app.include? "mapit" }
 
   compose_app_services = compose_files.flat_map do |filename|
     YAML.load_file(filename)["services"].to_a.select do |service_name, _service|


### PR DESCRIPTION
This adds Mapit as a service with a dependency on PostgreSQL and
nginx-proxy-app.

Mapit has a PostgreSQL database with the PostGIS extension installed to
enable location queries to be run in SQL, that's why we used a
docker image that includes this extension.

This should enable Mapit to work with govuk-docker but there will be
further work to enable importing data. There's a problem with loading
static files which is also an issue in the dev VM. However, this
shouldn't be a problem since we only really care about the database
being up to date in this app.

[Trello](https://trello.com/c/QXBhaFlh/1449-5-add-mapit-to-govuk-docker)