### PR TITLE
transition: Fix Makefile to run db migrations

### DIFF
--- a/projects/transition/Makefile
+++ b/projects/transition/Makefile
@@ -1,2 +1,2 @@
 transition: bundle-transition
-	$(GOVUK_DOCKER) compose run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'


### PR DESCRIPTION
```
/Users/issylong/govuk/govuk-docker/exe/govuk-docker compose run transition-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
docker-compose -f [...] compose run transition-lite sh -c bin/rake db:migrate 2>/dev/null || bin/rake db:setup
No such command: compose
```