### PR TITLE
Add web server stack for contacts admin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ services:
           - calculators.dev.gov.uk
           - collections-publisher.dev.gov.uk
           - collections.dev.gov.uk
+          - contacts-admin.dev.gov.uk
           - content-publisher.dev.gov.uk
           - content-store.dev.gov.uk
           - content-tagger.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -24,8 +24,7 @@ These are repos that can be started as a some kind of process, such as a web app
       * You will need to [populate the Content Store database](#mongodb) or run the live stack in order for it to work locally.
       * To view topic pages locally you still need to use the live stack as they rely on Elasticsearch data which we are yet to be able to import.
    - ✅ collections-publisher
-   - ⚠ contacts-admin
-      * **TODO: Missing support for a webserver stack**
+   - ✅ contacts-admin
    - ⚠ content-data-admin
       * **TODO: Missing support for a webserver stack**
    - ⚠ content-data-api

--- a/projects/contacts-admin/Makefile
+++ b/projects/contacts-admin/Makefile
@@ -1,4 +1,4 @@
-contacts-admin: bundle-contacts-admin
+contacts-admin: bundle-contacts-admin publishing-api content-store whitehall
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/contacts-admin/docker-compose.yml
+++ b/projects/contacts-admin/docker-compose.yml
@@ -29,3 +29,22 @@ services:
       TEST_DATABASE_URL: "mysql2://root:root@mysql-5.5/contacts_test"
       REDIS_URL: redis://redis
 
+  contacts-admin-app: &contacts-admin-app
+    <<: *contacts-admin
+    depends_on:
+      - mysql-5.5
+      - redis
+      - publishing-api-app
+      - nginx-proxy
+      - content-store-app
+      - whitehall-app
+    environment:
+      DATABASE_URL: "mysql2://root:root@mysql-5.5/contacts_development"
+      TEST_DATABASE_URL: "mysql2://root:root@mysql-5.5/contacts_test"
+      REDIS_URL: redis://redis
+      VIRTUAL_HOST: contacts-admin.dev.gov.uk
+      BINDING: 0.0.0.0
+    expose:
+      - "3000"
+    command: bin/rails s --restart
+


### PR DESCRIPTION
This is to facilitate https://trello.com/c/cIv5x8wB/2348-5-add-ability-to-unpublish-with-a-redirect-in-contacts-app.

Contacts Admin doesn't work perfectly with govuk-docker: notably, you currently need to run Publishing API in another shell. I'm not sure why that's the case, and am hoping it is something we can fix here, rather than have to document in https://github.com/alphagov/contacts-admin/pull/838.