### PR TITLE
Fix Makefile looking in wrong place for gemfile.lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ all-apps: $(APPS)
 bundle-%: clone-%
 	$(GOVUK_DOCKER) build $*-lite
 	$(GOVUK_DOCKER) run $*-lite rbenv install -s || ($(GOVUK_DOCKER) build --no-cache $*-lite; $(GOVUK_DOCKER) run $*-lite rbenv install -s)
-	if [ -f Gemfile.lock ]; then $(GOVUK_DOCKER) run $*-lite sh -c 'gem install --conservative --no-document bundler -v $$(grep -A1 "BUNDLED WITH" Gemfile.lock | tail -1)'; fi
+	if [ -f "${GOVUK_ROOT_DIR}/$*/Gemfile.lock" ]; then $(GOVUK_DOCKER) run $*-lite sh -c 'gem install --conservative --no-document bundler -v $$(grep -A1 "BUNDLED WITH" Gemfile.lock | tail -1)'; fi
 	$(GOVUK_DOCKER) run $*-lite bundle
 
 clone-%:


### PR DESCRIPTION
Closes #398

In commit #396 I introduced a mistake. The logic looks for a gemfile, but I think it's looking in the wrong directory, being explicit about where it should look helps with individual builds.

I've tested it and with this change:
- `make govspaek` starts working
- `make gds-api-adapters` continues to work