### PR TITLE
Whitehall specific Dockerfile

### DIFF
--- a/projects/whitehall/Dockerfile
+++ b/projects/whitehall/Dockerfile
@@ -1,0 +1,38 @@
+# Install packages for building ruby
+FROM buildpack-deps
+
+# Install chrome and its dependencies
+RUN apt-get update -qq && apt-get install -y libxss1 libappindicator1 libindicator7
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>&1 && \
+   apt install -y ./google-chrome*.deb && \
+    rm ./google-chrome*.deb
+
+# Install node / yarn
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update -qq && apt-get install -y yarn nodejs
+
+# Install phantomjs for some projects
+RUN export VERSION=2.1.1 && \
+    wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-$VERSION-linux-x86_64.tar.bz2 2>&1 && \
+    tar -vxf phantomjs-$VERSION-linux-x86_64.tar.bz2 && \
+    cp -v phantomjs-$VERSION-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs && \
+    rm -vr phantomjs-$VERSION-linux-x86_64
+
+# Workaround for phantomjs openssl issue
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=918727
+ENV OPENSSL_CONF=/dev/null
+
+# Install rbenv to manage ruby versions
+RUN git clone https://github.com/sstephenson/rbenv.git /rbenv
+RUN git clone https://github.com/sstephenson/ruby-build.git /rbenv/plugins/ruby-build
+RUN /rbenv/plugins/ruby-build/install.sh
+ENV PATH /rbenv/bin:$PATH
+
+# Install Whitehall specific dependencies
+RUN apt-get update -qq && apt-get install -y mysql-client ghostscript
+
+RUN useradd -m build
+ENV PATH /home/build/.rbenv/shims:${PATH}
+USER build

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.7'
 x-whitehall: &whitehall
   build:
     context: .
-    dockerfile: Dockerfile.govuk-base
+    dockerfile: projects/whitehall/Dockerfile
   image: whitehall
   stdin_open: true
   tty: true


### PR DESCRIPTION
This creates a Dockerfile that is used for Whitehall builds. It adds the
ghostscript and mysql-client dependencies. Whitehall uses ghostscript as
a means to create image files from PDFs and it calls out to the MySQL
client during tests to test a sanitisation script.

These seem to be the missing steps needed to get a fully passing
Whitehall test suite passing with GOV.UK docker.