### PR TITLE
Add 'live' stack for licence-finder

### DIFF
--- a/projects/licence-finder/docker-compose.yml
+++ b/projects/licence-finder/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       TEST_MONGODB_URI: "mongodb://mongo/licence-finder_test"
       ELASTICSEARCH_URI: http://elasticsearch6:9200
 
-  licence-finder-app:
+  licence-finder-app: &licence-finder-app
     <<: *licence-finder
     depends_on:
       - mongo
@@ -43,3 +43,17 @@ services:
     expose:
       - "3000"
     command: bin/rails s --restart
+
+  licence-finder-app-live:
+    <<: *licence-finder-app
+    depends_on:
+      - mongo
+      - nginx-proxy
+    environment:
+      MONGODB_URI: "mongodb://mongo/licence-finder_development"
+      PLEK_SERVICE_SEARCH_URI: https://www.gov.uk/api
+      GOVUK_WEBSITE_ROOT: https://www.gov.uk
+      PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
+      PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
+      VIRTUAL_HOST: licence-finder.dev.gov.uk
+      HOST: 0.0.0.0


### PR DESCRIPTION
I found this useful when debugging something, since I didn't need
to fabricate my own local data.