### PR TITLE
Jenkinsfile: Remove reference to `withStatsdTiming`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,7 @@ node {
     rubyLintDiff: false,
     overrideTestTask: {
       stage("Run tests") {
-        govuk.withStatsdTiming("test_task") {
-          sh "GOVUK_DOCKER_DIR=. make test"
-        }
+        sh "GOVUK_DOCKER_DIR=. make test"
       }
     }
   )


### PR DESCRIPTION
- The functionality to collect metrics about timings of CI runs, visible in CI Graphite, was removed in https://github.com/alphagov/govuk-jenkinslib/pull/69.