### PR TITLE
Fix deprecation warning due to Rails 6

### DIFF
--- a/projects/smart-answers/docker-compose.yml
+++ b/projects/smart-answers/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - whitehall-app
     environment:
       VIRTUAL_HOST: smart-answers.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart


### PR DESCRIPTION
https://github.com/alphagov/govuk-docker/issues/176