### PR TITLE
Remove account-manager / finder-frontend JWT env vars

### DIFF
--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -72,8 +72,6 @@ services:
       BINDING: 0.0.0.0
       MEMCACHE_SERVERS: memcached
       GOVUK_ACCOUNT_OAUTH_CLIENT_ID: transition-checker-id
-      GOVUK_ACCOUNT_JWT_KEY_PEM: "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEID+UE4jB5QtUFOtekHJliaSB8K2xQU2AS4xczOLAqvCUoAoGCCqGSM49\nAwEHoUQDQgAEjMgE/d6Bdu1K17BTjNycDvIXKSmUgZ5YYoayU3gGqTLhgefuK2qb\no99Wx+SuvdW/GRvIlUIW1ooNRdQ3QFwwCw==\n-----END EC PRIVATE KEY-----\n"
-      GOVUK_ACCOUNT_JWT_KEY_UUID: "898d62b7-eed9-464a-a4ae-9d9e08bd9bee"
       GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: transition-checker-secret
       PLEK_SERVICE_ACCOUNT_MANAGER_URI: "http://www.login.service.dev.gov.uk"
       FEATURE_FLAG_ACCOUNTS: "enabled"

--- a/projects/govuk-account-manager-prototype/docker-compose.yml
+++ b/projects/govuk-account-manager-prototype/docker-compose.yml
@@ -27,9 +27,6 @@ services:
       DATABASE_URL: "postgresql://postgres@postgres-9.6/govuk-account-manager-prototype"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/govuk-account-manager-prototype-test"
       REDIRECT_BASE_URL: http://www.login.service.dev.gov.uk
-      FINDER_FRONTEND_OAUTH_CLIENT_ID: transition-checker-id
-      FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY_UUID: 898d62b7-eed9-464a-a4ae-9d9e08bd9bee
-      FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY: "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjMgE/d6Bdu1K17BTjNycDvIXKSmU\ngZ5YYoayU3gGqTLhgefuK2qbo99Wx+SuvdW/GRvIlUIW1ooNRdQ3QFwwCw==\n-----END PUBLIC KEY-----\n"
 
   govuk-account-manager-prototype-app: &govuk-account-manager-prototype-app
     <<: *govuk-account-manager-prototype
@@ -48,9 +45,6 @@ services:
       ATTRIBUTE_SERVICE_URL: http://attributes.login.service.dev.gov.uk
       REDIRECT_BASE_URL: http://www.login.service.dev.gov.uk
       REDIS_URL: redis://redis:6379/0
-      FINDER_FRONTEND_OAUTH_CLIENT_ID: transition-checker-id
-      FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY_UUID: 898d62b7-eed9-464a-a4ae-9d9e08bd9bee
-      FINDER_FRONTEND_OAUTH_CLIENT_PUBLIC_KEY: "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjMgE/d6Bdu1K17BTjNycDvIXKSmU\ngZ5YYoayU3gGqTLhgefuK2qbo99Wx+SuvdW/GRvIlUIW1ooNRdQ3QFwwCw==\n-----END PUBLIC KEY-----\n"
     expose:
       - "3000"
     command: bin/rails s --restart


### PR DESCRIPTION
These are no longer needed as finder-frontend is calling an
authenticated endpoint in the account-manager.

---

[Trello card](https://trello.com/c/nfoKVqOK/629-use-the-new-non-posty-jwt-mechanism-in-the-transition-checker)