### PR TITLE
Revert "Add spring support for email-alert-api-lite"

### DIFF
--- a/projects/email-alert-api/docker-compose.yml
+++ b/projects/email-alert-api/docker-compose.yml
@@ -13,22 +13,15 @@ x-email-alert-api: &email-alert-api
   working_dir: /govuk/email-alert-api
 
 services:
-  email-alert-api-lite: &email-alert-api-lite
+  email-alert-api-lite:
     <<: *email-alert-api
     depends_on:
       - postgres
       - redis
-      - email-alert-api-spring
     environment:
       DATABASE_URL: "postgresql://postgres@postgres/email-alert-api"
       TEST_DATABASE_URL: "postgresql://postgres@postgres/email-alert-api-test"
       REDIS_URL: redis://redis
-      SPRING_SOCKET: tmp/spring.socket
-
-  email-alert-api-spring:
-    <<: *email-alert-api-lite
-    depends_on: []
-    command: spring server
 
   email-alert-api-app: &email-alert-api-app
     <<: *email-alert-api


### PR DESCRIPTION
Reverts alphagov/govuk-docker#377

Related to: https://github.com/alphagov/email-alert-api/pull/1393