### PR TITLE
Fix search-api Makefile

### DIFF
--- a/projects/search-api/Makefile
+++ b/projects/search-api/Makefile
@@ -1,4 +1,4 @@
 search-api: bundle-search-api publishing-api
 	$(GOVUK_DOCKER) run $@-lite env SEARCH_INDEX=all bundle exec rake search:create_all_indices
 	$(GOVUK_DOCKER) run $@-lite bundle exec rake message_queue:create_queues
-	$(GOVUK_DOCKER) run $@-setup rake publishing_api:publish_supergroup_finders
+	$(GOVUK_DOCKER) run $@-setup bundle exec rake publishing_api:publish_supergroup_finders


### PR DESCRIPTION
The make file was running rake with system gems, in other makefiles we
use bin/rake to mitigate this, however search api does not have a rake
bin. So here I've switched them to use bundle exec rake, which allows
them to build without depdency failures.