### PR TITLE
Use a shared cache for yarn

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -19,6 +19,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y yarn nodejs
+RUN yarn config set cache-folder /root/.yarn/
 
 # Install rbenv to manage ruby versions
 RUN git clone https://github.com/sstephenson/rbenv.git /rbenv

--- a/projects/asset-manager/Dockerfile
+++ b/projects/asset-manager/Dockerfile
@@ -15,6 +15,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y yarn nodejs
+RUN yarn config set cache-folder /root/.yarn/
 
 # Install rbenv to manage ruby versions
 RUN git clone https://github.com/sstephenson/rbenv.git /rbenv

--- a/projects/whitehall/Dockerfile
+++ b/projects/whitehall/Dockerfile
@@ -15,6 +15,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y yarn nodejs
+RUN yarn config set cache-folder /root/.yarn/
 
 # Install rbenv to manage ruby versions
 RUN git clone https://github.com/sstephenson/rbenv.git /rbenv


### PR DESCRIPTION
Trello: https://trello.com/c/MeG1zc2m/195-roll-out-stylelint-config-gds-across-govuk

This can speed up installs quite significantly when packages have been
installed by a different project. I saw Specialist Publisher go from
~30s install to ~10s - both with an empty node_modules.