### PR TITLE
Add support for HMRC Manuals API web stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,7 @@ services:
           - government-frontend.dev.gov.uk
           - govuk-developer-docs.dev.gov.uk
           - govuk-publishing-components.dev.gov.uk
+          - hmrc-manuals-api.dev.gov.uk
           - info-frontend.dev.gov.uk
           - licence-finder.dev.gov.uk
           - link-checker-api.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -42,8 +42,7 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ govuk-attribute-service-prototype
    - ✅ govuk-account-manager-prototype
    - ✅ govuk-developer-docs
-   - ⚠ hmrc-manuals-api
-      * **TODO: Missing support for a webserver stack**
+   - ✅ hmrc-manuals-api
    - ⚠ imminence
       * **TODO: Missing support for a webserver stack**
    - ✅ info-frontend

--- a/projects/hmrc-manuals-api/Makefile
+++ b/projects/hmrc-manuals-api/Makefile
@@ -1,1 +1,1 @@
-hmrc-manuals-api: bundle-hmrc-manuals-api
+hmrc-manuals-api: bundle-hmrc-manuals-api publishing-api

--- a/projects/hmrc-manuals-api/docker-compose.yml
+++ b/projects/hmrc-manuals-api/docker-compose.yml
@@ -19,3 +19,15 @@ x-hmrc-manuals-api: &hmrc-manuals-api
 services:
   hmrc-manuals-api-lite:
     <<: *hmrc-manuals-api
+
+  hmrc-manuals-api-app: &hmrc-manuals-api-app
+    <<: *hmrc-manuals-api
+    depends_on:
+      - publishing-api-app
+      - nginx-proxy
+    environment:
+      VIRTUAL_HOST: hmrc-manuals-api.dev.gov.uk
+      BINDING: 0.0.0.0
+    expose:
+      - "3000"
+    command: bin/rails s -P /tmp/rails.pid


### PR DESCRIPTION
Depends on: https://github.com/alphagov/hmrc-manuals-api/pull/577