### PR TITLE
Add Sidekiq worker to Publishing API

### DIFF
--- a/projects/publishing-api/docker-compose.yml
+++ b/projects/publishing-api/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     <<: *publishing-api
     depends_on:
       - postgres-9.6
+      - publishing-api-worker
       - redis
       - nginx-proxy
     environment:
@@ -45,3 +46,13 @@ services:
     expose:
       - "3000"
     command: bin/rails s --restart
+
+  publishing-api-worker:
+    <<: *publishing-api
+    depends_on:
+      - postgres-9.6
+      - redis
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres-9.6/publishing-api"
+      REDIS_URL: redis://redis
+    command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
This is to facilitate being able to view Bank Holidays pages in
Frontend locally, which require running:
`bundle exec rake publishing_api:publish_calendars`

This would queue up sidekiq jobs in Publishing API, but these jobs
would never be processed. Now they are.

Trello: https://trello.com/c/Pvoq4sQY/2370-5-enable-continuous-deployment-for-frontend