### PR TITLE
Fix Whitehall URI

### DIFF
--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - nginx-proxy
     environment:
       PLEK_SERVICE_SEARCH_URI: https://www.gov.uk/api
-      PLEK_SERVICE_WHITEHALL_ADMIN_URI: https://www.gov.uk
+      PLEK_SERVICE_WHITEHALL_FRONTEND_URI: https://www.gov.uk
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk


### PR DESCRIPTION
Following https://github.com/alphagov/finder-frontend/commit/bb43ad7818245c041dd2ef1546c8ed746ab3159b
we need to set the whitehall uri to be the frontend url in development when pointing the the live enviroment