### PR TITLE
Replace govuk-lint with rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,6 @@
 inherit_gem:
-  govuk-lint: "configs/rubocop/all.yml"
-
-Rails:
-  Enabled: false
+  rubocop-govuk: 
+    - "config/default.yml"
 
 AllCops:
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "climate_control"
 gem "colorize"
-gem "govuk-lint"
+gem "rubocop-govuk", "~> 1"
 gem "pry"
 gem "rspec"
 gem "thor"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,12 +6,6 @@ GEM
     coderay (1.1.2)
     colorize (0.8.1)
     diff-lcs (1.3)
-    ffi (1.11.1)
-    govuk-lint (4.2.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     jaro_winkler (1.5.4)
     method_source (0.9.2)
     parallel (1.18.0)
@@ -22,9 +16,6 @@ GEM
       method_source (~> 0.9.0)
     rack (2.0.7)
     rainbow (3.0.0)
-    rb-fsevent (0.10.3)
-    rb-inotify (0.10.0)
-      ffi (~> 1.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -45,19 +36,16 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
     rubocop-rspec (1.36.0)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
-    sass (3.7.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     thor (0.20.3)
     unicode-display_width (1.6.0)
 
@@ -67,9 +55,9 @@ PLATFORMS
 DEPENDENCIES
   climate_control
   colorize
-  govuk-lint
   pry
   rspec
+  rubocop-govuk (~> 1)
   thor
 
 BUNDLED WITH


### PR DESCRIPTION
As govuk-lint is being deprecated, this commit replaces usage of govuk-lint with rubocop and rubocop-govuk.