### PR TITLE
Fix incorrect '-f' flag in how-to

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,16 +75,13 @@ Sometimes things go wrong or some investigation is needed. As govuk-docker is ju
 git pull
 
 # make sure the service is built OK
-make -f <service>
+make <service>
 
 # tail logs for running services
 govuk-docker logs -f
 
 # get all the running containers
 docker ps -a
-
-# get a terminal inside a service
-govuk-docker run <service>-lite bash
 ```
 
 ### How to: update everything!


### PR DESCRIPTION
This removes an incorrect '-f' flag from one of the how-to suggestions
around re-building a service, as well as a couple of commands:

   - 'git pull' seems a little too obvious
   - 'run bash' is covered in the intro docs