### PR TITLE
Use a standard Makefile command to setup DB

### DIFF
--- a/projects/service-manual-publisher/Makefile
+++ b/projects/service-manual-publisher/Makefile
@@ -1,2 +1,2 @@
 service-manual-publisher: bundle-service-manual-publisher
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:create'
+	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'


### PR DESCRIPTION
https://trello.com/c/KNWv9Dgx/258-migrate-legacy-email-signup-pages-for-service-manual-formats

Previously we had to use a custom command to setup the DB for Service
Manual Publisher, since it used an unconventional "structure.sql" file
to manage it's DB. This switches to the normal command we use to setup
Postgres DBs for other apps, which the app now supports [1].

[1]: https://github.com/alphagov/service-manual-publisher/pull/816