### PR TITLE
Make the replication scripts work with the GDS CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ There may be times when a full database is required locally.  The following scri
 - `replicate-mysql.sh APP-NAME`
 - `replicate-postgresql.sh APP-NAME`
 
+You will need to assume-role into AWS using the [gds-cli](https://docs.publishing.service.gov.uk/manual/gds-cli.html) before running the scripts. For example, to replicate data for Content Publisher as an AWS PowerUser, run:
+
+```
+gds aws govuk-integration-poweruser ./bin/replicate-postgresql.sh content-publisher
+```
+
 All the scripts, other than `replicate-elasticsearch.sh`, take the name of the app to replicate data for.
 
 Draft data can be replicated with `replicate-mongodb.sh draft-content-store` and `replicate-mongodb.sh draft-router`.

--- a/bin/replicate-elasticsearch.sh
+++ b/bin/replicate-elasticsearch.sh
@@ -13,7 +13,7 @@ if [[ -e "$archive_path" ]]; then
   echo "Skipping download - remove ${archive_path} to force"
 else
   mkdir -p "$replication_dir"
-  aws --profile govuk-integration s3 sync "s3://${bucket}/" "${archive_path}/"
+  aws s3 sync "s3://${bucket}/" "${archive_path}/"
 fi
 
 if [[ -n "${SKIP_IMPORT:-}" ]]; then

--- a/bin/replicate-mongodb.sh
+++ b/bin/replicate-mongodb.sh
@@ -46,8 +46,8 @@ if [[ -e "$archive_path" ]]; then
   echo "Skipping download - remove ${archive_path} to force"
 else
   mkdir -p "$archive_dir"
-  remote_file_name=$(aws --profile govuk-integration s3 ls "s3://${bucket}/mongodb/daily/${hostname}/" | tail -n1 | sed 's/^.* .* .* //')
-  aws --profile govuk-integration s3 cp "s3://${bucket}/mongodb/daily/${hostname}/${remote_file_name}" "$archive_path"
+  remote_file_name=$(aws s3 ls "s3://${bucket}/mongodb/daily/${hostname}/" | tail -n1 | sed 's/^.* .* .* //')
+  aws s3 cp "s3://${bucket}/mongodb/daily/${hostname}/${remote_file_name}" "$archive_path"
 fi
 
 if [[ -n "${SKIP_IMPORT:-}" ]]; then

--- a/bin/replicate-mysql.sh
+++ b/bin/replicate-mysql.sh
@@ -22,7 +22,7 @@ if [[ -e "$archive_path" ]]; then
   echo "Skipping download - remove ${archive_path} to force"
 else
   mkdir -p "$archive_dir"
-  aws --profile govuk-integration s3 cp "s3://${bucket}/mysql/$(date '+%Y-%m-%d')/${archive_file}" "${archive_path}"
+  aws s3 cp "s3://${bucket}/mysql/$(date '+%Y-%m-%d')/${archive_file}" "${archive_path}"
 fi
 
 if [[ -n "${SKIP_IMPORT:-}" ]]; then

--- a/bin/replicate-postgresql.sh
+++ b/bin/replicate-postgresql.sh
@@ -2,7 +2,7 @@
 
 function try_find_file {
   set +e
-  out="$(aws --profile govuk-integration s3 ls "s3://${bucket}/postgresql-backend/" | grep "${1}_production.gz" | sed 's/.* //' | sort | tail -n1)"
+  out="$(aws s3 ls "s3://${bucket}/postgresql-backend/" | grep "${1}_production.gz" | sed 's/.* //' | sort | tail -n1)"
   set -e
   echo "$out"
 }
@@ -46,7 +46,7 @@ else
     echo "couldn't figure out backup filename in S3 - if you're sure the app uses PostgreSQL, file an issue in alphagov/govuk-docker."
     exit 1
   fi
-  aws --profile govuk-integration s3 cp "s3://${bucket}/postgresql-backend/${s3_file}" "${archive_path}"
+  aws s3 cp "s3://${bucket}/postgresql-backend/${s3_file}" "${archive_path}"
 fi
 
 if [[ -n "${SKIP_IMPORT:-}" ]]; then


### PR DESCRIPTION
- In the new, gds-cli-based world, people don't have integration
  profiles in `~/.aws/config`, they run commands like `gds aws
  govuk-integration-poweruser aws s3 ls`.
- Hence, we no longer use `aws --profile integration` because we no
  longer have plain-text credentials and config in `~/.aws/...`.