### PR TITLE
Adds missing Redis dependency

### DIFF
--- a/projects/manuals-publisher/docker-compose.yml
+++ b/projects/manuals-publisher/docker-compose.yml
@@ -20,8 +20,10 @@ services:
   manuals-publisher-lite:
     <<: *manuals-publisher
     depends_on:
+      - redis
       - mongo-3.6
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/manuals-publisher"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/manuals-publisher-test"
+      REDIS_URL: redis://redis
 


### PR DESCRIPTION
This is a pre-cursor to enabling CD on Manuals Publisher. Without
specifying Redis as a dependency, incorporating the
`GovukHealthcheck::SidekiqRedis` healthcheck results in a status
like:

`"{\"status\":\"critical\",\"checks\":{\"redis_connectivity\":{\"status\":\"critical\"}}}"`

With the improved Docker Compose, the output becomes:

`"{\"status\":\"ok\",\"checks\":{\"redis_connectivity\":{\"status\":\"ok\"}}}"`