### PR TITLE
Send docker-compose line to stderr

### DIFF
--- a/exe/govuk-docker
+++ b/exe/govuk-docker
@@ -21,5 +21,5 @@ if ! "$(dirname "$0")"/govuk-docker-version >/dev/null; then
   read -rp "Press enter to continue..."
 fi
 
-echo "docker-compose -f [...] $*"
+>&2 echo "docker-compose -f [...] $*"
 docker-compose "${COMPOSE_FLAGS[@]}" "$@"


### PR DESCRIPTION
This isn't technically part of the output of the command and it's harder to manipulate the output through a shell with this being included in stdout.

We had this problem when importing the latest mapit data when we wanted to run a command like this:

```
govuk-docker run mapit-app psql -U postgres pg_dump mapit | gzip > mapit.sql.gz
```

And the SQL ended up with the `docker-compose` line at the top of the file.