### PR TITLE
Add account manager environment variables to finder-frontend

### DIFF
--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -35,6 +35,9 @@ services:
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       BINDING: 0.0.0.0
       MEMCACHE_SERVERS: memcached
+      ACCOUNT_MANAGER_URL: http://www.login.service.dev.gov.uk
+      OIDC_CLIENT_ID: transition-checker-id
+      OIDC_CLIENT_SECRET: transition-checker-secret
     expose:
       - "3000"
     command: bin/rails s --restart


### PR DESCRIPTION
This includes the account manager URL and secrets that will be used when developing the OIDC integration for the transition checker.

Not to be merged until both https://github.com/alphagov/govuk-account-manager-prototype/pull/126 and the corresponding changes in the transition checker have been implemented.

Trello card: https://trello.com/c/gFFpl0Sj