### PR TITLE
Configure Nginx proxy buffer size to prevent 502 responses

### DIFF
--- a/nginx-proxy.conf
+++ b/nginx-proxy.conf
@@ -19,3 +19,11 @@ add_header 'Access-Control-Allow-Origin' '*';
 client_max_body_size 500m;
 
 proxy_read_timeout 200s;
+
+# Rails 6.1 introduced a preload_links_header which can produce particularly
+# large HTTP headers when running applications in development mode. These
+# large headers can exhaust nginx proxy buffers causing a 502 response, to
+# counter this these buffers are increased from their default 8k size.
+proxy_buffer_size 128k;
+proxy_buffers 8 128k;
+proxy_busy_buffers_size 128k;


### PR DESCRIPTION
I've found that Content Publisher stopped working with govuk-docker once
it was upgraded to Rails 6.1 and the new Rails option of
`action_view.preload_links_header` was enabled. This option adds a Link HTTP
header to HTML responses which includes preload information to each
asset. When running an asset pipeline app in development mode there is
potential for this header to be pretty huge as each asset file is
returned individually. For Content Publisher the Link header was 13,554 bytes.

These large Link headers cause 502 responses as the header size exceeds
the Nginx proxy buffer size [1].

I've resolved this by increasing the default buffer size from 8k to
128k, which should have amble room for apps with lots of assets. The
decision to go this size was based on Content Publisher reaching
approximately 16k. I felt going 8x this size offered a very low chance
that we'd see this error again.

I did consider whether this Rails option should be on in development,
since the benefits of this header are likely low and it seems a bit
weird to have such a large header. However I chose to make this config
change in this app rather than changing Content Publisher as I expect,
given this is a new default Rails option, that it will affect other
applications in due course.

[1]: https://ma.ttias.be/nginx-proxy-upstream-sent-big-header-reading-response-header-upstream/