### PR TITLE
Fix postgres database replication

### DIFF
--- a/bin/replicate-mysql.sh
+++ b/bin/replicate-mysql.sh
@@ -34,7 +34,7 @@ echo "stopping running govuk-docker containers..."
 govuk-docker down
 
 govuk-docker up -d mysql
-trap 'govuk-docker compose stop mysql' EXIT
+trap 'govuk-docker stop mysql' EXIT
 
 echo "waiting for mysql..."
 until govuk-docker run mysql mysql -h mysql -u root --password=root -e 'SELECT 1' &>/dev/null; do

--- a/bin/replicate-postgresql.sh
+++ b/bin/replicate-postgresql.sh
@@ -68,4 +68,4 @@ done
 database="$app"
 govuk-docker run postgres /usr/bin/psql -h postgres -U postgres -c "DROP DATABASE IF EXISTS \"${database}\""
 govuk-docker run postgres /usr/bin/createdb -h postgres -U postgres "$database"
-pv "$archive_path"  | gunzip | grep -v 'ALTER \(.*\) OWNER TO \(.*\);' | govuk-docker run postgres /usr/bin/psql -h postgres -U postgres -qAt -d "$database"
+pv "$archive_path" | govuk-docker run postgres /usr/bin/pg_restore -h postgres -U postgres -d "$database" --no-owner

--- a/bin/replicate-postgresql.sh
+++ b/bin/replicate-postgresql.sh
@@ -58,7 +58,7 @@ echo "stopping running govuk-docker containers..."
 govuk-docker down
 
 govuk-docker up -d postgres
-trap 'govuk-docker compose stop postgres' EXIT
+trap 'govuk-docker stop postgres' EXIT
 
 echo "waiting for postgres..."
 until govuk-docker run postgres /usr/bin/psql -h postgres -U postgres -c 'SELECT 1' &>/dev/null; do

--- a/bin/replicate-postgresql.sh
+++ b/bin/replicate-postgresql.sh
@@ -43,7 +43,7 @@ else
     s3_file=$(try_find_file "${app//-/_}")
   fi
   if [[ -z "$s3_file" ]]; then
-    echo "couldn't figure out backup filename in S3 - this is a bug (or the app doesn't use postgres)."
+    echo "couldn't figure out backup filename in S3 - if you're sure the app uses PostgreSQL, file an issue in alphagov/govuk-docker."
     exit 1
   fi
   aws --profile govuk-integration s3 cp "s3://${bucket}/postgresql-backend/${s3_file}" "${archive_path}"


### PR DESCRIPTION
At some point the filename pattern changed: backups are now in the
"postgresql-backend" directory, and it's not consistent at all whether
things use hyphens or underscores.

I decided to use `aws s3 ls ... | grep` to find the app, rather than
hard code a list of app name -> backup file name mappings.  The list
would be long, and the `aws s3 ls` is needed anyway, as the backup
timestamps also now include the time the backup was taken, not just
the date.