### PR TITLE
Remove E2E stacks for most projects

### DIFF
--- a/projects/asset-manager/docker-compose.yml
+++ b/projects/asset-manager/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - mongo
       - redis
       - nginx-proxy
+      - asset-manager-worker
     environment:
       MONGODB_URI: "mongodb://mongo/asset-manager"
       REDIS_URL: redis://redis
@@ -37,14 +38,6 @@ services:
     expose:
       - "3000"
     command: bin/rails s --restart
-
-  asset-manager-app-e2e:
-    <<: *asset-manager-app
-    depends_on:
-      - mongo
-      - redis
-      - nginx-proxy
-      - asset-manager-worker
 
   asset-manager-worker:
     <<: *asset-manager

--- a/projects/collections-publisher/docker-compose.yml
+++ b/projects/collections-publisher/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - link-checker-api-app
       - nginx-proxy
       - publishing-api-app
+      - collections-publisher-worker
     environment:
       DATABASE_URL: "mysql2://root:root@mysql/collections_publisher_development"
       REDIS_URL: redis://redis
@@ -48,18 +49,8 @@ services:
     depends_on:
       - redis
       - mysql
-      - publishing-api-app-e2e
+      - publishing-api-app
     environment:
       DATABASE_URL: "mysql2://root:root@mysql/collections_publisher_development"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
-
-  collections-publisher-app-e2e:
-    <<: *collections-publisher-app
-    depends_on:
-      - redis
-      - mysql
-      - content-store-app
-      - link-checker-api-app
-      - nginx-proxy
-      - collections-publisher-worker

--- a/projects/email-alert-frontend/Makefile
+++ b/projects/email-alert-frontend/Makefile
@@ -1,6 +1,1 @@
-email-alert-frontend: bundle-email-alert-frontend email-alert-api content-store static publishing-api router
-	$(GOVUK_DOCKER) run $@-setup bin/rake publishing_api:publish_email_signup_page
-	$(GOVUK_DOCKER) run $@-setup bin/rake publishing_api:publish_email_unsubscribe_prefix
-	$(GOVUK_DOCKER) run $@-setup bin/rake publishing_api:publish_email_subscriptions_prefix
-	$(GOVUK_DOCKER) run $@-setup bin/rake publishing_api:publish_email_authenticate_prefix
-	$(GOVUK_DOCKER) run $@-setup bin/rake publishing_api:publish_email_manage_prefix
+email-alert-frontend: bundle-email-alert-frontend email-alert-api content-store static router

--- a/projects/email-alert-frontend/docker-compose.yml
+++ b/projects/email-alert-frontend/docker-compose.yml
@@ -16,12 +16,6 @@ services:
   email-alert-frontend-lite:
     <<: *email-alert-frontend
 
-  email-alert-frontend-setup:
-    <<: *email-alert-frontend
-    depends_on:
-      - publishing-api-app-e2e
-      - nginx-proxy
-
   email-alert-frontend-app: &email-alert-frontend-app
     <<: *email-alert-frontend
     depends_on:

--- a/projects/frontend/Makefile
+++ b/projects/frontend/Makefile
@@ -1,2 +1,1 @@
-frontend: bundle-frontend content-store router static publishing-api
-	$(GOVUK_DOCKER) run $@-setup bin/rake publishing_api:publish_special_routes
+frontend: bundle-frontend content-store router static

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -32,11 +32,6 @@ services:
       - "3000"
     command: bin/rails s --restart
 
-  frontend-setup:
-    <<: *frontend
-    depends_on:
-      - publishing-api-app-e2e
-
   frontend-app-draft:
     <<: *frontend-app
     depends_on:

--- a/projects/publisher/Makefile
+++ b/projects/publisher/Makefile
@@ -1,2 +1,2 @@
-publisher: bundle-publisher publishing-api frontend link-checker-api
+publisher: bundle-publisher publishing-api link-checker-api
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'

--- a/projects/publisher/docker-compose.yml
+++ b/projects/publisher/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - mongo
       - nginx-proxy
       - publishing-api-app
-      - frontend-app
       - link-checker-api-app
       - publisher-worker
     environment:

--- a/projects/publisher/docker-compose.yml
+++ b/projects/publisher/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - publishing-api-app
       - frontend-app
       - link-checker-api-app
+      - publisher-worker
     environment:
       MONGODB_URI: "mongodb://mongo/publisher"
       REDIS_URL: redis://redis
@@ -42,24 +43,13 @@ services:
       - "3000"
     command: bin/rails s --restart
 
-  publisher-app-e2e:
-    <<: *publisher-app
-    depends_on:
-      - redis
-      - mongo
-      - publisher-worker
-      - nginx-proxy
-      - publishing-api-app-e2e
-      - frontend-app
-      - link-checker-api-app
-
   publisher-worker:
     <<: *publisher
     depends_on:
       - redis
       - mongo
       - nginx-proxy
-      - publishing-api-app-e2e
+      - publishing-api-app
     environment:
       MONGODB_URI: "mongodb://mongo/publisher"
       REDIS_URL: redis://redis

--- a/projects/publishing-api/Makefile
+++ b/projects/publishing-api/Makefile
@@ -1,4 +1,4 @@
-publishing-api: bundle-publishing-api content-store govuk-content-schemas
+publishing-api: bundle-publishing-api govuk-content-schemas
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'
 	$(GOVUK_DOCKER) run $@-lite bin/rake setup_exchange

--- a/projects/publishing-api/docker-compose.yml
+++ b/projects/publishing-api/docker-compose.yml
@@ -41,26 +41,3 @@ services:
     expose:
       - "3000"
     command: bin/rails s --restart
-
-  publishing-api-app-e2e:
-    <<: *publishing-api-app
-    depends_on:
-      - postgres
-      - redis
-      - nginx-proxy
-      - publishing-api-worker
-
-  publishing-api-worker:
-    <<: *publishing-api
-    depends_on:
-      - postgres
-      - redis
-      - rabbitmq
-      - content-store-app-draft
-      - content-store-app
-    environment:
-      RABBITMQ_EXCHANGE: published_documents
-      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
-      DATABASE_URL: "postgresql://postgres@postgres/publishing-api"
-      REDIS_URL: redis://redis
-    command: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -45,7 +45,7 @@ services:
   search-api-setup:
     <<: *search-api
     depends_on:
-      - publishing-api-app-e2e
+      - publishing-api-app
 
   search-api-worker:
     <<: *search-api

--- a/projects/specialist-publisher/docker-compose.yml
+++ b/projects/specialist-publisher/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - publishing-api-app
       - asset-manager-app
       - email-alert-api-app
+      - specialist-publisher-worker
     environment:
       MONGODB_URI: "mongodb://mongo/specialist-publisher"
       REDIS_URL: redis://redis
@@ -42,24 +43,13 @@ services:
       - "3000"
     command: bin/rails s --restart
 
-  specialist-publisher-app-e2e:
-    <<: *specialist-publisher-app
-    depends_on:
-      - mongo
-      - redis
-      - specialist-publisher-worker
-      - publishing-api-app-e2e
-      - asset-manager-app-e2e
-      - email-alert-api-app
-      - nginx-proxy
-
   specialist-publisher-worker:
     <<: *specialist-publisher
     depends_on:
       - mongo
       - redis
-      - publishing-api-app-e2e
-      - asset-manager-app-e2e
+      - publishing-api-app
+      - asset-manager-app
     environment:
       MONGODB_URI: "mongodb://mongo/specialist-publisher"
       REDIS_URL: redis://redis

--- a/projects/travel-advice-publisher/docker-compose.yml
+++ b/projects/travel-advice-publisher/docker-compose.yml
@@ -47,8 +47,8 @@ services:
     depends_on:
       - mongo
       - redis
-      - publishing-api-app-e2e
-      - asset-manager-app-e2e
+      - publishing-api-app
+      - asset-manager-app
     environment:
       DATABASE_URL: "postgresql://postgres@postgres/travel-advice-publisher"
       REDIS_URL: redis://redis

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -43,13 +43,3 @@ services:
       - "3000"
     # Change to 'bin/rails --restart' when rails >= 5.2
     command: /bin/sh -c "rm -f tmp/pids/server.pid && rails s"
-
-  whitehall-app-e2e:
-    <<: *whitehall-app
-    depends_on:
-      - mysql
-      - redis
-      - static-app
-      - nginx-proxy
-      - asset-manager-app-e2e
-      - publishing-api-app-e2e


### PR DESCRIPTION
Previously these stacks were created to simulate a realistic GOV.UK
end-to-end experience on a local machine. However, the dependency chain
they create for running 'make' is excessive for the day-to-day value they
add. This remove most uses of E2E dependencies.

Please see the commits for more details.