### PR TITLE
Modify account dev URL to serve from SecureContext

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,4 +123,4 @@ services:
           - www-origin.dev.gov.uk
           - www.dev.gov.uk
           - attributes.login.service.dev.gov.uk
-          - www.login.service.dev.gov.uk
+          - www.login.service.localhost

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -75,5 +75,5 @@ services:
       GOVUK_ACCOUNT_JWT_KEY_PEM: "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEID+UE4jB5QtUFOtekHJliaSB8K2xQU2AS4xczOLAqvCUoAoGCCqGSM49\nAwEHoUQDQgAEjMgE/d6Bdu1K17BTjNycDvIXKSmUgZ5YYoayU3gGqTLhgefuK2qb\no99Wx+SuvdW/GRvIlUIW1ooNRdQ3QFwwCw==\n-----END EC PRIVATE KEY-----\n"
       GOVUK_ACCOUNT_JWT_KEY_UUID: "898d62b7-eed9-464a-a4ae-9d9e08bd9bee"
       GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: transition-checker-secret
-      PLEK_SERVICE_ACCOUNT_MANAGER_URI: "http://www.login.service.dev.gov.uk"
+      PLEK_SERVICE_ACCOUNT_MANAGER_URI: "http://www.login.service.localhost"
       FEATURE_FLAG_ACCOUNTS: "enabled"

--- a/projects/govuk-account-manager-prototype/docker-compose.yml
+++ b/projects/govuk-account-manager-prototype/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       MEMCACHE_SERVERS: memcached
       DATABASE_URL: "postgresql://postgres@postgres-9.6/govuk-account-manager-prototype"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/govuk-account-manager-prototype-test"
-      REDIRECT_BASE_URL: http://www.login.service.dev.gov.uk
+      REDIRECT_BASE_URL: http://www.login.service.localhost
       FINDER_FRONTEND_OAUTH_CLIENT_ID: transition-checker-id
       FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY_UUID: 898d62b7-eed9-464a-a4ae-9d9e08bd9bee
       FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY: "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjMgE/d6Bdu1K17BTjNycDvIXKSmU\ngZ5YYoayU3gGqTLhgefuK2qbo99Wx+SuvdW/GRvIlUIW1ooNRdQ3QFwwCw==\n-----END PUBLIC KEY-----\n"
@@ -40,13 +40,13 @@ services:
       - govuk-attribute-service-prototype-app
       - govuk-account-manager-prototype-worker
     environment:
-      ASSET_HOST: www.login.service.dev.gov.uk
-      VIRTUAL_HOST: www.login.service.dev.gov.uk
+      ASSET_HOST: www.login.service.localhost
+      VIRTUAL_HOST: www.login.service.localhost
       BINDING: 0.0.0.0
       MEMCACHE_SERVERS: memcached
       DATABASE_URL: "postgresql://postgres@postgres-9.6/govuk-account-manager-prototype"
       ATTRIBUTE_SERVICE_URL: http://attributes.login.service.dev.gov.uk
-      REDIRECT_BASE_URL: http://www.login.service.dev.gov.uk
+      REDIRECT_BASE_URL: http://www.login.service.localhost
       REDIS_URL: redis://redis:6379/0
       FINDER_FRONTEND_OAUTH_CLIENT_ID: transition-checker-id
       FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY_UUID: 898d62b7-eed9-464a-a4ae-9d9e08bd9bee
@@ -63,6 +63,6 @@ services:
     environment:
       ATTRIBUTE_SERVICE_URL: http://attributes.login.service.dev.gov.uk
       REDIS_URL: redis://redis:6379/0
-      REDIRECT_BASE_URL: http://www.login.service.dev.gov.uk
+      REDIRECT_BASE_URL: http://www.login.service.localhost
       DATABASE_URL: "postgresql://postgres@postgres-9.6/govuk-account-manager-prototype"
     command: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/projects/govuk-attribute-service-prototype/docker-compose.yml
+++ b/projects/govuk-attribute-service-prototype/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     environment:
       MEMCACHE_SERVERS: memcached
       DATABASE_URL: "postgresql://postgres@postgres-9.6/govuk-attribute-service-prototype"
-      ACCOUNT_MANAGER_URL: http://www.login.service.dev.gov.uk
+      ACCOUNT_MANAGER_URL: http://www.login.service.localhost
       ACCOUNT_MANAGER_TOKEN: attribute-service-token
       TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/govuk-attribute-service-prototype-test"
 
@@ -39,7 +39,7 @@ services:
     environment:
       ASSET_HOST: attributes.login.service.dev.gov.uk
       VIRTUAL_HOST: attributes.login.service.dev.gov.uk
-      ACCOUNT_MANAGER_URL: http://www.login.service.dev.gov.uk
+      ACCOUNT_MANAGER_URL: http://www.login.service.localhost
       ACCOUNT_MANAGER_TOKEN: attribute-service-token
       BINDING: 0.0.0.0
       MEMCACHE_SERVERS: memcached


### PR DESCRIPTION
[Account Team Trello](https://trello.com/c/QTDcQIui/616-https-er-ize-local-dev-setup)

The account manager prototype contains UI to allow a user to log in and
manage accounts.

As part of that login journey we have been prototyping webauthn
integration. This has revealed there are a range of secure-only browser
APIs that are only available over a HTTPs connection or in another
secure context.

We looked into adding HTTPs certificates however, an easier win seemed
to be modifying the domain to serve from a `.localhost` domain which is
regarded as a secure context[1].

This may have some advantages over self signed certificates in terms of
simplicity of setup[2], but that requires a bit more of a look.

So as a result we move the URL for only the account manager from a
`dev.gov.uk` account to a `.localhost` domain.

[1]: https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts
[2]: https://medium.com/@bramus/on-secure-contexts-in-firefox-https-for-local-development-and-a-potential-nice-gesture-by-cea4ab4903a