### PR TITLE
Set mongodb to use smallfiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
     ports:
       - "27017:27017"
       - "28017:28017"
+    command: --smallfiles
 
   mysql:
     image: mysql:5.5.58


### PR DESCRIPTION
Seeing persistent errors that there's not enough space. This is a
[common issue in MongoDB prior to 3.0](https://github.com/dockerfile/mongodb/issues/9). Setting the --smallfiles
flag addressed the problem.