### PR TITLE
Remove REDIS_HOST environment variables

### DIFF
--- a/projects/contacts-admin/docker-compose.yml
+++ b/projects/contacts-admin/docker-compose.yml
@@ -27,6 +27,5 @@ services:
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-5.5/contacts_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-5.5/contacts_test"
-      REDIS_HOST: redis
       REDIS_URL: redis://redis
 

--- a/projects/email-alert-service/docker-compose.yml
+++ b/projects/email-alert-service/docker-compose.yml
@@ -18,5 +18,4 @@ services:
     depends_on:
       - redis
     environment:
-      REDIS_HOST: redis
       REDIS_URL: redis://redis

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -16,7 +16,6 @@ x-search-api: &search-api
     RABBITMQ_VHOST: /
     RABBITMQ_USER: guest
     RABBITMQ_PASSWORD: guest
-    REDIS_HOST: redis
     REDIS_URL: redis://redis
     ELASTICSEARCH_URI: http://elasticsearch-6:9200
 
@@ -39,7 +38,6 @@ services:
       - search-api-listener-insert-data
       - search-api-listener-bulk-insert-data
     environment:
-      REDIS_HOST: redis
       REDIS_URL: redis://redis
       ELASTICSEARCH_URI: http://elasticsearch-6:9200
       VIRTUAL_HOST: search-api.dev.gov.uk, search.dev.gov.uk

--- a/projects/short-url-manager/docker-compose.yml
+++ b/projects/short-url-manager/docker-compose.yml
@@ -27,7 +27,6 @@ services:
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/short-url-manager"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/short-url-manager-test"
-      REDIS_HOST: redis
       REDIS_URL: redis://redis
 
   short-url-manager-app: &short-url-manager-app
@@ -39,7 +38,6 @@ services:
       - publishing-api-app
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/short-url-manager"
-      REDIS_HOST: redis
       REDIS_URL: redis://redis
       VIRTUAL_HOST: short-url-manager.dev.gov.uk
       BINDING: 0.0.0.0

--- a/projects/signon/docker-compose.yml
+++ b/projects/signon/docker-compose.yml
@@ -27,7 +27,6 @@ services:
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-5.5/signon_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-5.5/signon_test"
-      REDIS_HOST: redis
       REDIS_URL: redis://redis
 
   signon-app:
@@ -40,7 +39,6 @@ services:
       DATABASE_URL: "mysql2://root:root@mysql-5.5/signon_development"
       VIRTUAL_HOST: signon.dev.gov.uk
       BINDING: 0.0.0.0
-      REDIS_HOST: redis
       REDIS_URL: redis://redis
     expose:
       - "3000"


### PR DESCRIPTION
These apps have all been migrated to use REDIS_URL so they no longer
need this environment variable. There's a chance this might cause some
inconveniences for people working with old branches of apps, but I think
it's worth doing this sooner rather than risking let it linger.