### PR TITLE
Introduce a govuk-docker-version helper script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 replication
 stderr.log
+.version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 0.0.1
+
+* Introduce versioning feature to support people when things change

--- a/exe/govuk-docker
+++ b/exe/govuk-docker
@@ -17,5 +17,9 @@ for file in $COMPOSE_FILES; do
   COMPOSE_FLAGS+=("-f" "$file")
 done
 
+if ! govuk-docker-version >/dev/null; then
+  read -rp "Press enter to continue..."
+fi
+
 echo "docker-compose -f [...] $*"
 docker-compose "${COMPOSE_FLAGS[@]}" "$@"

--- a/exe/govuk-docker-version
+++ b/exe/govuk-docker-version
@@ -1,0 +1,26 @@
+#! /usr/bin/env bash
+
+VERSION_FILE="$(dirname "$0")/../.version"
+CHANGELOG_FILE="$(dirname "$0")/../CHANGELOG.md"
+
+VERSION=0.0.1
+LOCAL_VERSION=$(cat "$VERSION_FILE" 2>/dev/null)
+
+if grep -xsq $VERSION "$VERSION_FILE"; then
+  echo $VERSION
+  exit
+fi
+
+>&2 echo -e "WARNING: The version of govuk-docker has changed.\n"
+
+if [ "$LOCAL_VERSION" ]; then
+  >&2 sed /"$LOCAL_VERSION"/q "$CHANGELOG_FILE"
+else
+  >&2 cat "$CHANGELOG_FILE"
+fi
+
+>&2 echo
+
+echo $VERSION > "$VERSION_FILE"
+echo $VERSION
+exit 1


### PR DESCRIPTION
This introduces a new script to print version info about govuk-docker
and ties it into the main wrapper script, as a way to motivate people
to maintain the version and the associated CHANGELOG. Sometimes there
are breaking changes in this repo, for which a notification facility
would be helpful, since people are less likely to notice an update to
a CHANGELOG without an explicit call-to-action.