### PR TITLE
Support interactive debugging for Rails apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ While most environment variables should be set in the config for a service, some
 govuk-docker run content-publisher-lite env MY_VAR=my_val bundle exec rake my_task
 ```
 
+### How to: debug a running Rails app
+
+Normally it's enough to run a Rails app using `govuk-docker up`. To get a `debugger` console for a specific app or one of its dependencies, we need to attach an interactive terminal to the running container.
+
+```
+# find the container name
+govuk-docker ps
+
+# attach to the container
+docker attach govuk-docker_content-publisher-app_1
+
+# awesome debugging stuff
+...
+
+# detach from the container
+CTRL-P CTRL-Q
+```
+
 ### How to: install a new release of Ruby
 
 Many of our services use a `.ruby-version` file in conjunction with `rbenv`. When a new version of Ruby is released and we start upgrading our services, you may start seeing the following error when you run commands.

--- a/services/asset-manager/docker-compose.yml
+++ b/services/asset-manager/docker-compose.yml
@@ -5,6 +5,8 @@ x-asset-manager: &asset-manager
     context: .
     dockerfile: services/asset-manager/Dockerfile
   image: asset-manager
+  tty: true
+  stdin_open: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/authenticating-proxy/docker-compose.yml
+++ b/services/authenticating-proxy/docker-compose.yml
@@ -5,6 +5,8 @@ x-authenticating-proxy: &authenticating-proxy
     context: .
     dockerfile: Dockerfile.govuk-base
   image: authenticating-proxy
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/calculators/docker-compose.yml
+++ b/services/calculators/docker-compose.yml
@@ -5,6 +5,8 @@ x-calculators: &calculators
     context: .
     dockerfile: Dockerfile.govuk-base
   image: calculators
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/calendars/docker-compose.yml
+++ b/services/calendars/docker-compose.yml
@@ -5,6 +5,8 @@ x-calendars: &calendars
     context: .
     dockerfile: Dockerfile.govuk-base
   image: calendars
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/collections-publisher/docker-compose.yml
+++ b/services/collections-publisher/docker-compose.yml
@@ -5,6 +5,8 @@ x-collections-publisher: &collections-publisher
     context: .
     dockerfile: Dockerfile.govuk-base
   image: collections-publisher
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/collections/docker-compose.yml
+++ b/services/collections/docker-compose.yml
@@ -5,6 +5,8 @@ x-collections: &collections
     context: .
     dockerfile: Dockerfile.govuk-base
   image: collections
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/content-data-admin/docker-compose.yml
+++ b/services/content-data-admin/docker-compose.yml
@@ -5,6 +5,8 @@ x-content-data-admin: &content-data-admin
     context: .
     dockerfile: Dockerfile.govuk-base
   image: content-data-admin
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/content-publisher/docker-compose.yml
+++ b/services/content-publisher/docker-compose.yml
@@ -5,6 +5,8 @@ x-content-publisher: &content-publisher
     context: .
     dockerfile: Dockerfile.govuk-base
   image: content-publisher
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/content-store/docker-compose.yml
+++ b/services/content-store/docker-compose.yml
@@ -5,6 +5,8 @@ x-content-store: &content-store
     context: .
     dockerfile: Dockerfile.govuk-base
   image: content-store
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/content-tagger/docker-compose.yml
+++ b/services/content-tagger/docker-compose.yml
@@ -5,6 +5,8 @@ x-content-tagger: &content-tagger
     context: .
     dockerfile: Dockerfile.govuk-base
   image: content-tagger
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/email-alert-api/docker-compose.yml
+++ b/services/email-alert-api/docker-compose.yml
@@ -5,6 +5,8 @@ x-email-alert-api: &email-alert-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: email-alert-api
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/email-alert-frontend/docker-compose.yml
+++ b/services/email-alert-frontend/docker-compose.yml
@@ -5,6 +5,8 @@ x-email-alert-frontend: &email-alert-frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: email-alert-frontend
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/finder-frontend/docker-compose.yml
+++ b/services/finder-frontend/docker-compose.yml
@@ -5,6 +5,8 @@ x-finder-frontend: &finder-frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: finder-frontend
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/frontend/docker-compose.yml
+++ b/services/frontend/docker-compose.yml
@@ -5,6 +5,8 @@ x-frontend: &frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: frontend
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/government-frontend/docker-compose.yml
+++ b/services/government-frontend/docker-compose.yml
@@ -5,6 +5,8 @@ x-government-frontend: &government-frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: government-frontend
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/govuk-developer-docs/docker-compose.yml
+++ b/services/govuk-developer-docs/docker-compose.yml
@@ -5,6 +5,8 @@ x-govuk-developer-docs: &govuk-developer-docs
     context: .
     dockerfile: Dockerfile.govuk-base
   image: govuk-developer-docs
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/govuk_publishing_components/docker-compose.yml
+++ b/services/govuk_publishing_components/docker-compose.yml
@@ -5,6 +5,8 @@ x-govuk_publishing_components: &govuk_publishing_components
     context: .
     dockerfile: Dockerfile.govuk-base
   image: govuk_publishing_components
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/info-frontend/docker-compose.yml
+++ b/services/info-frontend/docker-compose.yml
@@ -5,6 +5,8 @@ x-tmp: &info-frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: info-frontend
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/licence-finder/docker-compose.yml
+++ b/services/licence-finder/docker-compose.yml
@@ -5,6 +5,8 @@ x-licence-finder: &licence-finder
     context: .
     dockerfile: Dockerfile.govuk-base
   image: licence-finder
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/link-checker-api/docker-compose.yml
+++ b/services/link-checker-api/docker-compose.yml
@@ -5,6 +5,8 @@ x-link-checker-api: &link-checker-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: link-checker-api
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/manuals-frontend/docker-compose.yml
+++ b/services/manuals-frontend/docker-compose.yml
@@ -5,6 +5,8 @@ x-manuals-frontend: &manuals-frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: manuals-frontend
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/publisher/docker-compose.yml
+++ b/services/publisher/docker-compose.yml
@@ -5,6 +5,8 @@ x-publisher: &publisher
     context: .
     dockerfile: Dockerfile.govuk-base
   image: publisher
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/publishing-api/docker-compose.yml
+++ b/services/publishing-api/docker-compose.yml
@@ -5,6 +5,8 @@ x-publishing-api: &publishing-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: publishing-api
+  tty: true
+  stdin_open: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/router-api/docker-compose.yml
+++ b/services/router-api/docker-compose.yml
@@ -5,6 +5,8 @@ x-router-api: &router-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: router-api
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/router/docker-compose.yml
+++ b/services/router/docker-compose.yml
@@ -5,6 +5,8 @@ x-router: &router
     context: .
     dockerfile: services/router/Dockerfile
   image: router
+  stdin_open: true
+  tty: true
   volumes:
     - go:/go
     - ${GOVUK_ROOT_DIR:-~/govuk}/router:/go/src/github.com/alphagov/router:delegated

--- a/services/search-admin/docker-compose.yml
+++ b/services/search-admin/docker-compose.yml
@@ -5,6 +5,8 @@ x-search-admin: &search-admin-base
     context: .
     dockerfile: Dockerfile.govuk-base
   image: search-admin
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/search-api/docker-compose.yml
+++ b/services/search-api/docker-compose.yml
@@ -5,6 +5,8 @@ x-search-api: &search-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: search-api
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/service-manual-frontend/docker-compose.yml
+++ b/services/service-manual-frontend/docker-compose.yml
@@ -5,6 +5,8 @@ x-service-manual-frontend: &service-manual-frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: service-manual-frontend
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/short-url-manager/docker-compose.yml
+++ b/services/short-url-manager/docker-compose.yml
@@ -5,6 +5,8 @@ x-short-url-manager: &short-url-manager
     context: .
     dockerfile: Dockerfile.govuk-base
   image: short-url-manager
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/signon/docker-compose.yml
+++ b/services/signon/docker-compose.yml
@@ -5,6 +5,8 @@ x-signon: &signon
     context: .
     dockerfile: Dockerfile.govuk-base
   image: signon
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/smart-answers/docker-compose.yml
+++ b/services/smart-answers/docker-compose.yml
@@ -5,6 +5,8 @@ x-smart-answers: &smart-answers
     context: .
     dockerfile: Dockerfile.govuk-base
   image: smart-answers
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/specialist-publisher/docker-compose.yml
+++ b/services/specialist-publisher/docker-compose.yml
@@ -5,6 +5,8 @@ x-specialist-publisher: &specialist-publisher
     context: .
     dockerfile: services/specialist-publisher/Dockerfile
   image: specialist-publisher
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/static/docker-compose.yml
+++ b/services/static/docker-compose.yml
@@ -5,6 +5,8 @@ x-static: &static
     context: .
     dockerfile: Dockerfile.govuk-base
   image: static
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/support-api/docker-compose.yml
+++ b/services/support-api/docker-compose.yml
@@ -5,6 +5,8 @@ x-support-api: &support-api
     context: .
     dockerfile: services/support-api/Dockerfile
   image: support-api
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/support/docker-compose.yml
+++ b/services/support/docker-compose.yml
@@ -5,6 +5,8 @@ x-support: &support
     context: .
     dockerfile: Dockerfile.govuk-base
   image: support
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/transition/docker-compose.yml
+++ b/services/transition/docker-compose.yml
@@ -5,6 +5,8 @@ x-transition: &transition
     context: .
     dockerfile: Dockerfile.govuk-base
   image: transition
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/travel-advice-publisher/docker-compose.yml
+++ b/services/travel-advice-publisher/docker-compose.yml
@@ -5,6 +5,8 @@ x-travel-advice-publisher: &travel-advice-publisher
     context: .
     dockerfile: services/travel-advice-publisher/Dockerfile
   image: travel-advice-publisher
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/services/whitehall/docker-compose.yml
+++ b/services/whitehall/docker-compose.yml
@@ -5,6 +5,8 @@ x-whitehall: &whitehall
     context: .
     dockerfile: Dockerfile.govuk-base
   image: whitehall
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build

--- a/spec/integration/compose/rails_debugger_spec.rb
+++ b/spec/integration/compose/rails_debugger_spec.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+
+RSpec.describe "Compose rails debugger" do
+  compose_files = Dir.glob("services/**/docker-compose.yml")
+
+  compose_app_services = compose_files.flat_map do |filename|
+    YAML.load_file(filename)["services"].to_a.select do |service_name, _service|
+      service_name =~ /app(-\w+)?$/
+    end
+  end
+
+  compose_app_services.each do |service_name, service|
+    it "#{service_name} supports attaching an interactive debugger" do
+      expect(service["tty"]).to be_truthy
+      expect(service["stdin_open"]).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
This enables interactive terminals on all app stacks, together with a
how-to that explains using 'docker attach' to work with an interactive
inline debugger, which is commonly used with Rails apps. Although it's
possible to get an interactive terminal using 'run', this only works for
the top-level app, whereas this technique also supports using an inline
debugger in background dependencies.