### PR TITLE
Fix phantomjs not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 1.0.0
+
+* Signify that GOV.UK Docker is stable and ready for widespread use.
+
+## 0.0.2
+
+* Fix issue with Jasmine tests using PhantomJS (issue with OpenSSL)
+
+You’ll need to run 'govuk-docker build <project>-lite' to apply the fix.
+
 ## 0.0.1
 
 * Introduce versioning feature to support people when things change

--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -24,6 +24,10 @@ RUN export VERSION=2.1.1 && \
     cp -v phantomjs-$VERSION-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs && \
     rm -vr phantomjs-$VERSION-linux-x86_64
 
+# Workaround for phantomjs openssl issue
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=918727
+ENV OPENSSL_CONF=/dev/null
+
 # Install rbenv to manage ruby versions
 RUN git clone https://github.com/sstephenson/rbenv.git /rbenv
 RUN git clone https://github.com/sstephenson/ruby-build.git /rbenv/plugins/ruby-build

--- a/exe/govuk-docker-version
+++ b/exe/govuk-docker-version
@@ -3,7 +3,7 @@
 VERSION_FILE="$(dirname "$0")/../.version"
 CHANGELOG_FILE="$(dirname "$0")/../CHANGELOG.md"
 
-VERSION=0.0.1
+VERSION=1.0.0
 LOCAL_VERSION=$(cat "$VERSION_FILE" 2>/dev/null)
 
 if grep -xsq $VERSION "$VERSION_FILE"; then


### PR DESCRIPTION
This has been causing apps like finder-frontend to fail when running                                                                                                                                                
'rake' or 'rake spec:javascript' since it still uses phantomjs as the 
headless browser, and phantomjs stopped working.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=918727

Similar issue: https://github.com/grafana/grafana/issues/17588. 

Looks like the principle way to fix this is to replace PhantomJS!