### PR TITLE
ci: Run checks on master branch builds and all PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: govuk-docker
 
-on: push
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
- This matches our current thinking in
  https://github.com/alphagov/govuk-rfcs/pull/123, given that [push
  events don't run on forked branches in the forked repo, or when
  they're made into PRs](https://github.com/alphagov/govuk-docker/pull/337).