### PR TITLE
Ignore Brewfile.lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 replication
 stderr.log
 .version
+Brewfile.lock.json


### PR DESCRIPTION
It's not needed as it doesn't give us information that we need to keep
consistent between machines.

From https://github.com/Homebrew/homebrew-bundle/pull/552:
> we will never have a “proper” lockfile in Homebrew/homebrew-bundle
> that installs all your dependencies at exactly the versions you want
> because Homebrew doesn’t work that way (and never will because e.g.
> pinning OpenSSL at the same version forever is a bad idea).
>
> brew bundle will output a Brewfile.lock.json in the same directory as
> the Brewfile if all dependencies are installed successfully. This
> contains dependency and system status information which can be useful
> in debugging brew bundle failures and replicating a “last known good
> build” state.
>
> You may wish to check this file into the same version control system
> as your Brewfile (or ensure your version control system ignores it if
> you’d prefer to rely on debugging information from a local machine).