### PR TITLE
Remove publish_eu_exit_business_finder from make task

### DIFF
--- a/projects/search-api/Makefile
+++ b/projects/search-api/Makefile
@@ -1,5 +1,4 @@
 search-api: bundle-search-api publishing-api
 	$(GOVUK_DOCKER) run $@-lite env SEARCH_INDEX=all bundle exec rake search:create_all_indices
 	$(GOVUK_DOCKER) run $@-lite bundle exec rake message_queue:create_queues
-	$(GOVUK_DOCKER) run $@-setup rake publishing_api:publish_eu_exit_business_finder
 	$(GOVUK_DOCKER) run $@-setup rake publishing_api:publish_supergroup_finders


### PR DESCRIPTION
The old EU exit campaign page has been removed from GOV.UK, this step needs to be removed otherwise finder-frontend will no longer build when the tech debt has been cleared up