### PR TITLE
Set REDIS_URL env vars where there are REDIS_HOST vars

### DIFF
--- a/projects/contacts-admin/docker-compose.yml
+++ b/projects/contacts-admin/docker-compose.yml
@@ -28,4 +28,5 @@ services:
       DATABASE_URL: "mysql2://root:root@mysql-5.5/contacts_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-5.5/contacts_test"
       REDIS_HOST: redis
+      REDIS_URL: redis://redis
 

--- a/projects/email-alert-service/docker-compose.yml
+++ b/projects/email-alert-service/docker-compose.yml
@@ -19,3 +19,4 @@ services:
       - redis
     environment:
       REDIS_HOST: redis
+      REDIS_URL: redis://redis

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -17,6 +17,7 @@ x-search-api: &search-api
     RABBITMQ_USER: guest
     RABBITMQ_PASSWORD: guest
     REDIS_HOST: redis
+    REDIS_URL: redis://redis
     ELASTICSEARCH_URI: http://elasticsearch-6:9200
 
 services:
@@ -39,6 +40,7 @@ services:
       - search-api-listener-bulk-insert-data
     environment:
       REDIS_HOST: redis
+      REDIS_URL: redis://redis
       ELASTICSEARCH_URI: http://elasticsearch-6:9200
       VIRTUAL_HOST: search-api.dev.gov.uk, search.dev.gov.uk
       HOST: 0.0.0.0

--- a/projects/short-url-manager/docker-compose.yml
+++ b/projects/short-url-manager/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       MONGODB_URI: "mongodb://mongo-3.6/short-url-manager"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/short-url-manager-test"
       REDIS_HOST: redis
+      REDIS_URL: redis://redis
 
   short-url-manager-app: &short-url-manager-app
     <<: *short-url-manager
@@ -38,7 +39,8 @@ services:
       - publishing-api-app
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/short-url-manager"
-      REDIS_URL: redis
+      REDIS_HOST: redis
+      REDIS_URL: redis://redis
       VIRTUAL_HOST: short-url-manager.dev.gov.uk
       HOST: 0.0.0.0
     expose:

--- a/projects/signon/docker-compose.yml
+++ b/projects/signon/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       DATABASE_URL: "mysql2://root:root@mysql-5.5/signon_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-5.5/signon_test"
       REDIS_HOST: redis
+      REDIS_URL: redis://redis
 
   signon-app:
     <<: *signon
@@ -40,6 +41,7 @@ services:
       VIRTUAL_HOST: signon.dev.gov.uk
       HOST: 0.0.0.0
       REDIS_HOST: redis
+      REDIS_URL: redis://redis
     expose:
       - "3000"
     command: bin/rails s --restart


### PR DESCRIPTION
Trello: https://trello.com/c/dXud4WIt/206-inconsistent-redisurl-config

This is to allow transitioning the remaining apps that need REDIS_HOST
over to use REDIS_URL and allow us to remove REDIS_HOST and REDIS_PORT
env vars.

Once this change is complete I'll remove the REDIS_HOST definitions.