### PR TITLE
Remove ROUTER_NODES environment variable

### DIFF
--- a/projects/router-api/docker-compose.yml
+++ b/projects/router-api/docker-compose.yml
@@ -32,7 +32,6 @@ services:
       - router-app
       - nginx-proxy
     environment:
-      ROUTER_NODES: router-app:3055
       MONGODB_URI: "mongodb://mongo-3.6/router"
       VIRTUAL_HOST: router-api.dev.gov.uk
       BINDING: 0.0.0.0


### PR DESCRIPTION
This PR removes the `ROUTER_NODES` environment variable. Router is being changed to self-update routes from MongoDB rather than having Router API inform it when to update routes, so removing this environment variable will allow that to happen.