### PR TITLE
Add Contacts Admin app to GOV.UK Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
           - calendars.dev.gov.uk
           - collections-publisher.dev.gov.uk
           - collections.dev.gov.uk
+          - contacts-admin.dev.gov.uk
           - content-publisher.dev.gov.uk
           - content-store.dev.gov.uk
           - content-tagger.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -16,7 +16,7 @@ The following apps are supported by govuk-docker to some extent.
       * You will need to [populate the Content Store database](#mongodb) or run the live stack in order for it to work locally.
       * To view topic pages locally you still need to use the live stack as they rely on Elasticsearch data which we are yet to be able to import.
    - ✅ collections-publisher
-   - ❌ contacts-admin
+   - ✅ contacts-admin
    - ⚠ content-data-admin
       * **TODO: Missing support for a webserver stack**
    - ❌ content-data-api

--- a/projects/contacts-admin/Makefile
+++ b/projects/contacts-admin/Makefile
@@ -1,0 +1,2 @@
+contacts-admin: bundle-contacts-admin collections static whitehall
+	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/projects/contacts-admin/docker-compose.yml
+++ b/projects/contacts-admin/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.7'
+
+x-contacts-admin: &contacts-admin
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: contacts-admin
+  stdin_open: true
+  tty: true
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - home:/home/build
+  working_dir: /govuk/contacts-admin
+
+services:
+  contacts-admin-lite:
+    <<: *contacts-admin
+    privileged: true
+    depends_on:
+      - mysql
+      - redis
+    environment:
+      DATABASE_URL: "mysql2://root:root@mysql/contacts_development"
+      TEST_DATABASE_URL: "mysql2://root:root@mysql/contacts_test"
+      REDIS_HOST: redis
+
+  contacts-admin-app:
+    <<: *contacts-admin
+    depends_on:
+      - collections
+      - mysql
+      - nginx-proxy
+      - redis
+      - static
+      - whitehall
+    environment:
+      DATABASE_URL: "mysql2://root:root@mysql/contacts_development"
+      VIRTUAL_HOST: contacts-admin.dev.gov.uk
+      HOST: 0.0.0.0
+      REDIS_HOST: redis
+    expose:
+      - "3000"
+    command: bin/rails s --restart


### PR DESCRIPTION
- All I wanted to do was run `bundle exec rubocop` to fix a bunch of linting errors so that RE can merge one of their PRs.
- Now, contacts-admin is in GOV.UK Docker! The app uses a MySQL database, which I don't have on my local machine, so `bundle install` was failing and it felt easier to do Docker for the benefit of everyone else who might ever need to develop this app.
- The Yak is taking longer to shave than I expected.

----

This is draft as it's not working yet (database woes), but I wanted to raise awareness.