### PR TITLE
Fix image named after gds-api-adapters

### DIFF
--- a/projects/generic-ruby-library/docker-compose.yml
+++ b/projects/generic-ruby-library/docker-compose.yml
@@ -4,7 +4,7 @@ x-generic-ruby-library: &generic-ruby-library
   build:
     context: .
     dockerfile: Dockerfile.govuk-base
-  image: gds-api-adapters
+  image: generic-ruby-library
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - home:/home/build


### PR DESCRIPTION
This shouldn't have the name of a particular project, I'm assuming it was just something missed with the change.