### PR TITLE
Remove rake task from search-api Makefile

### DIFF
--- a/projects/search-api/Makefile
+++ b/projects/search-api/Makefile
@@ -2,5 +2,4 @@ search-api: bundle-search-api publishing-api
 	$(GOVUK_DOCKER) run $@-lite env SEARCH_INDEX=all bundle exec rake search:create_all_indices
 	$(GOVUK_DOCKER) run $@-lite bundle exec rake message_queue:create_queues
 	$(GOVUK_DOCKER) run $@-setup rake publishing_api:publish_eu_exit_business_finder
-	$(GOVUK_DOCKER) run $@-setup rake publishing_api:publish_facet_group_eu_exit_business_finder
 	$(GOVUK_DOCKER) run $@-setup rake publishing_api:publish_supergroup_finders


### PR DESCRIPTION
This task no longer exists - it was removed in https://github.com/alphagov/search-api/commit/d1eed978cdc4ed7f2d3ca46296baef851c07d37a#diff-546d45c60e00b17ec032ebea7bf6a17d