### PR TITLE
Add whitehall-frontend.dev.gov.uk as a virtual host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
           - support.dev.gov.uk
           - transition.dev.gov.uk
           - travel-advice-publisher.dev.gov.uk
+          - whitehall-frontend.dev.gov.uk
           - whitehall-admin.dev.gov.uk
           - www-origin.dev.gov.uk
           - www.dev.gov.uk

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     environment:
       DATABASE_URL: "mysql2://root:root@mysql/whitehall_development"
       REDIS_URL: redis://redis
-      VIRTUAL_HOST: whitehall-admin.dev.gov.uk
+      VIRTUAL_HOST: whitehall-admin.dev.gov.uk, whitehall-frontend.dev.gov.uk
       HOST: 0.0.0.0
     expose:
       - "3000"


### PR DESCRIPTION
The existing host for whitehall is whitehall-admin.dev.gov.uk which
is not intuitive when trying to run the app to view frontend pages.
This allows either url to work on the frontend parts of whitehall.