### PR TITLE
Simplify and enhance DB setup for Rails 6.1

### DIFF
--- a/projects/asset-manager/Makefile
+++ b/projects/asset-manager/Makefile
@@ -1,3 +1,3 @@
 asset-manager: bundle-asset-manager
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'

--- a/projects/asset-manager/Makefile
+++ b/projects/asset-manager/Makefile
@@ -1,3 +1,4 @@
 asset-manager: bundle-asset-manager
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'

--- a/projects/collections-publisher/Makefile
+++ b/projects/collections-publisher/Makefile
@@ -1,3 +1,3 @@
 collections-publisher: bundle-collections-publisher publishing-api content-store link-checker-api
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/collections-publisher/Makefile
+++ b/projects/collections-publisher/Makefile
@@ -1,3 +1,4 @@
 collections-publisher: bundle-collections-publisher publishing-api content-store link-checker-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/contacts-admin/Makefile
+++ b/projects/contacts-admin/Makefile
@@ -1,3 +1,4 @@
 contacts-admin: bundle-contacts-admin
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/contacts-admin/Makefile
+++ b/projects/contacts-admin/Makefile
@@ -1,3 +1,3 @@
 contacts-admin: bundle-contacts-admin
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/content-data-admin/Makefile
+++ b/projects/content-data-admin/Makefile
@@ -1,3 +1,4 @@
 content-data-admin: bundle-content-data-admin
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/content-data-admin/Makefile
+++ b/projects/content-data-admin/Makefile
@@ -1,3 +1,3 @@
 content-data-admin: bundle-content-data-admin
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/content-data-api/Makefile
+++ b/projects/content-data-api/Makefile
@@ -1,2 +1,3 @@
 content-data-api: bundle-content-data-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup

--- a/projects/content-data-api/Makefile
+++ b/projects/content-data-api/Makefile
@@ -1,2 +1,2 @@
 content-data-api: bundle-content-data-api
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup

--- a/projects/content-publisher/Makefile
+++ b/projects/content-publisher/Makefile
@@ -1,3 +1,4 @@
 content-publisher: bundle-content-publisher asset-manager publishing-api content-store
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/content-publisher/Makefile
+++ b/projects/content-publisher/Makefile
@@ -1,3 +1,3 @@
 content-publisher: bundle-content-publisher asset-manager publishing-api content-store
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/content-tagger/Makefile
+++ b/projects/content-tagger/Makefile
@@ -1,3 +1,3 @@
 content-tagger: bundle-content-tagger publishing-api
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/content-tagger/Makefile
+++ b/projects/content-tagger/Makefile
@@ -1,3 +1,4 @@
 content-tagger: bundle-content-tagger publishing-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/datagovuk_publish/Makefile
+++ b/projects/datagovuk_publish/Makefile
@@ -1,2 +1,3 @@
 datagovuk_publish: bundle-datagovuk_publish
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup

--- a/projects/datagovuk_publish/Makefile
+++ b/projects/datagovuk_publish/Makefile
@@ -1,2 +1,2 @@
 datagovuk_publish: bundle-datagovuk_publish
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup

--- a/projects/email-alert-api/Makefile
+++ b/projects/email-alert-api/Makefile
@@ -1,2 +1,3 @@
 email-alert-api: bundle-email-alert-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup

--- a/projects/email-alert-api/Makefile
+++ b/projects/email-alert-api/Makefile
@@ -1,2 +1,2 @@
 email-alert-api: bundle-email-alert-api
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup

--- a/projects/govuk-account-manager-prototype/Makefile
+++ b/projects/govuk-account-manager-prototype/Makefile
@@ -1,2 +1,3 @@
 govuk-account-manager-prototype: bundle-govuk-account-manager-prototype govuk-attribute-service-prototype
 	$(GOVUK_DOCKER) run $@-lite bin/rails db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup

--- a/projects/govuk-account-manager-prototype/Makefile
+++ b/projects/govuk-account-manager-prototype/Makefile
@@ -1,2 +1,2 @@
 govuk-account-manager-prototype: bundle-govuk-account-manager-prototype govuk-attribute-service-prototype
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rails db:migrate 2>/dev/null || bin/rails db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rails db:setup

--- a/projects/govuk-attribute-service-prototype/Makefile
+++ b/projects/govuk-attribute-service-prototype/Makefile
@@ -1,2 +1,3 @@
 govuk-attribute-service-prototype: bundle-govuk-attribute-service-prototype
 	$(GOVUK_DOCKER) run $@-lite bin/rails db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup

--- a/projects/govuk-attribute-service-prototype/Makefile
+++ b/projects/govuk-attribute-service-prototype/Makefile
@@ -1,2 +1,2 @@
 govuk-attribute-service-prototype: bundle-govuk-attribute-service-prototype
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rails db:migrate 2>/dev/null || bin/rails db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rails db:setup

--- a/projects/licence-finder/Makefile
+++ b/projects/licence-finder/Makefile
@@ -1,2 +1,2 @@
 licence-finder: bundle-licence-finder static content-store
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup

--- a/projects/licence-finder/Makefile
+++ b/projects/licence-finder/Makefile
@@ -1,2 +1,3 @@
 licence-finder: bundle-licence-finder static content-store
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup

--- a/projects/link-checker-api/Makefile
+++ b/projects/link-checker-api/Makefile
@@ -1,2 +1,3 @@
 link-checker-api: bundle-link-checker-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup

--- a/projects/link-checker-api/Makefile
+++ b/projects/link-checker-api/Makefile
@@ -1,2 +1,2 @@
 link-checker-api: bundle-link-checker-api
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup

--- a/projects/local-links-manager/Makefile
+++ b/projects/local-links-manager/Makefile
@@ -1,3 +1,4 @@
 local-links-manager: bundle-local-links-manager
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/local-links-manager/Makefile
+++ b/projects/local-links-manager/Makefile
@@ -1,3 +1,3 @@
 local-links-manager: bundle-local-links-manager
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/publisher/Makefile
+++ b/projects/publisher/Makefile
@@ -1,3 +1,4 @@
 publisher: bundle-publisher publishing-api link-checker-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/publisher/Makefile
+++ b/projects/publisher/Makefile
@@ -1,3 +1,3 @@
 publisher: bundle-publisher publishing-api link-checker-api
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/publishing-api/Makefile
+++ b/projects/publishing-api/Makefile
@@ -1,4 +1,4 @@
 publishing-api: bundle-publishing-api govuk-content-schemas
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'
 	$(GOVUK_DOCKER) run $@-lite bin/rake setup_exchange

--- a/projects/publishing-api/Makefile
+++ b/projects/publishing-api/Makefile
@@ -1,4 +1,5 @@
 publishing-api: bundle-publishing-api govuk-content-schemas
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'
 	$(GOVUK_DOCKER) run $@-lite bin/rake setup_exchange

--- a/projects/release/Makefile
+++ b/projects/release/Makefile
@@ -1,3 +1,4 @@
 release: bundle-release
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/release/Makefile
+++ b/projects/release/Makefile
@@ -1,3 +1,3 @@
 release: bundle-release
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/search-admin/Makefile
+++ b/projects/search-admin/Makefile
@@ -1,4 +1,5 @@
 search-admin: bundle-search-admin publishing-api search-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/search-admin/Makefile
+++ b/projects/search-admin/Makefile
@@ -1,4 +1,4 @@
 search-admin: bundle-search-admin publishing-api search-api
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/service-manual-publisher/Makefile
+++ b/projects/service-manual-publisher/Makefile
@@ -1,3 +1,4 @@
 service-manual-publisher: bundle-service-manual-publisher
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/service-manual-publisher/Makefile
+++ b/projects/service-manual-publisher/Makefile
@@ -1,3 +1,3 @@
 service-manual-publisher: bundle-service-manual-publisher
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/signon/Makefile
+++ b/projects/signon/Makefile
@@ -1,3 +1,3 @@
 signon: bundle-signon
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/signon/Makefile
+++ b/projects/signon/Makefile
@@ -1,3 +1,4 @@
 signon: bundle-signon
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/specialist-publisher/Makefile
+++ b/projects/specialist-publisher/Makefile
@@ -1,3 +1,4 @@
 specialist-publisher: bundle-specialist-publisher asset-manager publishing-api email-alert-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/specialist-publisher/Makefile
+++ b/projects/specialist-publisher/Makefile
@@ -1,3 +1,3 @@
 specialist-publisher: bundle-specialist-publisher asset-manager publishing-api email-alert-api
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/support-api/Makefile
+++ b/projects/support-api/Makefile
@@ -1,2 +1,3 @@
 support-api: bundle-support-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup

--- a/projects/support-api/Makefile
+++ b/projects/support-api/Makefile
@@ -1,2 +1,2 @@
 support-api: bundle-support-api
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup

--- a/projects/transition/Makefile
+++ b/projects/transition/Makefile
@@ -1,2 +1,3 @@
 transition: bundle-transition
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup

--- a/projects/transition/Makefile
+++ b/projects/transition/Makefile
@@ -1,2 +1,2 @@
 transition: bundle-transition
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup

--- a/projects/travel-advice-publisher/Makefile
+++ b/projects/travel-advice-publisher/Makefile
@@ -1,3 +1,4 @@
 travel-advice-publisher: bundle-travel-advice-publisher asset-manager content-store publishing-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/travel-advice-publisher/Makefile
+++ b/projects/travel-advice-publisher/Makefile
@@ -1,3 +1,3 @@
 travel-advice-publisher: bundle-travel-advice-publisher asset-manager content-store publishing-api
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/whitehall/Makefile
+++ b/projects/whitehall/Makefile
@@ -1,4 +1,5 @@
 whitehall: bundle-whitehall asset-manager publishing-api static
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn
 	$(GOVUK_DOCKER) run $@-lite bin/rake shared_mustache:compile

--- a/projects/whitehall/Makefile
+++ b/projects/whitehall/Makefile
@@ -1,4 +1,4 @@
 whitehall: bundle-whitehall asset-manager publishing-api static
-	$(GOVUK_DOCKER) run $@-lite sh -c 'bin/rake db:migrate 2>/dev/null || bin/rake db:setup'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn
 	$(GOVUK_DOCKER) run $@-lite bin/rake shared_mustache:compile


### PR DESCRIPTION
Fixes: https://github.com/alphagov/govuk-docker/issues/452

This simplifies the existing DB setup steps before adding another to
cope with a breaking change in Rails 6.1. While not all of our repos 
use Rails 6.1 yet, this change is backwards-compatible; we may as 
well fix the problem for everything preemptively if we can Please see 
the commits for more details.