### PR TITLE
Make it possible to download data without importing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ All the scripts, other than `replicate-elasticsearch.sh`, take the name of the a
 
 Draft data can be replicated with `replicate-mongodb.sh draft-content-store` and `replicate-mongodb.sh draft-router`.
 
+If you want to download data without importing it, set the `SKIP_IMPORT` environment variable (to anything).
+
 ### How to: set environment variables
 
 While most environment variables should be set in the config for a service, sometimes it's necessary to set assign one or more variables at the point of running a command, such as a Rake task. This can be done using `env` e.g.

--- a/bin/replicate-elasticsearch.sh
+++ b/bin/replicate-elasticsearch.sh
@@ -16,6 +16,11 @@ else
   aws --profile govuk-integration s3 sync "s3://${bucket}/" "${archive_path}/"
 fi
 
+if [[ -n "$SKIP_IMPORT" ]]; then
+  echo "Skipping import as \$SKIP_IMPORT is set"
+  exit 0
+fi
+
 # temporary config file because ES needs to be configured in advance
 # for filesystem-based snapshots
 cfg_path=$(mktemp '/tmp/govuk-docker-data-sync.XXXXX')

--- a/bin/replicate-mongodb.sh
+++ b/bin/replicate-mongodb.sh
@@ -50,6 +50,11 @@ else
   aws --profile govuk-integration s3 cp "s3://${bucket}/mongodb/daily/${hostname}/${remote_file_name}" "$archive_path"
 fi
 
+if [[ -n "$SKIP_IMPORT" ]]; then
+  echo "Skipping import as \$SKIP_IMPORT is set"
+  exit 0
+fi
+
 extract_path="${archive_path}-${app}"
 
 if [[ -d "$extract_path" ]]; then

--- a/bin/replicate-mysql.sh
+++ b/bin/replicate-mysql.sh
@@ -25,6 +25,11 @@ else
   aws --profile govuk-integration s3 cp "s3://${bucket}/mysql/$(date '+%Y-%m-%d')/${archive_file}" "${archive_path}"
 fi
 
+if [[ -n "$SKIP_IMPORT" ]]; then
+  echo "Skipping import as \$SKIP_IMPORT is set"
+  exit 0
+fi
+
 echo "stopping running govuk-docker containers..."
 govuk-docker down
 

--- a/bin/replicate-postgresql.sh
+++ b/bin/replicate-postgresql.sh
@@ -34,6 +34,11 @@ else
   aws --profile govuk-integration s3 cp "s3://${bucket}/postgres/$(date '+%Y-%m-%d')/${archive_file}" "${archive_path}"
 fi
 
+if [[ -n "$SKIP_IMPORT" ]]; then
+  echo "Skipping import as \$SKIP_IMPORT is set"
+  exit 0
+fi
+
 echo "stopping running govuk-docker containers..."
 govuk-docker down
 


### PR DESCRIPTION
We want to remove the old replication scripts, as they don't work with gds-cli (https://github.com/alphagov/govuk-puppet/pull/9866).  The dev VM is still around, so this means we'd ideally have a (possibly painful, manual) process to import data even so. 

This PR makes it possible to download data without importing it to govuk-docker databases, and will be step 1 of importing data to the dev VM.  Step 2 will be something like "look at what the import part of the script does and do that manually".