### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,11 @@
+## Describe the issue
+
+What went wrong? What were you trying to do?
+
+Include the exact commands you ran, and any errors.
+
+## Are you... [x]
+
+- [ ] Familiar with the [how to guides in the README](https://github.com/alphagov/govuk-docker#how-tos)?
+- [ ] Familiar with the [basic training on Docker](https://docs.publishing.service.gov.uk/manual/intro-to-docker.html)?
+- [ ] Familiar with the [advanced training on Docker](https://docs.publishing.service.gov.uk/manual/intro-to-docker-advanced.html)?


### PR DESCRIPTION
https://trello.com/c/AQnHFzSl/187-help-people-to-make-better-complaints-about-govuk-docker

Previously we have received many non-specific comments about issues
with GOV.UK Docker. It's unclear if some of these are due to a lack
of understanding, or represent actual bugs to fix in this repo. For
any problem, we want to encourage people to raise an issue, so that
we can capture the discussion more permanently than on Slack. This
adds an issue template to ensure we capture sufficient detail when
someone raises an issue - enough to suggest a fix.