### PR TITLE
Add new account-api app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
     networks:
       default:
         aliases:
+          - account-api.dev.gov.uk
           - asset-manager.dev.gov.uk
           - authenticating-proxy.dev.gov.uk
           - collections-publisher.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -10,6 +10,7 @@ The following lists indicates the support status of a repo in GOV.UK Docker.
 
 These are repos that can be started as a some kind of process, such as a web app or worker.
 
+   - ✅ account-api
    - ✅ asset-manager
    - ⚠ bouncer
       * **TODO: Missing support for a webserver stack**

--- a/projects/account-api/Makefile
+++ b/projects/account-api/Makefile
@@ -1,0 +1,3 @@
+account-api: bundle-account-api
+	$(GOVUK_DOCKER) run $@-lite bin/rails db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rails db:setup

--- a/projects/account-api/docker-compose.yml
+++ b/projects/account-api/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.7'
+
+volumes:
+  account-api-tmp:
+
+x-account-api: &account-api
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: account-api
+  stdin_open: true
+  tty: true
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - root-home:/root
+    - account-api-tmp:/govuk/account-api/tmp
+  working_dir: /govuk/account-api
+
+services:
+  account-api-lite:
+    <<: *account-api
+    depends_on:
+      - postgres-9.6
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres-9.6/account-api"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/account-api-test"
+
+  account-api-app:
+    <<: *account-api
+    depends_on:
+      - nginx-proxy
+      - postgres-9.6
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres-9.6/account-api"
+      VIRTUAL_HOST: account-api.dev.gov.uk
+      BINDING: 0.0.0.0
+      GOVUK_ACCOUNT_OAUTH_CLIENT_ID: client-id
+      GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: client-secret
+      PLEK_SERVICE_ACCOUNT_MANAGER_URI: "http://www.login.service.dev.gov.uk"
+    expose:
+      - "3000"
+    command: bin/rails s --restart


### PR DESCRIPTION
We now have three account-related apps in govuk-docker:

1. govuk-account-manager-prototype
2. govuk-attribute-service-prototype
3. account-api

(1) and (2) are running in production on the PaaS, and are prototypes
of the cross-government authentication and attribute storage systems,
with the GOV.UK Transition Checker as the only user currently.

Responsibility for the cross-gov side of accounts is moving to the
Digital Identity (DI) programme, so those apps will be retired as soon
as DI have viable replacements.

(3) is a GOV.UK-internal app specified in [RFC 134][] which lets
different GOV.UK microservices make use of the accounts and
attributes.

When (3) is set up, finder-frontend will talk to it, and not to the
other apps.

[RFC 134]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-134-govuk-wide-session-cookie-and-login.md

---

To make this work we need to add `config.hosts.clear` to the `config/environments/development.rb` of account-api, like this: https://github.com/alphagov/email-alert-api/blob/6d5ed70353cf260910a1f7d7788939600c205ab4/config/environments/development.rb#L55-L56

---

[Trello card](https://trello.com/c/ZeAKl2SM/651-set-up-a-new-app)