### PR TITLE
Correct mongo admin port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - mongo:/data/db
     ports:
       - "27017:27017"
-      - "27018:27018"
+      - "28017:28017"
 
   mysql:
     image: mysql:5.5.58


### PR DESCRIPTION
The mongo admin port is 28017, not 27018. As per the output when
starting mongo with `govuk-docker run --service-ports mongo`

```
Mon Jan 20 09:55:00.674 [initandlisten] waiting for connections on port 27017
Mon Jan 20 09:55:00.677 [websvr] admin web console waiting for connections on port 28017
```

[Trello](https://trello.com/c/EZhXbcFY/263-make-govuk-knowledge-graph-work-on-local-machine)