### PR TITLE
router-api: rename env var HOST to BINDING

### DIFF
--- a/projects/router-api/docker-compose.yml
+++ b/projects/router-api/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       ROUTER_NODES: router-app:3055
       MONGODB_URI: "mongodb://mongo/router"
       VIRTUAL_HOST: router-api.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -46,4 +46,4 @@ services:
       ROUTER_NODES: router-app-draft:3055
       MONGODB_URI: "mongodb://mongo/draft-router"
       VIRTUAL_HOST: draft-router-api.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0


### PR DESCRIPTION
Rails 6 deprecated the HOST variable in favour of BINDING
See: https://github.com/rails/rails/pull/32540