### PR TITLE
Create app-account stack, add to finder-frontend + collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Variations on the `app` stack are allowed where necessary such as:
 
   - **app-draft**: used for testing the [authenticating-proxy](https://github.com/alphagov/govuk-docker/tree/master/projects/authenticating-proxy) against a draft version of the [router](https://github.com/alphagov/govuk-docker/tree/master/projects/router) app.
   - **app-live**: used to test a read-only frontend app against live GOV.UK APIs (avoids having to replicate data locally).
+  - **app-account**: used to enable integrations with a local [account manager app prototype](https://github.com/alphagov/govuk-account-manager-prototype) and [attribute store](https://github.com/alphagov/govuk-attribute-service-prototype/). Currently a part of the [GOV Accounts trial](https://gds.blog.gov.uk/2020/09/22/introducing-gov-uk-accounts/)
 
 Some `app` stacks also depend on a `worker` stack, to run asynchronous tasks [[example](https://github.com/alphagov/govuk-docker/blob/d286748e0300df8f0d1ed618086d4f8f951e752a/projects/content-publisher/docker-compose.yml#L46)].
 

--- a/projects/collections/Makefile
+++ b/projects/collections/Makefile
@@ -1,1 +1,1 @@
-collections: bundle-collections content-store router static
+collections: bundle-collections content-store router static govuk-account-manager-prototype

--- a/projects/collections/docker-compose.yml
+++ b/projects/collections/docker-compose.yml
@@ -44,3 +44,14 @@ services:
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: collections.dev.gov.uk
       HOST: 0.0.0.0
+
+  collections-app-account:
+    <<: *collections-app
+    depends_on:
+      - nginx-proxy
+      - govuk-account-manager-prototype-app
+    environment:
+      FEATURE_FLAG_ACCOUNTS: "enabled"
+      ASSET_HOST: collections.dev.gov.uk
+      VIRTUAL_HOST: collections.dev.gov.uk
+      HOST: 0.0.0.0

--- a/projects/finder-frontend/Makefile
+++ b/projects/finder-frontend/Makefile
@@ -1,2 +1,2 @@
-finder-frontend: bundle-finder-frontend content-store static search-api router
+finder-frontend: bundle-finder-frontend content-store static search-api router email-alert-api govuk-account-manager-prototype
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -35,11 +35,6 @@ services:
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       BINDING: 0.0.0.0
       MEMCACHE_SERVERS: memcached
-      GOVUK_ACCOUNT_OAUTH_CLIENT_ID: transition-checker-id
-      GOVUK_ACCOUNT_JWT_KEY_PEM: "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEID+UE4jB5QtUFOtekHJliaSB8K2xQU2AS4xczOLAqvCUoAoGCCqGSM49\nAwEHoUQDQgAEjMgE/d6Bdu1K17BTjNycDvIXKSmUgZ5YYoayU3gGqTLhgefuK2qb\no99Wx+SuvdW/GRvIlUIW1ooNRdQ3QFwwCw==\n-----END EC PRIVATE KEY-----\n"
-      GOVUK_ACCOUNT_JWT_KEY_UUID: "898d62b7-eed9-464a-a4ae-9d9e08bd9bee"
-      GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: transition-checker-secret
-      PLEK_SERVICE_ACCOUNT_MANAGER_URI: "http://www.login.service.dev.gov.uk"
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -56,8 +51,24 @@ services:
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       BINDING: 0.0.0.0
+
+  finder-frontend-app-account:
+    <<: *finder-frontend-app
+    depends_on:
+      - router-app
+      - nginx-proxy
+      - email-alert-api-app
+      - static-app
+      - memcached
+      - govuk-account-manager-prototype-app
+    environment:
+      ASSET_HOST: finder-frontend.dev.gov.uk
+      VIRTUAL_HOST: finder-frontend.dev.gov.uk
+      BINDING: 0.0.0.0
+      MEMCACHE_SERVERS: memcached
       GOVUK_ACCOUNT_OAUTH_CLIENT_ID: transition-checker-id
       GOVUK_ACCOUNT_JWT_KEY_PEM: "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEID+UE4jB5QtUFOtekHJliaSB8K2xQU2AS4xczOLAqvCUoAoGCCqGSM49\nAwEHoUQDQgAEjMgE/d6Bdu1K17BTjNycDvIXKSmUgZ5YYoayU3gGqTLhgefuK2qb\no99Wx+SuvdW/GRvIlUIW1ooNRdQ3QFwwCw==\n-----END EC PRIVATE KEY-----\n"
       GOVUK_ACCOUNT_JWT_KEY_UUID: "898d62b7-eed9-464a-a4ae-9d9e08bd9bee"
       GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: transition-checker-secret
       PLEK_SERVICE_ACCOUNT_MANAGER_URI: "http://www.login.service.dev.gov.uk"
+      FEATURE_FLAG_ACCOUNTS: "enabled"


### PR DESCRIPTION
## What

- Creates a new `app-*` stack called `app-account`
- Adds it to collections (so that the transition header will work with the feature flag)
- Addsit to finder-frontend (so the Brexit transition checker will work with accounts)

## Why
Finder frontend is currently being used as part of the trial / prototype
of GOV.UK accounts. These integrations are likely to be tested with
other apps in the near future.

A re-usable account sstack would therefore be a useful shorthand to
developers giving the expectation that it will:
- spin up dependent apps required to make account features work
- provide all environment variables (eg: keys, feature flags) to ensure
things run smoothly.

## New dependencies here
For finder frontend, that adds the additional dependencies of
email-alert-api (used to get subscription titles to send to the account
in the JWT) and the account manager prototype itself.

I've also moved environment variables out of other stacks, the expecation
of using a vanilla `app` stack should be that accounts will not be enabled.
Which should also provide a useful way to test locally that services fail gracefully
given the absence of a dependent service and enviornment variables.