### PR TITLE
Install rbenv using brew on setup

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,5 @@
 brew "dnsmasq"
+brew "rbenv"
 brew "pv"
 brew "shellcheck"
 


### PR DESCRIPTION
This was an additional step we were expected to do manually, so adding rbenv to the Brewfile so it gets installed when `bin/setup` is run.