### PR TITLE
Fix typo in authenticating-proxy/Makefile

### DIFF
--- a/projects/authenticating-proxy/Makefile
+++ b/projects/authenticating-proxy/Makefile
@@ -1,2 +1,2 @@
 authenticating-proxy: bundle-authenticating-proxy router
-	$(GOVUK_DOCKER) compose run $@-lite bin/rails runner 'User.first || User.create'
+	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'


### PR DESCRIPTION
There isn't a govuk-docker compose command, so i expect this a leftover from an earlier iteration of this code, that perhaps hasn't been spotted on a less frequently used service