### PR TITLE
Remove the last remaining E2E stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,6 @@ To provide consistency we have a convention for these names:
     point to the [draft content-store](https://docs.publishing.service.gov.uk/manual/content-preview.html).
   - **app-live**: if the app is a read-only frontend app, the live stack will
     point the production versions of content-store, search-api and static.
-  - **app-e2e**: to run the app with all the other apps necessary to provide
-    full end to end user journeys.
-
-### Interoperability of stacks
-
-Even if an e2e stack is started, functionality won't necessarily work as expected "end to end" as govuk-docker doesn't mimick the routing we have on GOV.UK. For example, publishing apps that link to draft-origin.dev.gov.uk frontends will see a server error, as draft-origin isn't a project in govuk-docker.
-
-In these cases, you can swap out the URL for the relevant frontend (such as draft-collections.dev.gov.uk). It's also worth noting that this frontend will need to be started separately, as publishing apps don't define frontend apps in their dependencies; a publishing app doesn't need its corresponding frontend in order to be able to publish.
 
 ## How to's
 

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -33,6 +33,10 @@ services:
       - nginx-proxy
       - redis
       - elasticsearch6
+      - search-api-worker
+      - search-api-listener-publishing-queue
+      - search-api-listener-insert-data
+      - search-api-listener-bulk-insert-data
     environment:
       REDIS_HOST: redis
       ELASTICSEARCH_URI: http://elasticsearch6:9200
@@ -72,14 +76,3 @@ services:
     depends_on:
       - rabbitmq
     command: bundle exec rake message_queue:bulk_insert_data_into_govuk
-
-  search-api-app-e2e:
-    <<: *search-api-app
-    depends_on:
-      - nginx-proxy
-      - redis
-      - elasticsearch6
-      - search-api-worker
-      - search-api-listener-publishing-queue
-      - search-api-listener-insert-data
-      - search-api-listener-bulk-insert-data


### PR DESCRIPTION
Previously we removed all the E2E stacks [1], with one for Search
API still remaining. Since the 'E2E' stack just spins up a few more
workers, it can just be merged with the existing '-app' stack.

[1]: https://github.com/alphagov/govuk-docker/pull/368