### PR TITLE
Add basic test support for govuk_crawler_worker

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -38,6 +38,8 @@ The following apps are supported by govuk-docker to some extent.
    - ✅ government-frontend
    - ✅ govspeak
    - ✅ govuk_app_config
+   - ⚠ govuk_crawler_worker
+      * **TODO: Missing support for running the worker**
    - ✅ govuk_publishing_components
    - ✅ govuk-cdn-config
    - ✅ govuk-content-schemas

--- a/projects/govuk_crawler_worker/Dockerfile
+++ b/projects/govuk_crawler_worker/Dockerfile
@@ -1,0 +1,1 @@
+FROM golang:1.9.1

--- a/projects/govuk_crawler_worker/Makefile
+++ b/projects/govuk_crawler_worker/Makefile
@@ -1,0 +1,2 @@
+govuk_crawler_worker: clone-govuk_crawler_worker
+	$(GOVUK_DOCKER) run $@-lite sh -c "make build"

--- a/projects/govuk_crawler_worker/docker-compose.yml
+++ b/projects/govuk_crawler_worker/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.7'
+
+x-govuk_crawler_worker: &govuk_crawler_worker
+  build:
+    context: .
+    dockerfile: projects/govuk_crawler_worker/Dockerfile
+  image: govuk_crawler_worker
+  volumes:
+    - go:/go
+    - ${GOVUK_ROOT_DIR:-~/govuk}/govuk_crawler_worker:/go/src/github.com/alphagov/govuk_crawler_worker:delegated
+  working_dir: /go/src/github.com/alphagov/govuk_crawler_worker
+
+services:
+  govuk_crawler_worker-lite:
+    <<: *govuk_crawler_worker
+    depends_on:
+      - rabbitmq
+      - redis
+    environment:
+      AMQP_ADDRESS: amqp://guest:guest@rabbitmq:5672
+      REDIS_ADDRESS: redis:6379

--- a/projects/router/docker-compose.yml
+++ b/projects/router/docker-compose.yml
@@ -8,7 +8,6 @@ x-router: &router
   volumes:
     - go:/go
     - ${GOVUK_ROOT_DIR:-~/govuk}/router:/go/src/github.com/alphagov/router:delegated
-    - home:/home/build
   working_dir: /go/src/github.com/alphagov/router
 
 services:


### PR DESCRIPTION
Depends on: https://github.com/alphagov/govuk_crawler_worker/pull/134

All tests pass when running:

  govuk-docker-run govuk_crawler_worker-lite make test