### PR TITLE
Brewfile: Install Docker when on Linux too

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,8 +1,11 @@
-tap "homebrew/cask"
-
 brew "dnsmasq"
-brew "docker-compose"
 brew "pv"
 brew "shellcheck"
 
-cask "docker"
+if OS.mac?
+  tap "homebrew/cask"
+  cask "docker"
+else
+  brew "docker"
+  brew "docker-compose"
+end


### PR DESCRIPTION
- There was some discussion in #271 about making the installation
  instructions better for Linux.
- The Brewfile works on Linux, but for completeness and parity between
  the systems, let's install Docker when on Linux too (Casks are
  auto-skipped).
- There is still a long way to go to make GOV.UK Docker work on Linux,
  notably the GDS BYOD VPN and the dnsmasq configuration, but we can at
  least have everything installed for if ever Linux users want to figure
  it out.