### PR TITLE
Add ASSET_HOST env var to frontend apps

### DIFF
--- a/projects/calculators/docker-compose.yml
+++ b/projects/calculators/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - static-app
       - nginx-proxy
     environment:
+      ASSET_HOST: calculators.dev.gov.uk
       GOVUK_ASSET_ROOT: calculators.dev.gov.uk
       VIRTUAL_HOST: calculators.dev.gov.uk
       HOST: 0.0.0.0
@@ -41,6 +42,7 @@ services:
       - static-app-draft
       - nginx-proxy
     environment:
+      ASSET_HOST: draft-calculators.dev.gov.uk
       GOVUK_ASSET_ROOT: draft-calculators.dev.gov.uk
       VIRTUAL_HOST: draft-calculators.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"

--- a/projects/collections/docker-compose.yml
+++ b/projects/collections/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - static-app
       - nginx-proxy
     environment:
+      ASSET_HOST: collections.dev.gov.uk
       GOVUK_ASSET_ROOT: collections.dev.gov.uk
       VIRTUAL_HOST: collections.dev.gov.uk
       HOST: 0.0.0.0
@@ -42,6 +43,7 @@ services:
       - static-app-draft
       - nginx-proxy
     environment:
+      ASSET_HOST: draft-collections.dev.gov.uk
       GOVUK_ASSET_ROOT: draft-collections.dev.gov.uk
       VIRTUAL_HOST: draft-collections.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"

--- a/projects/email-alert-frontend/docker-compose.yml
+++ b/projects/email-alert-frontend/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - email-alert-api-app
       - nginx-proxy
     environment:
+      ASSET_HOST: email-alert-frontend.dev.gov.uk
       GOVUK_ASSET_ROOT: email-alert-frontend.dev.gov.uk
       VIRTUAL_HOST: email-alert-frontend.dev.gov.uk
       BINDING: 0.0.0.0

--- a/projects/feedback/docker-compose.yml
+++ b/projects/feedback/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - support-api-app
       - support-app
     environment:
+      ASSET_HOST: feedback.dev.gov.uk
       GOVUK_ASSET_ROOT: feedback.dev.gov.uk
       VIRTUAL_HOST: feedback.dev.gov.uk
       HOST: 0.0.0.0

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - memcached
       - nginx-proxy
     environment:
+      ASSET_HOST: finder-frontend.dev.gov.uk
       GOVUK_ASSET_ROOT: finder-frontend.dev.gov.uk
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       BINDING: 0.0.0.0

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - static-app
       - nginx-proxy
     environment:
+      ASSET_HOST: frontend.dev.gov.uk
       GOVUK_ASSET_ROOT: frontend.dev.gov.uk
       VIRTUAL_HOST: frontend.dev.gov.uk
       BINDING: 0.0.0.0
@@ -45,6 +46,7 @@ services:
       - static-app-draft
       - nginx-proxy
     environment:
+      ASSET_HOST: draft-frontend.dev.gov.uk
       GOVUK_ASSET_ROOT: draft-frontend.dev.gov.uk
       VIRTUAL_HOST: draft-frontend.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"

--- a/projects/government-frontend/docker-compose.yml
+++ b/projects/government-frontend/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - static-app
       - nginx-proxy
     environment:
+      ASSET_HOST: government-frontend.dev.gov.uk
       GOVUK_ASSET_ROOT: government-frontend.dev.gov.uk
       VIRTUAL_HOST: government-frontend.dev.gov.uk
       HOST: 0.0.0.0
@@ -40,6 +41,7 @@ services:
       - static-app-draft
       - nginx-proxy
     environment:
+      ASSET_HOST: draft-government-frontend.dev.gov.uk
       GOVUK_ASSET_ROOT: draft-government-frontend.dev.gov.uk
       VIRTUAL_HOST: draft-government-frontend.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"

--- a/projects/info-frontend/docker-compose.yml
+++ b/projects/info-frontend/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - static-app
       - nginx-proxy
     environment:
+      ASSET_HOST: info-frontend.dev.gov.uk
       GOVUK_ASSET_ROOT: info-frontend.dev.gov.uk
       VIRTUAL_HOST: info-frontend.dev.gov.uk
       HOST: 0.0.0.0

--- a/projects/manuals-frontend/docker-compose.yml
+++ b/projects/manuals-frontend/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - static-app
       - nginx-proxy
     environment:
+      ASSET_HOST: manuals-frontend.dev.gov.uk
       GOVUK_ASSET_ROOT: manuals-frontend.dev.gov.uk
       VIRTUAL_HOST: manuals-frontend.dev.gov.uk
       HOST: 0.0.0.0
@@ -40,6 +41,7 @@ services:
       - static-app-draft
       - nginx-proxy
     environment:
+      ASSET_HOST: draft-manuals-frontend.dev.gov.uk
       GOVUK_ASSET_ROOT: draft-manuals-frontend.dev.gov.uk
       VIRTUAL_HOST: draft-manuals-frontend.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"

--- a/projects/service-manual-frontend/docker-compose.yml
+++ b/projects/service-manual-frontend/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - static-app
       - nginx-proxy
     environment:
+      ASSET_HOST: service-manual-frontend.dev.gov.uk
       GOVUK_ASSET_ROOT: service-manual-frontend.dev.gov.uk
       VIRTUAL_HOST: service-manual-frontend.dev.gov.uk
       HOST: 0.0.0.0
@@ -39,6 +40,7 @@ services:
       - static-app-draft
       - nginx-proxy
     environment:
+      ASSET_HOST: draft-service-manual-frontend.dev.gov.uk
       GOVUK_ASSET_ROOT: draft-service-manual-frontend.dev.gov.uk
       VIRTUAL_HOST: draft-service-manual-frontend.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"

--- a/projects/static/docker-compose.yml
+++ b/projects/static/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - redis
       - nginx-proxy
     environment:
+      ASSET_HOST: static.dev.gov.uk
       REDIS_URL: redis://redis
       GOVUK_ASSET_ROOT: static.dev.gov.uk
       VIRTUAL_HOST: static.dev.gov.uk
@@ -36,6 +37,7 @@ services:
       - redis
       - nginx-proxy
     environment:
+      ASSET_HOST: draft-static.dev.gov.uk
       REDIS_URL: redis://redis
       GOVUK_ASSET_ROOT: draft-static.dev.gov.uk
       VIRTUAL_HOST: draft-static.dev.gov.uk


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This adds environment variables for all the frontend apps that can be
used to specify the hostname used for assets. This is to support the
change of hostname for assets of GOV.UK apps from the
`assets.publishing.service.gov.uk` hostname to the `www.gov.uk` one.
For more information on this change see: https://github.com/alphagov/govuk-puppet/pull/10360.

This change pre-emptively applies this environment variable to all
frontend apps with the expectation that the apps will gradually support
this env var as the apps are migrated. Once each app has been
migrated the GOVUK_ASSET_ROOT environment variables for them can be
removed.