### PR TITLE
Remove all-apps from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ APPS ?= $(shell ls ${GOVUK_DOCKER_DIR}/projects/*/Makefile | xargs -L 1 dirname 
 
 # Best practice to ensure these targets always execute, even if a
 # file like 'clone' exists in the current directory.
-.PHONY: clone pull test all-apps
+.PHONY: clone pull test
 
 default:
 	@echo "Run 'make APP-NAME' to set up an app and its dependencies."
@@ -30,10 +30,6 @@ test:
 
 	# Validate shell scripts
 	$(SHELLCHECK) $(shell ls ${GOVUK_DOCKER_DIR}/bin/*.sh ${GOVUK_DOCKER_DIR}/exe/*)
-
-# This will be slow and may repeat work, so generally you don't want
-# to run this.
-all-apps: $(APPS)
 
 bundle-%: clone-%
 	$(GOVUK_DOCKER) build $*-lite


### PR DESCRIPTION
Closes #407

The usefulness of this command has declined over time, and since we moved the generic ruby libraries to their own directory this command will fail as it tries to build based on folder name.

As this is not a command most users might be expected to run, we're removing it here.

If you have a need to build your own apps, you'd be better off doing so by running your own command to list relevant directories.

The following takes the existing command and does an inverted grep to create a blocklisti that could prove useful
`ls projects/*/Makefile | xargs -L 1 dirname | xargs -L 1 basename | grep -v generic-ruby-library`