### PR TITLE
Use 'expose' option instead of 'ports'

### DIFF
--- a/services/asset-manager/docker-compose.yml
+++ b/services/asset-manager/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: asset-manager.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/authenticating-proxy/docker-compose.yml
+++ b/services/authenticating-proxy/docker-compose.yml
@@ -31,6 +31,6 @@ services:
       MONGODB_URI: "mongodb://mongo/authenticating-proxy"
       VIRTUAL_HOST: authenticating-proxy.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart

--- a/services/calculators/docker-compose.yml
+++ b/services/calculators/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       GOVUK_ASSET_ROOT: calculators.dev.gov.uk
       VIRTUAL_HOST: calculators.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/calendars/docker-compose.yml
+++ b/services/calendars/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       GOVUK_ASSET_ROOT: calendars.dev.gov.uk
       VIRTUAL_HOST: calendars.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/collections-publisher/docker-compose.yml
+++ b/services/collections-publisher/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: collections-publisher.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/collections/docker-compose.yml
+++ b/services/collections/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       GOVUK_ASSET_ROOT: collections.dev.gov.uk
       VIRTUAL_HOST: collections.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/content-publisher/docker-compose.yml
+++ b/services/content-publisher/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: content-publisher.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/content-store/docker-compose.yml
+++ b/services/content-store/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       MONGODB_URI: "mongodb://mongo/content-store"
       VIRTUAL_HOST: content-store.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/content-tagger/docker-compose.yml
+++ b/services/content-tagger/docker-compose.yml
@@ -33,6 +33,6 @@ services:
       VIRTUAL_HOST: content-tagger.dev.gov.uk
       REDIS_URL: redis://redis
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart

--- a/services/email-alert-api/docker-compose.yml
+++ b/services/email-alert-api/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: email-alert-api.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/email-alert-frontend/docker-compose.yml
+++ b/services/email-alert-frontend/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       GOVUK_ASSET_ROOT: email-alert-frontend.dev.gov.uk
       VIRTUAL_HOST: email-alert-frontend.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/finder-frontend/docker-compose.yml
+++ b/services/finder-frontend/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       HOST: 0.0.0.0
       MEMCACHE_SERVERS: memcached
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/frontend/docker-compose.yml
+++ b/services/frontend/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       GOVUK_ASSET_ROOT: frontend.dev.gov.uk
       VIRTUAL_HOST: frontend.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/government-frontend/docker-compose.yml
+++ b/services/government-frontend/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       GOVUK_ASSET_ROOT: government-frontend.dev.gov.uk
       VIRTUAL_HOST: government-frontend.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/govuk-developer-docs/docker-compose.yml
+++ b/services/govuk-developer-docs/docker-compose.yml
@@ -22,6 +22,6 @@ services:
       - nginx-proxy-app
     environment:
       VIRTUAL_HOST: govuk-developer-docs.dev.gov.uk
-    ports:
+    expose:
       - "4567"
     command: bundle exec middleman server --bind-address 0.0.0.0

--- a/services/govuk_publishing_components/docker-compose.yml
+++ b/services/govuk_publishing_components/docker-compose.yml
@@ -21,6 +21,6 @@ services:
       - nginx-proxy-app
     environment:
       VIRTUAL_HOST: govuk-publishing-components.dev.gov.uk
-    ports:
+    expose:
       - "9292"
     command: bundle exec rackup spec/dummy/config.ru --host 0.0.0.0

--- a/services/info-frontend/docker-compose.yml
+++ b/services/info-frontend/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       GOVUK_ASSET_ROOT: info-frontend.dev.gov.uk
       VIRTUAL_HOST: info-frontend.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s -P /tmp/rails.pid
 

--- a/services/licence-finder/docker-compose.yml
+++ b/services/licence-finder/docker-compose.yml
@@ -38,6 +38,6 @@ services:
       ELASTICSEARCH_URI: http://elasticsearch6:9200
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart

--- a/services/link-checker-api/docker-compose.yml
+++ b/services/link-checker-api/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: link-checker-api.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/manuals-frontend/docker-compose.yml
+++ b/services/manuals-frontend/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       GOVUK_ASSET_ROOT: manuals-frontend.dev.gov.uk
       VIRTUAL_HOST: manuals-frontend.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/publisher/docker-compose.yml
+++ b/services/publisher/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: publisher.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/publishing-api/docker-compose.yml
+++ b/services/publishing-api/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: publishing-api.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/router-api/docker-compose.yml
+++ b/services/router-api/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       MONGODB_URI: "mongodb://mongo/router"
       VIRTUAL_HOST: router-api.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/router/docker-compose.yml
+++ b/services/router/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     <<: *router
     depends_on:
       - mongo
-    ports:
+    expose:
       - "8080"
       - "3055"
     environment:

--- a/services/search-admin/docker-compose.yml
+++ b/services/search-admin/docker-compose.yml
@@ -35,6 +35,6 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: search-admin.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart

--- a/services/search-api/docker-compose.yml
+++ b/services/search-api/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       ELASTICSEARCH_URI: http://elasticsearch6:9200
       VIRTUAL_HOST: search-api.dev.gov.uk, search.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bundle exec mr-sparkle --force-polling -- -p 3000
 

--- a/services/service-manual-frontend/docker-compose.yml
+++ b/services/service-manual-frontend/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       GOVUK_ASSET_ROOT: service-manual-frontend.dev.gov.uk
       VIRTUAL_HOST: service-manual-frontend.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/short-url-manager/docker-compose.yml
+++ b/services/short-url-manager/docker-compose.yml
@@ -34,6 +34,6 @@ services:
       REDIS_URL: redis
       VIRTUAL_HOST: short-url-manager.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart

--- a/services/signon/docker-compose.yml
+++ b/services/signon/docker-compose.yml
@@ -33,6 +33,6 @@ services:
       VIRTUAL_HOST: signon.dev.gov.uk
       HOST: 0.0.0.0
       REDIS_HOST: redis
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart

--- a/services/smart-answers/docker-compose.yml
+++ b/services/smart-answers/docker-compose.yml
@@ -26,6 +26,6 @@ services:
     environment:
       VIRTUAL_HOST: smart-answers.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart

--- a/services/specialist-publisher/docker-compose.yml
+++ b/services/specialist-publisher/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: specialist-publisher.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/static/docker-compose.yml
+++ b/services/static/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       GOVUK_ASSET_ROOT: static.dev.gov.uk
       VIRTUAL_HOST: static.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/support-api/docker-compose.yml
+++ b/services/support-api/docker-compose.yml
@@ -32,6 +32,6 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: support-api.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart

--- a/services/support/docker-compose.yml
+++ b/services/support/docker-compose.yml
@@ -28,6 +28,6 @@ services:
       VIRTUAL_HOST: support.dev.gov.uk
       REDIS_URL: redis://redis
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart

--- a/services/transition/docker-compose.yml
+++ b/services/transition/docker-compose.yml
@@ -32,6 +32,6 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: transition.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart

--- a/services/travel-advice-publisher/docker-compose.yml
+++ b/services/travel-advice-publisher/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: travel-advice-publisher.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     command: bin/rails s --restart
 

--- a/services/whitehall/docker-compose.yml
+++ b/services/whitehall/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: whitehall-admin.dev.gov.uk
       HOST: 0.0.0.0
-    ports:
+    expose:
       - "3000"
     # Change to 'bin/rails --restart' when rails >= 5.2
     command: /bin/sh -c "rm -f tmp/pids/server.pid && rails s"


### PR DESCRIPTION
Previously we used the 'ports' option to declare the internal ports
for app services. In order for the declared ports to be exposed to the
internal nginx-proxy service, it was necessary to use the 'up' command
or the '--service-ports' flag with the 'run' command. Using the 'expose'
option means 'up' and 'run' can be used interchangeably, thus removing
a potential source of confusion.