### PR TITLE
Fix auth for new Postgres 9.6 image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ volumes:
 services:
   postgres:
     image: postgres:9.6
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - postgres:/var/lib/postgresql/data
 


### PR DESCRIPTION
    This forces the Postgres 9.6 service to use 'trust' authentication,
    to avoid having to specify a password everywhere. It seems the new
    Postgres 9.6 image no longer provides open access out-of-the-box.