### PR TITLE
Add missing yarn/npm install Makefile steps

### DIFF
--- a/projects/content-data-admin/Makefile
+++ b/projects/content-data-admin/Makefile
@@ -1,2 +1,3 @@
 content-data-admin: bundle-content-data-admin
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite npm install

--- a/projects/email-alert-frontend/Makefile
+++ b/projects/email-alert-frontend/Makefile
@@ -1,1 +1,2 @@
 email-alert-frontend: bundle-email-alert-frontend email-alert-api content-store static router
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/whitehall/Makefile
+++ b/projects/whitehall/Makefile
@@ -1,3 +1,4 @@
 whitehall: bundle-whitehall asset-manager publishing-api static
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite yarn
 	$(GOVUK_DOCKER) run $@-lite bin/rake shared_mustache:compile


### PR DESCRIPTION
These projects all use node modules, but these weren't previously
installed. Content Data Admin uses npm rather than yarn that most GOV.UK
apps use.