### PR TITLE
Add Maslow to GOV.UK Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,7 @@ services:
           - link-checker-api.dev.gov.uk
           - manuals-frontend.dev.gov.uk
           - mapit.dev.gov.uk
+          - maslow.dev.gov.uk
           - publisher.dev.gov.uk
           - publishing-api.dev.gov.uk
           - release.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -53,7 +53,7 @@ The following apps are supported by govuk-docker to some extent.
    - ❌ manuals-publisher
    - ✅ mapit
       * TODO: Data replication.
-   - ❌ maslow
+   - ✅ maslow
    - ✅ miller-columns-element
    - ✅ plek
    - ✅ publisher

--- a/projects/maslow/Makefile
+++ b/projects/maslow/Makefile
@@ -1,0 +1,3 @@
+maslow: bundle-maslow publishing-api
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:create
+	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'

--- a/projects/maslow/docker-compose.yml
+++ b/projects/maslow/docker-compose.yml
@@ -1,0 +1,37 @@
+version: '3.7'
+
+x-maslow: &maslow
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: maslow
+  stdin_open: true
+  tty: true
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - home:/home/build
+  working_dir: /govuk/maslow
+
+services:
+  maslow-lite:
+    <<: *maslow
+    privileged: true
+    depends_on:
+      - mongo
+    environment:
+      MONGODB_URI: "mongodb://mongo/maslow"
+      TEST_MONGODB_URI: "mongodb://mongo/maslow-test"
+
+  maslow-app: &maslow-app
+    <<: *maslow
+    depends_on:
+      - mongo
+      - nginx-proxy
+      - publishing-api-app
+    environment:
+      MONGODB_URI: "mongodb://mongo/maslow"
+      VIRTUAL_HOST: maslow.dev.gov.uk
+      HOST: 0.0.0.0
+    expose:
+      - "3000"
+    command: bin/rails s --restart


### PR DESCRIPTION
- Platform Health are upgrading this app to Rails 6, so I felt it was a
  good idea to make it runnable with GOV.UK Docker like the rest of the
  apps.

https://trello.com/c/1TKgm8xV/1743-add-maslow-to-govuk-docker