### PR TITLE
Add yarn/node_modules for repos that use yarn for linting

### DIFF
--- a/projects/calculators/Makefile
+++ b/projects/calculators/Makefile
@@ -1,1 +1,2 @@
 calculators: bundle-calculators static content-store router
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/calculators/docker-compose.yml
+++ b/projects/calculators/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   calculators-tmp:
+  calculators-node-modules:
 
 x-calculators: &calculators
   build:
@@ -14,6 +15,7 @@ x-calculators: &calculators
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - calculators-tmp:/govuk/calculators/tmp
+    - calculators-node-modules:/govuk/calculators/node_modules
   working_dir: /govuk/calculators
 
 services:

--- a/projects/collections/Makefile
+++ b/projects/collections/Makefile
@@ -1,1 +1,2 @@
 collections: bundle-collections content-store router static govuk-account-manager-prototype
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/collections/docker-compose.yml
+++ b/projects/collections/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   collections-tmp:
+  collections-node-modules:
 
 x-collections: &collections
   build:
@@ -14,6 +15,7 @@ x-collections: &collections
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - collections-tmp:/govuk/collections/tmp
+    - collections-node-modules:/govuk/collections/node_modules
   working_dir: /govuk/collections
 
 services:

--- a/projects/contacts-admin/Makefile
+++ b/projects/contacts-admin/Makefile
@@ -1,2 +1,3 @@
 contacts-admin: bundle-contacts-admin
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/contacts-admin/docker-compose.yml
+++ b/projects/contacts-admin/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   contacts-admin-tmp:
+  contacts-admin-node-modules:
 
 x-contacts-admin: &contacts-admin
   build:
@@ -14,6 +15,7 @@ x-contacts-admin: &contacts-admin
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - contacts-admin-tmp:/govuk/contacts-admin/tmp
+    - contacts-admin-node-modules:/govuk/contacts-admin/node_modules
   working_dir: /govuk/contacts-admin
 
 services:

--- a/projects/content-tagger/Makefile
+++ b/projects/content-tagger/Makefile
@@ -1,2 +1,3 @@
 content-tagger: bundle-content-tagger publishing-api
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/content-tagger/docker-compose.yml
+++ b/projects/content-tagger/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   content-tagger-tmp:
+  content-tagger-node-modules:
 
 x-content-tagger: &content-tagger
   build:
@@ -14,6 +15,7 @@ x-content-tagger: &content-tagger
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - content-tagger-tmp:/govuk/content-tagger/tmp
+    - content-tagger-node-modules:/govuk/content-tagger/node_modules
   working_dir: /govuk/content-tagger
 
 services:

--- a/projects/local-links-manager/Makefile
+++ b/projects/local-links-manager/Makefile
@@ -1,2 +1,3 @@
 local-links-manager: bundle-local-links-manager
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/local-links-manager/docker-compose.yml
+++ b/projects/local-links-manager/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   local-links-manager-tmp:
+  local-links-manager-node-modules:
 
 x-local-links-manager: &local-links-manager
   build:
@@ -14,6 +15,7 @@ x-local-links-manager: &local-links-manager
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - local-links-manager-tmp:/govuk/local-links-manager/tmp
+    - local-links-manager-node-modules:/govuk/local-links-manager/node_modules
   working_dir: /govuk/local-links-manager
 
 services:

--- a/projects/manuals-publisher/Makefile
+++ b/projects/manuals-publisher/Makefile
@@ -1,2 +1,3 @@
 manuals-publisher: bundle-manuals-publisher
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:create
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/manuals-publisher/docker-compose.yml
+++ b/projects/manuals-publisher/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   manuals-publisher-tmp:
+  manuals-publisher-node-modules:
 
 x-manuals-publisher: &manuals-publisher
   build:
@@ -14,6 +15,7 @@ x-manuals-publisher: &manuals-publisher
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - manuals-publisher-tmp:/govuk/manuals-publisher/tmp
+    - manuals-publisher-node-modules:/govuk/manuals-publisher/node_modules
   working_dir: /govuk/manuals-publisher
 
 services:

--- a/projects/maslow/Makefile
+++ b/projects/maslow/Makefile
@@ -1,3 +1,4 @@
 maslow: bundle-maslow publishing-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:create
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/maslow/docker-compose.yml
+++ b/projects/maslow/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   maslow-tmp:
+  maslow-node-modules:
 
 x-maslow: &maslow
   build:
@@ -14,6 +15,7 @@ x-maslow: &maslow
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - maslow-tmp:/govuk/maslow/tmp
+    - maslow-node-modules:/govuk/maslow/node_modules
   working_dir: /govuk/maslow
 
 services:

--- a/projects/publisher/Makefile
+++ b/projects/publisher/Makefile
@@ -1,2 +1,3 @@
 publisher: bundle-publisher publishing-api link-checker-api
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/publisher/docker-compose.yml
+++ b/projects/publisher/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   publisher-tmp:
+  publisher-node-modules:
 
 x-publisher: &publisher
   build:
@@ -14,6 +15,7 @@ x-publisher: &publisher
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - publisher-tmp:/govuk/publisher/tmp
+    - publisher-node-modules:/govuk/publisher/node_modules
   working_dir: /govuk/publisher
 
 services:

--- a/projects/release/Makefile
+++ b/projects/release/Makefile
@@ -1,2 +1,3 @@
 release: bundle-release
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/release/docker-compose.yml
+++ b/projects/release/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   release-tmp:
+  release-node-modules:
 
 x-release: &release
   build:
@@ -14,6 +15,7 @@ x-release: &release
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - release-tmp:/govuk/release/tmp
+    - release-node-modules:/govuk/release/node_modules
   working_dir: /govuk/release
 
 services:

--- a/projects/search-admin/Makefile
+++ b/projects/search-admin/Makefile
@@ -1,3 +1,4 @@
 search-admin: bundle-search-admin publishing-api search-api
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/search-admin/docker-compose.yml
+++ b/projects/search-admin/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   search-admin-tmp:
+  search-admin-node-modules:
 
 x-search-admin: &search-admin-base
   build:
@@ -14,6 +15,7 @@ x-search-admin: &search-admin-base
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - search-admin-tmp:/govuk/search-admin/tmp
+    - search-admin-node-modules:/govuk/search-admin/node_modules
   working_dir: /govuk/search-admin
 
 services:

--- a/projects/service-manual-publisher/Makefile
+++ b/projects/service-manual-publisher/Makefile
@@ -1,2 +1,3 @@
 service-manual-publisher: bundle-service-manual-publisher
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/service-manual-publisher/docker-compose.yml
+++ b/projects/service-manual-publisher/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   service-manual-publisher-tmp:
+  service-manual-publisher-node-modules:
 
 x-service-manual-publisher: &service-manual-publisher
   build:
@@ -14,6 +15,7 @@ x-service-manual-publisher: &service-manual-publisher
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - service-manual-publisher-tmp:/govuk/service-manual-publisher/tmp
+    - service-manual-publisher-node-modules:/govuk/service-manual-publisher/node_modules
   working_dir: /govuk/service-manual-publisher
 
 services:

--- a/projects/short-url-manager/Makefile
+++ b/projects/short-url-manager/Makefile
@@ -1,1 +1,2 @@
 short-url-manager: bundle-short-url-manager publishing-api
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/short-url-manager/docker-compose.yml
+++ b/projects/short-url-manager/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   short-url-manager-tmp:
+  short-url-manager-node-modules:
 
 x-short-url-manager: &short-url-manager
   build:
@@ -14,6 +15,7 @@ x-short-url-manager: &short-url-manager
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - short-url-manager-tmp:/govuk/short-url-manager/tmp
+    - short-url-manager-node-modules:/govuk/short-url-manager/node_modules
   working_dir: /govuk/short-url-manager
 
 services:

--- a/projects/signon/Makefile
+++ b/projects/signon/Makefile
@@ -1,2 +1,3 @@
 signon: bundle-signon
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/signon/docker-compose.yml
+++ b/projects/signon/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   signon-tmp:
+  signon-node-modules:
 
 x-signon: &signon
   build:
@@ -14,6 +15,7 @@ x-signon: &signon
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - signon-tmp:/govuk/signon/tmp
+    - signon-node-modules:/govuk/signon/node_modules
   working_dir: /govuk/signon
 
 services:

--- a/projects/specialist-publisher/Makefile
+++ b/projects/specialist-publisher/Makefile
@@ -1,2 +1,3 @@
 specialist-publisher: bundle-specialist-publisher asset-manager publishing-api email-alert-api
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/specialist-publisher/docker-compose.yml
+++ b/projects/specialist-publisher/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   specialist-publisher-tmp:
+  specialist-publisher-node-modules:
 
 x-specialist-publisher: &specialist-publisher
   build:
@@ -14,6 +15,7 @@ x-specialist-publisher: &specialist-publisher
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - specialist-publisher-tmp:/govuk/specialist-publisher/tmp
+    - specialist-publisher-node-modules:/govuk/specialist-publisher/node_modules
   working_dir: /govuk/specialist-publisher
 
 services:

--- a/projects/support/Makefile
+++ b/projects/support/Makefile
@@ -1,1 +1,2 @@
 support: bundle-support support-api
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/support/docker-compose.yml
+++ b/projects/support/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   support-tmp:
+  support-node-modules:
 
 x-support: &support
   build:
@@ -14,6 +15,7 @@ x-support: &support
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - support-tmp:/govuk/support/tmp
+    - support-node-modules:/govuk/support/node_modules
   working_dir: /govuk/support
 
 services:

--- a/projects/travel-advice-publisher/Makefile
+++ b/projects/travel-advice-publisher/Makefile
@@ -1,2 +1,3 @@
 travel-advice-publisher: bundle-travel-advice-publisher asset-manager content-store publishing-api
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/travel-advice-publisher/docker-compose.yml
+++ b/projects/travel-advice-publisher/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   travel-advice-publisher-tmp:
+  travel-advice-publisher-node-modules:
 
 x-travel-advice-publisher: &travel-advice-publisher
   build:
@@ -14,6 +15,7 @@ x-travel-advice-publisher: &travel-advice-publisher
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - travel-advice-publisher-tmp:/govuk/travel-advice-publisher/tmp
+    - travel-advice-publisher-node-modules:/govuk/travel-advice-publisher/node_modules
   working_dir: /govuk/travel-advice-publisher
 
 services:


### PR DESCRIPTION
Trello: https://trello.com/c/MeG1zc2m/195-roll-out-stylelint-config-gds-across-govuk

We're gradually migrating GOV.UK apps to do JS and Sass linting via node
based tools. This is a collection of apps that have been migrated to
this approach. This change adds yarn as part of the applications setup
and use a node_modules volume for the modules.

I've prepared this to be merged after I merge in the changes to the various apps that I have open PRs for. It should be pretty benign for apps to not have this change, it'll just mean installing yarn dependencies manually.