### PR TITLE
Fix accounts app not building from scratch

### DIFF
--- a/projects/govuk-account-manager-prototype/docker-compose.yml
+++ b/projects/govuk-account-manager-prototype/docker-compose.yml
@@ -22,7 +22,6 @@ services:
     depends_on:
       - postgres-9.6
       - memcached
-      - govuk-attribute-service-prototype-app
     environment:
       MEMCACHE_SERVERS: memcached
       DATABASE_URL: "postgresql://postgres@postgres-9.6/govuk-account-manager-prototype"


### PR DESCRIPTION
Previously the build failed because the "lite" service depended on "app",
which depended on the attribute "app", which caused it to try and start,
which caused a "tmp" directory to be created for it, which prevents it
cloning ater on, which prevents it from starting, causing errors back
down the chain. This removes the "app" dependency, noting that I can run
the setup without it, and the tests all pass.

In general, the "lite" stack should have the minimum dependencies in
order to run basic commands for a project [1].

[1]: https://github.com/alphagov/govuk-docker#the-lite-stack