### PR TITLE
Give more memory to Elasticsearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - http.host=0.0.0.0
       - transport.host=127.0.0.1
       - xpack.security.enabled=false
-      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - ES_JAVA_OPTS=-Xms1g -Xmx1g
     volumes:
       - elasticsearch6:/usr/share/elasticsearch/data
 


### PR DESCRIPTION
This should result in faster queries / long running jobs against the Elasticsearch docker container.