### PR TITLE
Automatically acquire new Ruby versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ all-apps: $(APPS)
 
 bundle-%: clone-%
 	$(GOVUK_DOCKER) build $*-lite
-	$(GOVUK_DOCKER) run $*-lite rbenv install -s
+	$(GOVUK_DOCKER) run $*-lite rbenv install -s || ($(GOVUK_DOCKER) build --no-cache $*-lite; $(GOVUK_DOCKER) run $*-lite rbenv install -s)
 	$(GOVUK_DOCKER) run $*-lite sh -c 'gem install --conservative --no-document bundler -v $$(grep -A1 "BUNDLED WITH" Gemfile.lock | tail -1)'
 	$(GOVUK_DOCKER) run $*-lite bundle
 

--- a/README.md
+++ b/README.md
@@ -161,22 +161,6 @@ docker attach govuk-docker_content-publisher-app_1
 CTRL-P CTRL-Q
 ```
 
-### How to: install a new release of Ruby
-
-Many of our projects use a `.ruby-version` file in conjunction with `rbenv`. When a new version of Ruby is released and we start upgrading our projects, you may start seeing the following error when you run commands.
-
-```
-ruby-build: definition not found: x.y.z
-```
-
-Most of our projects share a common Docker image, which needs rebuilding to be aware of the new Ruby version. To fix the error, run the following commands, replacing '<project>' with the name of the project, e.g. 'collections-publisher'.
-```
-govuk-docker build --no-cache <project>-lite
-
-# in the govuk-docker directory
-make <project>
-```
-
 ## Licence
 
 [MIT License](LICENCE)

--- a/README.md
+++ b/README.md
@@ -77,11 +77,14 @@ git pull
 # make sure the project is built OK
 make <project>
 
-# tail logs for running services
-govuk-docker logs -f
-
-# get all the running containers
+# check if any dependencies have exited
 docker ps -a
+
+# tail logs for running services/dependencies
+govuk-docker logs -f publishing-api-app
+
+# try clearing all containers / volumes
+govuk-docker rm -sv
 ```
 
 ### How to: update everything!
@@ -91,16 +94,6 @@ Sometimes it's useful to get all changes for all repos e.g. to support finding t
 ```
 make pull
 ```
-
-### How to: clear your Docker containers
-
-Sometimes things don't work as expected, and the easiest thing to do is to start over and stop/remove all GOV.UK Docker containers.
-
-```
-govuk-docker rm -sv
-```
-
-You should then be able to `make` your project and have confidence you're not suffering from configuration drift.
 
 ### How to: work with local gems
 


### PR DESCRIPTION
Previously we had documentation for when an app started using a new version
of Ruby that was not in the list that's built into the associated image.
This replaces the documentation with an automatic command to rebuild the
image with the latest list of Ruby versions. (Pointing people to docs over
and over gets old fast!)

Please see the commits for more details.