### PR TITLE
Change `'` to `"` for local gem guidance in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You should then be able to `make` your project and have confidence you're not su
 Provide a local gem path relative to the location of the Gemfile you're editing:
 
 ```ruby
-gem 'govuk_publishing_components', path: '../govuk_publishing_components'
+gem "govuk_publishing_components", path: "../govuk_publishing_components"
 ```
 
 ### How to: replicate data locally


### PR DESCRIPTION
Should the readme also meet our linting guidance? 

Makes sense for it to be either - having double quotes is consistent; but having single quotes can stop a local gem from being committed accidentally if the listing is run.