### PR TITLE
Add local-links-manager-app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,7 @@ services:
           - info-frontend.dev.gov.uk
           - licence-finder.dev.gov.uk
           - link-checker-api.dev.gov.uk
+          - local-links-manager.dev.gov.uk
           - manuals-frontend.dev.gov.uk
           - mapit.dev.gov.uk
           - maslow.dev.gov.uk

--- a/projects/local-links-manager/docker-compose.yml
+++ b/projects/local-links-manager/docker-compose.yml
@@ -19,3 +19,16 @@ services:
     environment:
       DATABASE_URL: "postgresql://postgres@postgres/local-links-manager"
       TEST_DATABASE_URL: "postgresql://postgres@postgres/local-links-manager-test"
+  local-links-manager-app:
+    <<: *local-links-manager
+    privileged: true
+    depends_on:
+      - postgres
+      - nginx-proxy
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres/local-links-manager"
+      VIRTUAL_HOST: local-links-manager.dev.gov.uk
+      HOST: 0.0.0.0
+    expose:
+      - "3000"
+    command: bin/rails s --restart

--- a/projects/local-links-manager/docker-compose.yml
+++ b/projects/local-links-manager/docker-compose.yml
@@ -5,6 +5,8 @@ x-local-links-manager: &local-links-manager
     context: .
     dockerfile: Dockerfile.govuk-base
   image: local-links-manager
+  stdin_open: true
+  tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build


### PR DESCRIPTION
As part of work on another card I realised getting local-links-manager running
locally was quite painful. So this PR adds `local-links-manager-app` so the app
can be run locally using govuk-docker.

https://trello.com/c/t0Lb55iG/1996-get-local-links-manager-working-in-govuk-docker