### PR TITLE
Only bundle install when a Gemfile.lock exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ all-apps: $(APPS)
 bundle-%: clone-%
 	$(GOVUK_DOCKER) build $*-lite
 	$(GOVUK_DOCKER) run $*-lite rbenv install -s || ($(GOVUK_DOCKER) build --no-cache $*-lite; $(GOVUK_DOCKER) run $*-lite rbenv install -s)
-	$(GOVUK_DOCKER) run $*-lite sh -c 'gem install --conservative --no-document bundler -v $$(grep -A1 "BUNDLED WITH" Gemfile.lock | tail -1)'
+	if [ -f Gemfile.lock ]; then $(GOVUK_DOCKER) run $*-lite sh -c 'gem install --conservative --no-document bundler -v $$(grep -A1 "BUNDLED WITH" Gemfile.lock | tail -1)'; fi
 	$(GOVUK_DOCKER) run $*-lite bundle
 
 clone-%:


### PR DESCRIPTION
A response to issue #389, govuk-docker contains some gems that are
needed to use with other applications that tend not to have a
Gemfile.lock when initialy cloned. This was causing make (eg. `make
gds-api-adapters`) to fail.

Here we make the depdency explicit and skip the step if no Gemfile.lock
exists, a step that hasn't proved disruptive to using the adapters in
other applications.