### PR TITLE
Add 'lite' stack for service-manual-publisher

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -68,7 +68,8 @@ The following apps are supported by govuk-docker to some extent.
    - ✅ search-admin
    - ✅ search-api
    - ✅ service-manual-frontend
-   - ❌ service-manual-publisher
+   - ⚠ service-manual-publisher
+      * **TODO: Missing support for a webserver stack**
    - ✅ short-url-manager
    - ✅ signon
    - ✅ smart-answers

--- a/projects/service-manual-publisher/Makefile
+++ b/projects/service-manual-publisher/Makefile
@@ -1,0 +1,2 @@
+service-manual-publisher: bundle-service-manual-publisher
+	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:create'

--- a/projects/service-manual-publisher/docker-compose.yml
+++ b/projects/service-manual-publisher/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.7'
+
+x-service-manual-publisher: &service-manual-publisher
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: service-manual-publisher
+  stdin_open: true
+  tty: true
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - home:/home/build
+  working_dir: /govuk/service-manual-publisher
+
+services:
+  service-manual-publisher-lite:
+    <<: *service-manual-publisher
+    privileged: true
+    depends_on:
+      - postgres
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres/service-manual-publisher"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres/service-manual-publisher-test"
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"


### PR DESCRIPTION
Running 'rake' is successful. We can always improve support for this
app (to run web server stacks) when the need arises.

Note that service-manual-publisher uses a legacy 'structure.sql' to
manage the DB, so we need to use 'db:create' to populate the it.

Running 'db:migrate' won't work.

    StandardError: An error has occurred, this and all later migrations canceled:

    Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

      class CreateUsers < ActiveRecord::Migration[4.2]