### PR TITLE
Update Mapit configuration

### DIFF
--- a/projects/mapit/Dockerfile
+++ b/projects/mapit/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-buster
+FROM python:3.6-buster
 
 RUN apt-get update -qq && apt-get install -y gettext \
         postgresql-client libgdal-dev libgeos-dev musl-dev ruby-dev

--- a/projects/mapit/Makefile
+++ b/projects/mapit/Makefile
@@ -1,5 +1,5 @@
 mapit:
-	- $(GOVUK_DOCKER) run $@-app createuser -U postgres mapit
+	- $(GOVUK_DOCKER) run $@-app createuser -U postgres -s mapit
 	- $(GOVUK_DOCKER) run $@-app createdb -U postgres --owner mapit mapit
 	- $(GOVUK_DOCKER) run $@-app psql -U postgres -c "CREATE EXTENSION postgis; CREATE EXTENSION postgis_topology;" mapit
 	- $(GOVUK_DOCKER) run $@-app python ./manage.py migrate -v 0


### PR DESCRIPTION
We are now [using Python 3.6 in CI](https://github.com/alphagov/mapit/pull/118/commits/2c06ee9e4968e3e7c9e170c9457f176ed131f17b), so we should run the same version in govuk-docker.

Additionally, it appears it has never been possible to run the test locally as the `mapit` database user does not have permissions to create and drop databases.  By making this user a superadmin, they will have that permission.