### PR TITLE
Add Whitehall as dependency for Smart Answers

### DIFF
--- a/services/smart-answers/Makefile
+++ b/services/smart-answers/Makefile
@@ -1,1 +1,1 @@
-smart-answers: bundle-smart-answers publishing-api content-store static
+smart-answers: bundle-smart-answers publishing-api content-store static whitehall

--- a/services/smart-answers/docker-compose.yml
+++ b/services/smart-answers/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - publishing-api-app
       - static-app
       - content-store-app
+      - whitehall-app
     environment:
       VIRTUAL_HOST: smart-answers.dev.gov.uk
       HOST: 0.0.0.0


### PR DESCRIPTION
Whitehall contains the Worldwide Locations API which is needed for
things like Marriage Abroad Smart Answers.