### PR TITLE
Fix 'clone everything' task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ default:
 	@echo "For example:"
 	@echo "    make content-publisher"
 
-clone: $(addprefix $(GOVUK_ROOT_DIR)/,$(APPS))
+clone: $(addprefix clone-,$(APPS))
 
 pull:
 	echo $(APPS) | cut -d/ -f3 | xargs -P8 -n1 ./bin/update-git-repo.sh


### PR DESCRIPTION
This broke when the task to clone individual services was renamed.