### PR TITLE
Update finder-frontend account stack to govuk account

### DIFF
--- a/projects/finder-frontend/Makefile
+++ b/projects/finder-frontend/Makefile
@@ -1,2 +1,2 @@
-finder-frontend: bundle-finder-frontend account-api content-store static search-api router email-alert-api govuk-account-manager-prototype
+finder-frontend: bundle-finder-frontend account-api content-store frontend static search-api router email-alert-api
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -62,17 +62,13 @@ services:
     depends_on:
       - router-app
       - nginx-proxy
+      - frontend-app-account
       - account-api-app
       - email-alert-api-app
       - static-app
       - memcached
-      - govuk-account-manager-prototype-app
     environment:
       ASSET_HOST: finder-frontend.dev.gov.uk
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       BINDING: 0.0.0.0
       MEMCACHE_SERVERS: memcached
-      GOVUK_ACCOUNT_OAUTH_CLIENT_ID: transition-checker-id
-      GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: transition-checker-secret
-      PLEK_SERVICE_ACCOUNT_MANAGER_URI: "http://www.login.service.dev.gov.uk"
-      FEATURE_FLAG_ACCOUNTS: "enabled"


### PR DESCRIPTION
[Trello](https://trello.com/c/43FM4pwv/673-switch-to-the-new-sign-in-out-endpoints)

We have migrated parts of the GOV.UK Account out of finder-frontend
(where it was specific to the brexit checker) to frontend (where it acts
as a global login).

We've also removed the feature flag from finder-frontend, the account is
assumed to always be on.