### PR TITLE
Add account-api to finder-frontend-app-account deps, and account-manager to account-api-app deps

### DIFF
--- a/projects/account-api/Makefile
+++ b/projects/account-api/Makefile
@@ -1,3 +1,3 @@
-account-api: bundle-account-api
+account-api: bundle-account-api govuk-account-manager-prototype
 	$(GOVUK_DOCKER) run $@-lite bin/rails db:setup
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rails db:setup

--- a/projects/account-api/docker-compose.yml
+++ b/projects/account-api/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     depends_on:
       - nginx-proxy
       - postgres-9.6
+      - govuk-account-manager-prototype-app
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-9.6/account-api"
       VIRTUAL_HOST: account-api.dev.gov.uk

--- a/projects/finder-frontend/Makefile
+++ b/projects/finder-frontend/Makefile
@@ -1,2 +1,2 @@
-finder-frontend: bundle-finder-frontend content-store static search-api router email-alert-api govuk-account-manager-prototype
+finder-frontend: bundle-finder-frontend account-api content-store static search-api router email-alert-api govuk-account-manager-prototype
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -62,6 +62,7 @@ services:
     depends_on:
       - router-app
       - nginx-proxy
+      - account-api-app
       - email-alert-api-app
       - static-app
       - memcached


### PR DESCRIPTION
We're moving the communication with the account manager to account-api, so we now have these service dependencies.

---

[Trello card](https://trello.com/c/Y8z5rsJl/653-move-oauth-sign-in-logic-from-the-transition-checker-to-the-new-app)