### PR TITLE
Add replication of integration database as a readonly user example

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,14 @@ There may be times when a full database is required locally.  The following scri
 - `replicate-mysql.sh APP-NAME`
 - `replicate-postgresql.sh APP-NAME`
 
-You will need to assume-role into AWS using the [gds-cli](https://docs.publishing.service.gov.uk/manual/gds-cli.html) before running the scripts. For example, to replicate data for Content Publisher as an AWS PowerUser, run:
+You will need to assume-role into AWS using the [gds-cli](https://docs.publishing.service.gov.uk/manual/gds-cli.html) before running the scripts. For example, to replicate data for Content Publisher, run:
 
 ```
+# as an AWS PowerUser...
 gds aws govuk-integration-poweruser ./bin/replicate-postgresql.sh content-publisher
+
+# as an AWS User...
+gds aws govuk-integration-readonly ./bin/replicate-postgresql.sh content-publisher
 ```
 
 All the scripts, other than `replicate-elasticsearch.sh`, take the name of the app to replicate data for.


### PR DESCRIPTION
If you have added yourself to the list(s) of users found in the data for the infra-security project as a User rather than a PowerUser, you will need to replicate using the `govuk-ENVIRONMENT-readonly`, instead of the `govuk-ENVIRONMENT-poweruser` assumed role.  For example, `govuk-integration-readonly`.