### PR TITLE
Replace mysql-client to default-mysql-client

### DIFF
--- a/projects/whitehall/Dockerfile
+++ b/projects/whitehall/Dockerfile
@@ -31,7 +31,7 @@ RUN /rbenv/plugins/ruby-build/install.sh
 ENV PATH /rbenv/bin:$PATH
 
 # Install Whitehall specific dependencies
-RUN apt-get update -qq && apt-get install -y mysql-client ghostscript
+RUN apt-get update -qq && apt-get install -y default-mysql-client ghostscript
 
 RUN useradd -m build
 ENV PATH /home/build/.rbenv/shims:${PATH}


### PR DESCRIPTION
mysql-client is no longer supported by Debian Buster as it has been replaced by default-mysql-client.
Reference: https://packages.debian.org/buster/default-mysql-client