### PR TITLE
Add command for installing rbenv

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -96,6 +96,7 @@ Then install the correct version of Ruby listed in [.ruby-version](https://githu
 
 ```
 cd ~/govuk/govuk-docker
+brew install rbenv
 rbenv install
 gem install bundler
 ```


### PR DESCRIPTION
I didn't install `rbenv` and the next step failed.