### PR TITLE
Add documentation about contributing / versioning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# CONTRIBUTING
+
+Contributions welcome - just raise a PR and make sure the tests pass!
+
+## Versioning
+
+GOV.UK Docker is [versioned][version] in order to notify users about important changes, where they may need to take action. Since we use the repo itself for distributing GOV.UK Docker, for many PRs it's unlikely you will need to change the version.
+
+> A consequence of this is that GOV.UK Docker does *not* (need to) follow [semantic versioning][semver].
+
+Any change to the [version][] should be accompanied with an explanation in the [CHANGELOG][]. When the [version][] changes, a user running the `govuk-docker` CLI will see a one-time notification, which includes the new [CHANGELOG][] entry.
+
+[version]: exe/govuk-docker-version
+[CHANGELOG]: CHANGELOG.md
+[semver]: https://semver.org/


### PR DESCRIPTION
Previously it was unclear when to use the in-built versioning system.