### PR TITLE
GOV.UK Accounts discovery | Account GOV.UK Docker setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,3 +111,4 @@ services:
           - whitehall-admin.dev.gov.uk
           - www-origin.dev.gov.uk
           - www.dev.gov.uk
+          - attributes.login.service.dev.gov.uk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,3 +112,4 @@ services:
           - www-origin.dev.gov.uk
           - www.dev.gov.uk
           - attributes.login.service.dev.gov.uk
+          - www.login.service.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -93,6 +93,8 @@ These are repos that can be started as a some kind of process, such as a web app
       * Who knows, really - several tests are failing, lots pass ;-)
       * Rake task to [create a test taxon](https://github.com/alphagov/whitehall/blob/master/lib/tasks/taxonomy.rake#L11) for publishing is not idempotent
       * Placeholder images don't work as missing proxy for [/government/assets](https://github.com/alphagov/whitehall/blob/master/app/presenters/publishing_api/news_article_presenter.rb#L133)
+   - ⚠ govuk-attribute-service-prototype
+      * **No support for a webserver stack**
 
 ## Generic Ruby libraries
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -95,6 +95,8 @@ These are repos that can be started as a some kind of process, such as a web app
       * Placeholder images don't work as missing proxy for [/government/assets](https://github.com/alphagov/whitehall/blob/master/app/presenters/publishing_api/news_article_presenter.rb#L133)
    - ⚠ govuk-attribute-service-prototype
       * **No support for a webserver stack**
+   - ⚠ govuk-account-manager-prototype
+      * **No support for a webserver stack**
 
 ## Generic Ruby libraries
 

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -35,6 +35,11 @@ services:
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       BINDING: 0.0.0.0
       MEMCACHE_SERVERS: memcached
+      GOVUK_ACCOUNT_OAUTH_CLIENT_ID: transition-checker-id
+      GOVUK_ACCOUNT_OAUTH_CLIENT_KEY: "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEID+UE4jB5QtUFOtekHJliaSB8K2xQU2AS4xczOLAqvCUoAoGCCqGSM49\nAwEHoUQDQgAEjMgE/d6Bdu1K17BTjNycDvIXKSmUgZ5YYoayU3gGqTLhgefuK2qb\no99Wx+SuvdW/GRvIlUIW1ooNRdQ3QFwwCw==\n-----END EC PRIVATE KEY-----\n"
+      GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID: "898d62b7-eed9-464a-a4ae-9d9e08bd9bee"
+      GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: transition-checker-secret
+      PLEK_SERVICE_ACCOUNT_MANAGER_URI: "http://www.login.service.dev.gov.uk"
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -51,3 +56,8 @@ services:
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       BINDING: 0.0.0.0
+      GOVUK_ACCOUNT_OAUTH_CLIENT_ID: transition-checker-id
+      GOVUK_ACCOUNT_OAUTH_CLIENT_KEY: "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEID+UE4jB5QtUFOtekHJliaSB8K2xQU2AS4xczOLAqvCUoAoGCCqGSM49\nAwEHoUQDQgAEjMgE/d6Bdu1K17BTjNycDvIXKSmUgZ5YYoayU3gGqTLhgefuK2qb\no99Wx+SuvdW/GRvIlUIW1ooNRdQ3QFwwCw==\n-----END EC PRIVATE KEY-----\n"
+      GOVUK_ACCOUNT_OAUTH_CLIENT_KEY_UUID: "898d62b7-eed9-464a-a4ae-9d9e08bd9bee"
+      GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: transition-checker-secret
+      PLEK_SERVICE_ACCOUNT_MANAGER_URI: "http://www.login.service.dev.gov.uk"

--- a/projects/govuk-account-manager-prototype/Makefile
+++ b/projects/govuk-account-manager-prototype/Makefile
@@ -1,0 +1,2 @@
+govuk-account-manager-prototype: bundle-govuk-account-manager-prototype govuk-attribute-service-prototype
+	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rails db:migrate 2>/dev/null || bin/rails db:setup'

--- a/projects/govuk-account-manager-prototype/docker-compose.yml
+++ b/projects/govuk-account-manager-prototype/docker-compose.yml
@@ -1,0 +1,66 @@
+version: '3.7'
+
+x-govuk-account-manager-prototype: &govuk-account-manager-prototype
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: govuk-account-manager-prototype
+  stdin_open: true
+  tty: true
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - home:/home/build
+  working_dir: /govuk/govuk-account-manager-prototype
+
+services:
+  govuk-account-manager-prototype-lite:
+    <<: *govuk-account-manager-prototype
+    privileged: true
+    depends_on:
+      - postgres
+      - memcached
+      - govuk-attribute-service-prototype-app
+    environment:
+      MEMCACHE_SERVERS: memcached
+      DATABASE_URL: "postgresql://postgres@postgres/govuk-account-manager-prototype"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres/govuk-account-manager-prototype-test"
+      REDIRECT_BASE_URL: http://www.login.service.dev.gov.uk
+      FINDER_FRONTEND_OAUTH_CLIENT_ID: transition-checker-id
+      FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY_UUID: 898d62b7-eed9-464a-a4ae-9d9e08bd9bee
+      FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY: "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjMgE/d6Bdu1K17BTjNycDvIXKSmU\ngZ5YYoayU3gGqTLhgefuK2qbo99Wx+SuvdW/GRvIlUIW1ooNRdQ3QFwwCw==\n-----END PUBLIC KEY-----\n"
+
+  govuk-account-manager-prototype-app: &govuk-account-manager-prototype-app
+    <<: *govuk-account-manager-prototype
+    depends_on:
+      - nginx-proxy
+      - postgres
+      - redis
+      - govuk-attribute-service-prototype-app
+      - govuk-account-manager-prototype-worker
+    environment:
+      ASSET_HOST: www.login.service.dev.gov.uk
+      VIRTUAL_HOST: www.login.service.dev.gov.uk
+      BINDING: 0.0.0.0
+      MEMCACHE_SERVERS: memcached
+      DATABASE_URL: "postgresql://postgres@postgres/govuk-account-manager-prototype"
+      ATTRIBUTE_SERVICE_URL: http://attributes.login.service.dev.gov.uk
+      REDIRECT_BASE_URL: http://www.login.service.dev.gov.uk
+      REDIS_URL: redis://redis:6379/0
+      FINDER_FRONTEND_OAUTH_CLIENT_ID: transition-checker-id
+      FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY_UUID: 898d62b7-eed9-464a-a4ae-9d9e08bd9bee
+      FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY: "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjMgE/d6Bdu1K17BTjNycDvIXKSmU\ngZ5YYoayU3gGqTLhgefuK2qbo99Wx+SuvdW/GRvIlUIW1ooNRdQ3QFwwCw==\n-----END PUBLIC KEY-----\n"
+    expose:
+      - "3000"
+    command: bin/rails s --restart
+
+  govuk-account-manager-prototype-worker:
+    <<: *govuk-account-manager-prototype
+    depends_on:
+      - redis
+      - govuk-attribute-service-prototype-app
+    environment:
+      ATTRIBUTE_SERVICE_URL: http://attributes.login.service.dev.gov.uk
+      REDIS_URL: redis://redis:6379/0
+      REDIRECT_BASE_URL: http://www.login.service.dev.gov.uk
+      DATABASE_URL: "postgresql://postgres@postgres/govuk-account-manager-prototype"
+    command: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/projects/govuk-attribute-service-prototype/Makefile
+++ b/projects/govuk-attribute-service-prototype/Makefile
@@ -1,0 +1,2 @@
+govuk-attribute-service-prototype: bundle-govuk-attribute-service-prototype
+	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rails db:migrate 2>/dev/null || bin/rails db:setup'

--- a/projects/govuk-attribute-service-prototype/docker-compose.yml
+++ b/projects/govuk-attribute-service-prototype/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.7'
+
+x-govuk-attribute-service-prototype: &govuk-attribute-service-prototype
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: govuk-attribute-service-prototype
+  stdin_open: true
+  tty: true
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - home:/home/build
+  working_dir: /govuk/govuk-attribute-service-prototype
+
+services:
+  govuk-attribute-service-prototype-lite:
+    <<: *govuk-attribute-service-prototype
+    privileged: true
+    depends_on:
+      - memcached
+      - postgres
+    environment:
+      MEMCACHE_SERVERS: memcached
+      DATABASE_URL: "postgresql://postgres@postgres/govuk-attribute-service-prototype"
+      ACCOUNT_MANAGER_URL: http://www.login.service.dev.gov.uk
+      ACCOUNT_MANAGER_TOKEN: attribute-service-token
+      TEST_DATABASE_URL: "postgresql://postgres@postgres/govuk-attribute-service-prototype-test"
+
+  govuk-attribute-service-prototype-app: &govuk-attribute-service-prototype-app
+    <<: *govuk-attribute-service-prototype
+    depends_on:
+      - nginx-proxy
+      - postgres
+    environment:
+      ASSET_HOST: attributes.login.service.dev.gov.uk
+      VIRTUAL_HOST: attributes.login.service.dev.gov.uk
+      ACCOUNT_MANAGER_URL: http://www.login.service.dev.gov.uk
+      ACCOUNT_MANAGER_TOKEN: attribute-service-token
+      BINDING: 0.0.0.0
+      MEMCACHE_SERVERS: memcached
+      DATABASE_URL: "postgresql://postgres@postgres/govuk-attribute-service-prototype"
+    expose:
+      - "3000"
+    command: bin/rails s --restart


### PR DESCRIPTION
Add docker containers for govuk accounts and govuk attribute store.
Both are currently private repos, and so any attempt to clone or update will fail for these repos.

However if you are an authorised developer who already has access, having them positioned correctly in your folder structure will allow you to work with them in `govuk-docker`

Once the repositories have been made public, the code will be accessible to anyone with no futher change to `govuk-docker`