### PR TITLE
Increase nginx proxy_read_timeout

### DIFF
--- a/nginx-proxy.conf
+++ b/nginx-proxy.conf
@@ -17,3 +17,5 @@ add_header 'Access-Control-Allow-Origin' '*';
 
 # Required for uploading files on various apps
 client_max_body_size 500m;
+
+proxy_read_timeout 200s;


### PR DESCRIPTION
When assets are compiling in frontend apps, we tend to see 504s as
the process takes so long. Rather than hitting refresh again and
again, increasing the timeout should cut down waiting times.