### PR TITLE
Create the /etc/resolver directory

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -9,6 +9,7 @@ echo -e "✅ Starting Docker...\n"
 
 echo "✅ Configuring dnsmasq [/etc/resolver/dev/gov.uk]"
 echo -e "You may need to enter your root password...\n"
+sudo mkdir /etc/resolver
 echo -e "nameserver 127.0.0.1\nport 53" | sudo tee /etc/resolver/dev.gov.uk >/dev/null
 
 echo -e "✅ Configuring dnsmasq [/usr/local/etc/dnsmasq.conf]\n"


### PR DESCRIPTION
`bin/setup` was writing a file to this directory, but it does not exist so the step was failing so the DNS was not correctly configured.