### PR TITLE
Install yarn for remaining apps

### DIFF
--- a/projects/content-data-admin/Makefile
+++ b/projects/content-data-admin/Makefile
@@ -1,3 +1,3 @@
 content-data-admin: bundle-content-data-admin
 	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
-	$(GOVUK_DOCKER) run $@-lite npm install
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/frontend/Makefile
+++ b/projects/frontend/Makefile
@@ -1,1 +1,2 @@
 frontend: bundle-frontend content-store router static
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   frontend-tmp:
+  frontend-node-modules:
 
 x-frontend: &frontend
   build:
@@ -14,6 +15,7 @@ x-frontend: &frontend
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - frontend-tmp:/govuk/frontend/tmp
+    - frontend-node-modules:/govuk/frontend/node_modules
   working_dir: /govuk/frontend
 
 services:

--- a/projects/government-frontend/Makefile
+++ b/projects/government-frontend/Makefile
@@ -1,1 +1,2 @@
 government-frontend: bundle-government-frontend content-store router static
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/government-frontend/docker-compose.yml
+++ b/projects/government-frontend/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   government-frontend-tmp:
+  government-frontend-node-modules:
 
 x-government-frontend: &government-frontend
   build:
@@ -14,6 +15,7 @@ x-government-frontend: &government-frontend
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - government-frontend-tmp:/govuk/government-frontend/tmp
+    - government-frontend-node-modules:/govuk/government-frontend/node_modules
   working_dir: /govuk/government-frontend
 
 services:

--- a/projects/manuals-frontend/Makefile
+++ b/projects/manuals-frontend/Makefile
@@ -1,1 +1,2 @@
 manuals-frontend: bundle-manuals-frontend content-store router static
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/manuals-frontend/docker-compose.yml
+++ b/projects/manuals-frontend/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   manuals-frontend-tmp:
+  manuals-frontend-node-modules:
 
 x-manuals-frontend: &manuals-frontend
   build:
@@ -14,6 +15,7 @@ x-manuals-frontend: &manuals-frontend
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - manuals-frontend-tmp:/govuk/manuals-frontend/tmp
+    - manuals-frontend-node-modules:/govuk/manuals-frontend/node_modules
   working_dir: /govuk/manuals-frontend
 
 services:

--- a/projects/service-manual-frontend/Makefile
+++ b/projects/service-manual-frontend/Makefile
@@ -1,1 +1,2 @@
 service-manual-frontend: bundle-service-manual-frontend static content-store router
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/service-manual-frontend/docker-compose.yml
+++ b/projects/service-manual-frontend/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   service-manual-frontend-tmp:
+  service-manual-frontend-node-modules:
 
 x-service-manual-frontend: &service-manual-frontend
   build:
@@ -14,6 +15,7 @@ x-service-manual-frontend: &service-manual-frontend
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - service-manual-frontend-tmp:/govuk/service-manual-frontend/tmp
+    - service-manual-frontend-node-modules:/govuk/service-manual-frontend/node_modules
   working_dir: /govuk/service-manual-frontend
 
 services:

--- a/projects/smart-answers/Makefile
+++ b/projects/smart-answers/Makefile
@@ -1,1 +1,2 @@
 smart-answers: bundle-smart-answers publishing-api content-store static whitehall
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/smart-answers/docker-compose.yml
+++ b/projects/smart-answers/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   smart-answers-tmp:
+  smart-answers-node-modules:
 
 x-smart-answers: &smart-answers
   build:
@@ -14,6 +15,7 @@ x-smart-answers: &smart-answers
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - smart-answers-tmp:/govuk/smart-answers/tmp
+    - smart-answers-node-modules:/govuk/smart-answers/node_modules
   working_dir: /govuk/smart-answers
 
 services:

--- a/projects/static/Makefile
+++ b/projects/static/Makefile
@@ -1,1 +1,2 @@
 static: bundle-static
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/static/docker-compose.yml
+++ b/projects/static/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.7'
 
 volumes:
   static-tmp:
+  static-node-modules:
 
 x-static: &static
   build:
@@ -14,6 +15,7 @@ x-static: &static
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
     - static-tmp:/govuk/static/tmp
+    - static-node-modules:/govuk/static/node_modules
   working_dir: /govuk/static
 
 services:


### PR DESCRIPTION
Trello: https://trello.com/c/MeG1zc2m/195-roll-out-stylelint-config-gds-across-govuk

This adds Yarn install steps for the following apps to reflect their linting configurations:

- https://github.com/alphagov/content-data-admin/pull/906
- https://github.com/alphagov/frontend/pull/2579
- https://github.com/alphagov/government-frontend/pull/1972
- https://github.com/alphagov/manuals-frontend/pull/1043
- https://github.com/alphagov/smart-answers/pull/5094
- https://github.com/alphagov/service-manual-frontend/pull/837
- https://github.com/alphagov/static/pull/2386