### PR TITLE
Fix using unsupported "HOST" environment variable

### DIFF
--- a/projects/asset-manager/docker-compose.yml
+++ b/projects/asset-manager/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       MONGODB_URI: "mongodb://mongo-3.6/asset-manager"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: asset-manager.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/authenticating-proxy/docker-compose.yml
+++ b/projects/authenticating-proxy/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       GOVUK_UPSTREAM_URI: http://draft-origin.dev.gov.uk
       MONGODB_URI: "mongodb://mongo-3.6/authenticating-proxy"
       VIRTUAL_HOST: authenticating-proxy.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/calculators/docker-compose.yml
+++ b/projects/calculators/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     environment:
       ASSET_HOST: calculators.dev.gov.uk
       VIRTUAL_HOST: calculators.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -46,4 +46,4 @@ services:
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: calculators.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0

--- a/projects/collections-publisher/docker-compose.yml
+++ b/projects/collections-publisher/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       DATABASE_URL: "mysql2://root:root@mysql-5.5/collections_publisher_development"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: collections-publisher.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/collections/docker-compose.yml
+++ b/projects/collections/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     environment:
       ASSET_HOST: collections.dev.gov.uk
       VIRTUAL_HOST: collections.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -48,7 +48,7 @@ services:
       PLEK_SERVICE_SEARCH_URI: https://www.gov.uk/api
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: collections.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
 
   collections-app-account:
     <<: *collections-app
@@ -59,4 +59,4 @@ services:
       FEATURE_FLAG_ACCOUNTS: "enabled"
       ASSET_HOST: collections.dev.gov.uk
       VIRTUAL_HOST: collections.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0

--- a/projects/content-store/docker-compose.yml
+++ b/projects/content-store/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/content-store"
       VIRTUAL_HOST: content-store.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/email-alert-api/docker-compose.yml
+++ b/projects/email-alert-api/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       DATABASE_URL: "postgresql://postgres@postgres-9.6/email-alert-api"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: email-alert-api.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/feedback/docker-compose.yml
+++ b/projects/feedback/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     environment:
       ASSET_HOST: feedback.dev.gov.uk
       VIRTUAL_HOST: feedback.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -47,4 +47,4 @@ services:
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: feedback.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -46,4 +46,4 @@ services:
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: frontend.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0

--- a/projects/government-frontend/docker-compose.yml
+++ b/projects/government-frontend/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     environment:
       ASSET_HOST: government-frontend.dev.gov.uk
       VIRTUAL_HOST: government-frontend.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -46,4 +46,4 @@ services:
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: government-frontend.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0

--- a/projects/info-frontend/docker-compose.yml
+++ b/projects/info-frontend/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     environment:
       ASSET_HOST: info-frontend.dev.gov.uk
       VIRTUAL_HOST: info-frontend.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s -P /tmp/rails.pid
@@ -44,4 +44,4 @@ services:
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: info-frontend.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0

--- a/projects/licence-finder/docker-compose.yml
+++ b/projects/licence-finder/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       MONGODB_URI: "mongodb://mongo-3.6/licence-finder_development"
       ELASTICSEARCH_URI: http://elasticsearch-6:9200
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -59,4 +59,4 @@ services:
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: licence-finder.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0

--- a/projects/local-links-manager/docker-compose.yml
+++ b/projects/local-links-manager/docker-compose.yml
@@ -35,7 +35,7 @@ services:
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-9.6/local-links-manager"
       VIRTUAL_HOST: local-links-manager.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/manuals-frontend/docker-compose.yml
+++ b/projects/manuals-frontend/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     environment:
       ASSET_HOST: manuals-frontend.dev.gov.uk
       VIRTUAL_HOST: manuals-frontend.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -46,4 +46,4 @@ services:
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: manuals-frontend.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0

--- a/projects/maslow/docker-compose.yml
+++ b/projects/maslow/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/maslow"
       VIRTUAL_HOST: maslow.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/publisher/docker-compose.yml
+++ b/projects/publisher/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       MONGODB_URI: "mongodb://mongo-3.6/publisher"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: publisher.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/publishing-api/docker-compose.yml
+++ b/projects/publishing-api/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       DATABASE_URL: "postgresql://postgres@postgres-9.6/publishing-api"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: publishing-api.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/release/docker-compose.yml
+++ b/projects/release/docker-compose.yml
@@ -34,8 +34,8 @@ services:
       - nginx-proxy
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-5.5/release_development"
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
       VIRTUAL_HOST: release.dev.gov.uk
     expose:
-      - 3000
+      - "3000"
     command: bin/rails s --restart

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       REDIS_URL: redis://redis
       ELASTICSEARCH_URI: http://elasticsearch-6:9200
       VIRTUAL_HOST: search-api.dev.gov.uk, search.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bundle exec mr-sparkle --force-polling -- -p 3000

--- a/projects/short-url-manager/docker-compose.yml
+++ b/projects/short-url-manager/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       REDIS_HOST: redis
       REDIS_URL: redis://redis
       VIRTUAL_HOST: short-url-manager.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/signon/docker-compose.yml
+++ b/projects/signon/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-5.5/signon_development"
       VIRTUAL_HOST: signon.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
       REDIS_HOST: redis
       REDIS_URL: redis://redis
     expose:

--- a/projects/specialist-publisher/docker-compose.yml
+++ b/projects/specialist-publisher/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       MONGODB_URI: "mongodb://mongo-3.6/specialist-publisher"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: specialist-publisher.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/static/docker-compose.yml
+++ b/projects/static/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       ASSET_HOST: static.dev.gov.uk
       REDIS_URL: redis://redis
       VIRTUAL_HOST: static.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/transition/docker-compose.yml
+++ b/projects/transition/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       DATABASE_URL: "postgresql://postgres@postgres-9.6/transition"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: transition.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/travel-advice-publisher/docker-compose.yml
+++ b/projects/travel-advice-publisher/docker-compose.yml
@@ -42,7 +42,7 @@ services:
       MONGODB_URI: "mongodb://mongo-3.6/travel-advice-publisher"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: travel-advice-publisher.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       DATABASE_URL: "mysql2://root:root@mysql-5.5/whitehall_development"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: whitehall-admin.dev.gov.uk, whitehall-frontend.dev.gov.uk
-      HOST: 0.0.0.0
+      BINDING: 0.0.0.0
     expose:
       - "3000"
     # Change to 'bin/rails --restart' when rails >= 5.2

--- a/spec/integration/compose/rails_binding_spec.rb
+++ b/spec/integration/compose/rails_binding_spec.rb
@@ -1,0 +1,13 @@
+require "spec_helper"
+
+RSpec.describe "Compose rails host" do
+  ComposeHelper.rails_app_services.each do |service_name, service|
+    it "#{service_name} allows connections from the host machine" do
+      expect(service["environment"]["BINDING"]).to_not be_empty
+    end
+
+    it "#{service_name} exposes the port to the host machine" do
+      expect(service["expose"]).to eq(%w[3000])
+    end
+  end
+end


### PR DESCRIPTION
Previously we mainly set "HOST" to "0.0.0.0" so that a Rails server
would listen on all network interfaces, in particular, the virtual
one used by Docker for communication with the host machine. Rails 6
began a transition to use "BINDING" instead of "HOST" [1], and since
6.1 support for "HOST" has been removed [2]. All of our apps seem
to be on Rails 6+ now, so this change should be non-breaking.

[1]: https://github.com/rails/rails/commit/37b373a8d2a1cd132bbde51cd5a3abd4ecee433b
[2]: https://github.com/rails/rails/commit/c0728ad3213d1e582871860e37c131b503372b2d#diff-f188e2ac461d2bcd6f3e4a3b27302df22ad2c696793637667a1f6ef59b00d2ae