### PR TITLE
Add database versions to replication scripts

### DIFF
--- a/bin/replicate-elasticsearch.sh
+++ b/bin/replicate-elasticsearch.sh
@@ -34,7 +34,7 @@ echo "
 echo "stopping running govuk-docker containers..."
 govuk-docker down
 
-container=$(govuk-docker run -d --rm -v "$archive_path:/replication" -v "$cfg_path:/usr/share/elasticsearch/config/elasticsearch.yml" -p 9200:9200 elasticsearch6 | tail -n1)
+container=$(govuk-docker run -d --rm -v "$archive_path:/replication" -v "$cfg_path:/usr/share/elasticsearch/config/elasticsearch.yml" -p 9200:9200 elasticsearch-6 | tail -n1)
 # we want $container and $cfg_path to be expanded now
 # shellcheck disable=SC2064
 trap "docker stop '$container'; rm '$cfg_path'" EXIT

--- a/bin/replicate-mongodb.sh
+++ b/bin/replicate-mongodb.sh
@@ -67,7 +67,7 @@ pv "$archive_path" | gunzip | tar -zx -f - -C "$extract_path" "var/lib/mongodb/b
 echo "stopping running govuk-docker containers..."
 govuk-docker down
 
-container=$(govuk-docker run -d --rm -v "${extract_path}:/replication" mongo | tail -n1)
+container=$(govuk-docker run -d --rm -v "${extract_path}:/replication" mongo-3.6 | tail -n1)
 # we want $container to be expanded now
 # shellcheck disable=SC2064
 trap "docker stop '$container'" EXIT

--- a/bin/replicate-mysql.sh
+++ b/bin/replicate-mysql.sh
@@ -42,16 +42,16 @@ fi
 echo "stopping running govuk-docker containers..."
 govuk-docker down
 
-govuk-docker up -d mysql
-trap 'govuk-docker stop mysql' EXIT
+govuk-docker up -d mysql-5.5
+trap 'govuk-docker stop mysql-5.5' EXIT
 
 echo "waiting for mysql..."
-until govuk-docker run mysql mysql -h mysql -u root --password=root -e 'SELECT 1' &>/dev/null; do
+until govuk-docker run mysql-5.5 mysql -h mysql-5.5 -u root --password=root -e 'SELECT 1' &>/dev/null; do
   sleep 1
 done
 
 database="${app//-/_}_development"
 
-govuk-docker run mysql mysql -h mysql -u root --password=root -e "DROP DATABASE IF EXISTS \`${database}\`"
-govuk-docker run mysql mysql -h mysql -u root --password=root -e "CREATE DATABASE \`${database}\`"
-pv "$archive_path" | gunzip | govuk-docker run mysql mysql -h mysql -u root --password=root "$database"
+govuk-docker run mysql-5.5 mysql -h mysql-5.5 -u root --password=root -e "DROP DATABASE IF EXISTS \`${database}\`"
+govuk-docker run mysql-5.5 mysql -h mysql-5.5 -u root --password=root -e "CREATE DATABASE \`${database}\`"
+pv "$archive_path" | gunzip | govuk-docker run mysql-5.5 mysql -h mysql-5.5 -u root --password=root "$database"

--- a/bin/replicate-postgresql.sh
+++ b/bin/replicate-postgresql.sh
@@ -57,15 +57,15 @@ fi
 echo "stopping running govuk-docker containers..."
 govuk-docker down
 
-govuk-docker up -d postgres
-trap 'govuk-docker stop postgres' EXIT
+govuk-docker up -d postgres-9.6
+trap 'govuk-docker stop postgres-9.6' EXIT
 
 echo "waiting for postgres..."
-until govuk-docker run postgres /usr/bin/psql -h postgres -U postgres -c 'SELECT 1' &>/dev/null; do
+until govuk-docker run postgres-9.6 /usr/bin/psql -h postgres-9.6 -U postgres -c 'SELECT 1' &>/dev/null; do
   sleep 1
 done
 
 database="$app"
-govuk-docker run postgres /usr/bin/psql -h postgres -U postgres -c "DROP DATABASE IF EXISTS \"${database}\""
-govuk-docker run postgres /usr/bin/createdb -h postgres -U postgres "$database"
-pv "$archive_path" | govuk-docker run postgres /usr/bin/pg_restore -h postgres -U postgres -d "$database" --no-owner
+govuk-docker run postgres-9.6 /usr/bin/psql -h postgres-9.6 -U postgres -c "DROP DATABASE IF EXISTS \"${database}\""
+govuk-docker run postgres-9.6 /usr/bin/createdb -h postgres-9.6 -U postgres "$database"
+pv "$archive_path" | govuk-docker run postgres-9.6 /usr/bin/pg_restore -h postgres-9.6 -U postgres -d "$database" --no-owner


### PR DESCRIPTION
As govuk-docker is now [using versioned database services](https://github.com/alphagov/govuk-docker/blob/master/docs/adr/0004-use-versioned-database-services.md) the data replication scripts need to include these versions.