### PR TITLE
Fix DB setup step to allow contacts-admin to build

### DIFF
--- a/projects/contacts-admin/Makefile
+++ b/projects/contacts-admin/Makefile
@@ -1,2 +1,2 @@
 contacts-admin: bundle-contacts-admin
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:create db:migrate'
+	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'


### PR DESCRIPTION
Resolves:  #318 

Tested with `make contacts-admin` - :+1:  it works!

The previous makefile was attempting to set up the initial DB by running
migrations which is not the [recommended appraoch for building the db of
a Rails app](https://guides.rubyonrails.org/v3.2/migrations.html#schema-dumping-and-you) as Kevin mentioned in [Issue #381](https://github.com/alphagov/govuk-docker/issues/381)

So I've brought this into line with [the whitehall makefile](https://github.com/alphagov/govuk-docker/blob/a9e00d16c613f42159897ea003e20b9ff3769c3e/projects/whitehall/Makefile#L2). This mirrors recent changes to [signon](https://github.com/alphagov/signon/pull/1458)

Co-authored-by: Kevin Dew <kevin-dew@digital.cabinet-office.gov.uk>