### PR TITLE
[DO NOT MERGE] GOV.UK account discovery | Turn on GOV.UK account feature

### DIFF
--- a/projects/collections/docker-compose.yml
+++ b/projects/collections/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       ASSET_HOST: collections.dev.gov.uk
       VIRTUAL_HOST: collections.dev.gov.uk
       HOST: 0.0.0.0
+      FEATURE_FLAG_ACCOUNTS: "enabled"
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -44,3 +45,4 @@ services:
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: collections.dev.gov.uk
       HOST: 0.0.0.0
+      FEATURE_FLAG_ACCOUNTS: "enabled"

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - static-app
       - search-api-app
       - memcached
+      - govuk-account-manager-prototype-app
       - nginx-proxy
     environment:
       ASSET_HOST: finder-frontend.dev.gov.uk
@@ -40,6 +41,7 @@ services:
       GOVUK_ACCOUNT_JWT_KEY_UUID: "898d62b7-eed9-464a-a4ae-9d9e08bd9bee"
       GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: transition-checker-secret
       PLEK_SERVICE_ACCOUNT_MANAGER_URI: "http://www.login.service.dev.gov.uk"
+      FEATURE_FLAG_ACCOUNTS: "enabled"
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -47,6 +49,7 @@ services:
   finder-frontend-app-live:
     <<: *finder-frontend-app
     depends_on:
+      - govuk-account-manager-prototype-app
       - nginx-proxy
     environment:
       PLEK_SERVICE_SEARCH_URI: https://www.gov.uk/api
@@ -61,3 +64,4 @@ services:
       GOVUK_ACCOUNT_JWT_KEY_UUID: "898d62b7-eed9-464a-a4ae-9d9e08bd9bee"
       GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: transition-checker-secret
       PLEK_SERVICE_ACCOUNT_MANAGER_URI: "http://www.login.service.dev.gov.uk"
+      FEATURE_FLAG_ACCOUNTS: "enabled"

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -24,6 +24,7 @@ services:
   finder-frontend-app: &finder-frontend-app
     <<: *finder-frontend
     depends_on:
+      - email-alert-api-app
       - router-app
       - content-store-app
       - static-app


### PR DESCRIPTION
Passes the feature flag to finder frontend allowing for GOV.UK account correspndance with the brexit checker.

Also makes govuk-accounts a depdendency of both the app and live stack