### PR TITLE
Remove data insertion step for Search API

### DIFF
--- a/projects/search-api/Makefile
+++ b/projects/search-api/Makefile
@@ -1,4 +1,3 @@
-search-api: bundle-search-api publishing-api
+search-api: bundle-search-api
 	$(GOVUK_DOCKER) run $@-lite env SEARCH_INDEX=all bundle exec rake search:create_all_indices
 	$(GOVUK_DOCKER) run $@-lite bundle exec rake message_queue:create_queues
-	$(GOVUK_DOCKER) run $@-setup bundle exec rake publishing_api:publish_supergroup_finders

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -42,11 +42,6 @@ services:
       - "3000"
     command: bundle exec mr-sparkle --force-polling -- -p 3000
 
-  search-api-setup:
-    <<: *search-api
-    depends_on:
-      - publishing-api-app
-
   search-api-worker:
     <<: *search-api
     depends_on:


### PR DESCRIPTION
Closes: https://github.com/alphagov/govuk-docker/issues/223

This can/should be achieved with data replication, so it's not a
necessary part of the build process.