### PR TITLE
Update link to gds-cli in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ There may be times when a full database is required locally.  The following scri
 - `replicate-mysql.sh APP-NAME`
 - `replicate-postgresql.sh APP-NAME`
 
-You will need to assume-role into AWS using the [gds-cli](https://docs.publishing.service.gov.uk/manual/gds-cli.html) before running the scripts. For example, to replicate data for Content Publisher, run:
+You will need to assume-role into AWS using the [gds-cli](https://docs.publishing.service.gov.uk/manual/access-aws-console.html) before running the scripts. For example, to replicate data for Content Publisher, run:
 
 ```
 # as an AWS PowerUser...


### PR DESCRIPTION
The developer docs page for gds-cli no longer exists, so this updates the link
in the README to the gds-cli repo which has instructions.