### PR TITLE
Bump mongo version to 3.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     image: memcached
 
   mongo:
-    image: mongo:2.4
+    image: mongo:3.6
     volumes:
       - mongo:/data/db
     ports:


### PR DESCRIPTION
This matches the upgrade to Publisher [1]. Also tested against
Content Store. Note that this may require a wipe of the previous
mongo volume, using 'docker volume rm govuk-docker_mongo'.

[1]: https://github.com/alphagov/publisher/pull/1275