### PR TITLE
Add missing imagemagick dependency to the Whitehall Dockerfile

### DIFF
--- a/projects/whitehall/Dockerfile
+++ b/projects/whitehall/Dockerfile
@@ -31,7 +31,7 @@ RUN /rbenv/plugins/ruby-build/install.sh
 ENV PATH /rbenv/bin:$PATH
 
 # Install Whitehall specific dependencies
-RUN apt-get update -qq && apt-get install -y default-mysql-client ghostscript
+RUN apt-get update -qq && apt-get install -y default-mysql-client ghostscript imagemagick
 
 RUN useradd -m build
 ENV PATH /home/build/.rbenv/shims:${PATH}


### PR DESCRIPTION
Whitehall uses the mini_magick Ruby library, and I believe this
Dockerfile is written with the intention of using bundler/rubygems to
install mini_magick.

Unfortunately, bundler/rubygems aren't capable enough to sort out
installing imagemagick, which is a problem, as it's needed to make
mini_magick work. Therefore, install the Debian package for
imagemagick through the Dockerfile.