### PR TITLE
Expose postgres port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     image: postgres:9.6
     volumes:
       - postgres:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
 
   memcached:
     image: memcached


### PR DESCRIPTION
Allow connections from the host machine from 0.0.0.0:5432 to aid in
running the knowledge graph locally.