### PR TITLE
Use `db:setup` instead of `db:create`

### DIFF
--- a/projects/manuals-publisher/Makefile
+++ b/projects/manuals-publisher/Makefile
@@ -1,3 +1,3 @@
 manuals-publisher: bundle-manuals-publisher
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:create
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn


### PR DESCRIPTION
Allows us to seed the database which is a requirement for running the
application locally.

Trello:
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh