### PR TITLE
Bump mapit's python version from 2.7 to 3.5

### DIFF
--- a/projects/mapit/Dockerfile
+++ b/projects/mapit/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-buster
+FROM python:3.5-buster
 
 RUN apt-get update -qq && apt-get install -y gettext \
         postgresql-client libgdal-dev libgeos-dev musl-dev ruby-dev


### PR DESCRIPTION
Mapit is running 3.5 now, trying to run this on 2.7 breaks things.