### PR TITLE
Remove GOVUK_ASSET_ROOT env vars

### DIFF
--- a/projects/calculators/docker-compose.yml
+++ b/projects/calculators/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: calculators.dev.gov.uk
-      GOVUK_ASSET_ROOT: calculators.dev.gov.uk
       VIRTUAL_HOST: calculators.dev.gov.uk
       HOST: 0.0.0.0
     expose:
@@ -43,7 +42,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: draft-calculators.dev.gov.uk
-      GOVUK_ASSET_ROOT: draft-calculators.dev.gov.uk
       VIRTUAL_HOST: draft-calculators.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"
       HOST: 0.0.0.0

--- a/projects/collections/docker-compose.yml
+++ b/projects/collections/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: collections.dev.gov.uk
-      GOVUK_ASSET_ROOT: collections.dev.gov.uk
       VIRTUAL_HOST: collections.dev.gov.uk
       HOST: 0.0.0.0
     expose:
@@ -44,7 +43,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: draft-collections.dev.gov.uk
-      GOVUK_ASSET_ROOT: draft-collections.dev.gov.uk
       VIRTUAL_HOST: draft-collections.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"
       HOST: 0.0.0.0

--- a/projects/email-alert-frontend/docker-compose.yml
+++ b/projects/email-alert-frontend/docker-compose.yml
@@ -32,7 +32,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: email-alert-frontend.dev.gov.uk
-      GOVUK_ASSET_ROOT: email-alert-frontend.dev.gov.uk
       VIRTUAL_HOST: email-alert-frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/feedback/docker-compose.yml
+++ b/projects/feedback/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       - support-app
     environment:
       ASSET_HOST: feedback.dev.gov.uk
-      GOVUK_ASSET_ROOT: feedback.dev.gov.uk
       VIRTUAL_HOST: feedback.dev.gov.uk
       HOST: 0.0.0.0
     expose:

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -32,7 +32,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: finder-frontend.dev.gov.uk
-      GOVUK_ASSET_ROOT: finder-frontend.dev.gov.uk
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       BINDING: 0.0.0.0
       MEMCACHE_SERVERS: memcached

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -26,7 +26,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: frontend.dev.gov.uk
-      GOVUK_ASSET_ROOT: frontend.dev.gov.uk
       VIRTUAL_HOST: frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -47,7 +46,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: draft-frontend.dev.gov.uk
-      GOVUK_ASSET_ROOT: draft-frontend.dev.gov.uk
       VIRTUAL_HOST: draft-frontend.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"
       BINDING: 0.0.0.0

--- a/projects/government-frontend/docker-compose.yml
+++ b/projects/government-frontend/docker-compose.yml
@@ -26,7 +26,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: government-frontend.dev.gov.uk
-      GOVUK_ASSET_ROOT: government-frontend.dev.gov.uk
       VIRTUAL_HOST: government-frontend.dev.gov.uk
       HOST: 0.0.0.0
     expose:
@@ -42,7 +41,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: draft-government-frontend.dev.gov.uk
-      GOVUK_ASSET_ROOT: draft-government-frontend.dev.gov.uk
       VIRTUAL_HOST: draft-government-frontend.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"
       HOST: 0.0.0.0

--- a/projects/info-frontend/docker-compose.yml
+++ b/projects/info-frontend/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: info-frontend.dev.gov.uk
-      GOVUK_ASSET_ROOT: info-frontend.dev.gov.uk
       VIRTUAL_HOST: info-frontend.dev.gov.uk
       HOST: 0.0.0.0
     expose:

--- a/projects/manuals-frontend/docker-compose.yml
+++ b/projects/manuals-frontend/docker-compose.yml
@@ -26,7 +26,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: manuals-frontend.dev.gov.uk
-      GOVUK_ASSET_ROOT: manuals-frontend.dev.gov.uk
       VIRTUAL_HOST: manuals-frontend.dev.gov.uk
       HOST: 0.0.0.0
     expose:
@@ -42,7 +41,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: draft-manuals-frontend.dev.gov.uk
-      GOVUK_ASSET_ROOT: draft-manuals-frontend.dev.gov.uk
       VIRTUAL_HOST: draft-manuals-frontend.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"
       HOST: 0.0.0.0

--- a/projects/service-manual-frontend/docker-compose.yml
+++ b/projects/service-manual-frontend/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: service-manual-frontend.dev.gov.uk
-      GOVUK_ASSET_ROOT: service-manual-frontend.dev.gov.uk
       VIRTUAL_HOST: service-manual-frontend.dev.gov.uk
       HOST: 0.0.0.0
     expose:
@@ -41,7 +40,6 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: draft-service-manual-frontend.dev.gov.uk
-      GOVUK_ASSET_ROOT: draft-service-manual-frontend.dev.gov.uk
       VIRTUAL_HOST: draft-service-manual-frontend.dev.gov.uk
       PLEK_HOSTNAME_PREFIX: "draft-"
       HOST: 0.0.0.0

--- a/projects/static/docker-compose.yml
+++ b/projects/static/docker-compose.yml
@@ -24,7 +24,6 @@ services:
     environment:
       ASSET_HOST: static.dev.gov.uk
       REDIS_URL: redis://redis
-      GOVUK_ASSET_ROOT: static.dev.gov.uk
       VIRTUAL_HOST: static.dev.gov.uk
       HOST: 0.0.0.0
     expose:
@@ -39,6 +38,5 @@ services:
     environment:
       ASSET_HOST: draft-static.dev.gov.uk
       REDIS_URL: redis://redis
-      GOVUK_ASSET_ROOT: draft-static.dev.gov.uk
       VIRTUAL_HOST: draft-static.dev.gov.uk
       HOST: 0.0.0.0


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

These are not necessary now these apps are migrated to use the ASSET_HOST env var, as was introduced in https://github.com/alphagov/govuk-docker/pull/351