### PR TITLE
Refresh compatibility list

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Do this to start a GOV.UK web app:
 govuk-docker up collections-publisher-app
 ```
 
+👉 [Replicate data locally](docs/how-tos.md#how-to-replicate-data-locally) (or use the [`app-live` stack](#the-app--stacks)).
+
 👉 [Check the troubleshooting guide if you have a problem.](docs/troubleshooting.md)
 
 ### The `app-*` stacks

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -14,8 +14,7 @@ These are repos that can be started as a some kind of process, such as a web app
    - ⚠ bouncer
       * **TODO: Missing support for a webserver stack**
    - ✅ cache-clearing-service
-   - ⚠ calculators
-      * Web UI doesn't work without the content item being present in the content-store.
+   - ✅ calculators
    - ❌ ckan
       * Has a [separate](https://github.com/alphagov/docker-ckan) Docker project.
    - ✅  collections

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -18,9 +18,7 @@ These are repos that can be started as a some kind of process, such as a web app
       * Web UI doesn't work without the content item being present in the content-store.
    - ❌ ckan
       * Has a [separate](https://github.com/alphagov/docker-ckan) Docker project.
-   - ⚠  collections
-      * You will need to [populate the Content Store database](#mongodb) or run the live stack in order for it to work locally.
-      * To view topic pages locally you still need to use the live stack as they rely on Elasticsearch data which we are yet to be able to import.
+   - ✅  collections
    - ✅ collections-publisher
    - ⚠ contacts-admin
       * **TODO: Missing support for a webserver stack**

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -40,7 +40,7 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ email-alert-service
    - ✅ feedback
    - ✅ finder-frontend
-   - ❓ frontend
+   - ✅ frontend
    - ✅ government-frontend
    - ⚠ govuk_crawler_worker
       * **TODO: Missing support for running the worker**

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -82,9 +82,7 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ transition
    - ❌ transition-config
    - ✅ travel-advice-publisher
-   - ⚠ whitehall
-      * Who knows, really - several tests are failing, lots pass ;-)
-      * Placeholder images don't work as missing proxy for [/government/assets](https://github.com/alphagov/whitehall/blob/master/app/presenters/publishing_api/news_article_presenter.rb#L133)
+   - ✅ whitehall
 
 ## Generic Ruby libraries
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -13,9 +13,7 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ asset-manager
    - ⚠ bouncer
       * **TODO: Missing support for a webserver stack**
-   - ⚠ cache-clearing-service
-      * Tests pass
-      * Queues are not set-up, so cache-clearing-service can't be run locally
+   - ✅ cache-clearing-service
    - ⚠ calculators
       * Web UI doesn't work without the content item being present in the content-store.
    - ❌ ckan
@@ -39,8 +37,7 @@ These are repos that can be started as a some kind of process, such as a web app
       * **TODO: Missing support for a webserver stack**
    - ✅ email-alert-api
    - ✅ email-alert-frontend
-   - ⚠ email-alert-service
-      * **TODO: Missing support for message queues**
+   - ✅ email-alert-service
    - ✅ feedback
    - ✅ finder-frontend
    - ❓ frontend

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -76,8 +76,7 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ smart-answers
    - ✅ special-route-publisher
    - ✅ specialist-publisher
-   - ⚠ static
-      * JavaScript 404 errors when previewing pages, possibly [related to analytics](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/init.js.erb#L28)
+   - ✅ static
    - ✅ support
    - ✅ support-api
    - ✅ transition

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -84,7 +84,6 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ travel-advice-publisher
    - ⚠ whitehall
       * Who knows, really - several tests are failing, lots pass ;-)
-      * Rake task to [create a test taxon](https://github.com/alphagov/whitehall/blob/master/lib/tasks/taxonomy.rake#L11) for publishing is not idempotent
       * Placeholder images don't work as missing proxy for [/government/assets](https://github.com/alphagov/whitehall/blob/master/app/presenters/publishing_api/news_article_presenter.rb#L133)
 
 ## Generic Ruby libraries

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -45,6 +45,8 @@ These are repos that can be started as a some kind of process, such as a web app
    - ⚠ govuk_crawler_worker
       * **TODO: Missing support for running the worker**
    - ✅ govuk_publishing_components
+   - ✅ govuk-attribute-service-prototype
+   - ✅ govuk-account-manager-prototype
    - ✅ govuk-developer-docs
    - ⚠ hmrc-manuals-api
       * **TODO: Missing support for a webserver stack**
@@ -89,10 +91,6 @@ These are repos that can be started as a some kind of process, such as a web app
       * Who knows, really - several tests are failing, lots pass ;-)
       * Rake task to [create a test taxon](https://github.com/alphagov/whitehall/blob/master/lib/tasks/taxonomy.rake#L11) for publishing is not idempotent
       * Placeholder images don't work as missing proxy for [/government/assets](https://github.com/alphagov/whitehall/blob/master/app/presenters/publishing_api/news_article_presenter.rb#L133)
-   - ⚠ govuk-attribute-service-prototype
-      * **No support for a webserver stack**
-   - ⚠ govuk-account-manager-prototype
-      * **No support for a webserver stack**
 
 ## Generic Ruby libraries
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -62,7 +62,6 @@ These are repos that can be started as a some kind of process, such as a web app
    - ⚠ manuals-publisher
       * **TODO: Missing support for a webserver stack**
    - ✅ mapit
-      * **TODO: Data replication**
    - ✅ maslow
    - ✅ publisher
    - ✅ publishing-api

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -46,5 +46,4 @@ services:
       BINDING: 0.0.0.0
     expose:
       - "3000"
-    # Change to 'bin/rails --restart' when rails >= 5.2
-    command: /bin/sh -c "rm -f tmp/pids/server.pid && rails s"
+    command: bin/rails s --restart


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

Fixes: https://github.com/alphagov/govuk-docker/issues/444

Depends on: https://github.com/alphagov/calculators/pull/1030

This switches to a more practical / positive approach to compatibility
for some services, and clarifies the compatibility for others. Please
see the commits for more details.