### PR TITLE
Change govuk_publishing_components to use yarn

### DIFF
--- a/projects/govuk_publishing_components/Makefile
+++ b/projects/govuk_publishing_components/Makefile
@@ -1,2 +1,2 @@
 govuk_publishing_components: bundle-govuk_publishing_components
-	$(GOVUK_DOCKER) run $@-lite npm install
+	$(GOVUK_DOCKER) run $@-lite yarn install


### PR DESCRIPTION
This reflects the change made in https://github.com/alphagov/govuk_publishing_components/pull/1610