### PR TITLE
Add http to finder-frontend VIRTUAL_HOST

### DIFF
--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: finder-frontend.dev.gov.uk
-      VIRTUAL_HOST: finder-frontend.dev.gov.uk
+      VIRTUAL_HOST: http://finder-frontend.dev.gov.uk
       BINDING: 0.0.0.0
       MEMCACHE_SERVERS: memcached
       GOVUK_ACCOUNT_OAUTH_CLIENT_ID: transition-checker-id


### PR DESCRIPTION
In https://github.com/alphagov/finder-frontend/pull/2239, we have allowed non-http to be used as the virtual host, so now need to specify the protocol in the environment variable.