### PR TITLE
Add web server stack for Manuals Publisher

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,6 +102,7 @@ services:
           - link-checker-api.dev.gov.uk
           - local-links-manager.dev.gov.uk
           - manuals-frontend.dev.gov.uk
+          - manuals-publisher.dev.gov.uk
           - mapit.dev.gov.uk
           - maslow.dev.gov.uk
           - publisher.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -52,8 +52,7 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ link-checker-api
    - ✅ local-links-manager
    - ✅ manuals-frontend
-   - ⚠ manuals-publisher
-      * **TODO: Missing support for a webserver stack**
+   - ✅ manuals-publisher
    - ✅ mapit
    - ✅ maslow
    - ✅ publisher

--- a/projects/manuals-publisher/Makefile
+++ b/projects/manuals-publisher/Makefile
@@ -1,3 +1,3 @@
-manuals-publisher: bundle-manuals-publisher
+manuals-publisher: bundle-manuals-publisher asset-manager publishing-api link-checker-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/manuals-publisher/Makefile
+++ b/projects/manuals-publisher/Makefile
@@ -1,3 +1,3 @@
 manuals-publisher: bundle-manuals-publisher
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:create
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/manuals-publisher/docker-compose.yml
+++ b/projects/manuals-publisher/docker-compose.yml
@@ -29,3 +29,34 @@ services:
       TEST_MONGODB_URI: "mongodb://mongo-3.6/manuals-publisher-test"
       REDIS_URL: redis://redis
 
+  manuals-publisher-app: &manuals-publisher-app
+    <<: *manuals-publisher
+    depends_on:
+      - redis
+      - mongo-3.6
+      - asset-manager-app
+      - publishing-api-app
+      - link-checker-api-app
+      - manuals-publisher-worker
+      - nginx-proxy
+    environment:
+      MONGODB_URI: "mongodb://mongo-3.6/manuals-publisher"
+      GOVUK_WEBSITE_ROOT: https://www.gov.uk
+      REDIS_URL: redis://redis
+      VIRTUAL_HOST: manuals-publisher.dev.gov.uk
+      BINDING: 0.0.0.0
+    expose:
+      - "3000"
+    command: bin/rails s --restart
+
+  manuals-publisher-worker:
+    <<: *manuals-publisher
+    depends_on:
+      - redis
+      - mongo-3.6
+      - asset-manager-app
+      - publishing-api-app
+    environment:
+      MONGODB_URI: "mongodb://mongo-3.6/manuals-publisher"
+      REDIS_URL: redis://redis
+    command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
We can now use GOV.UK Docker to run Manuals Publisher.

GOVUK_WEBSITE_ROOT variable has been set to allow the [/api/organisations](https://www.gov.uk/api/organisations) endpoint to be queried when [creating a manual](https://github.com/alphagov/manuals-publisher/blob/22dba788f02a90b24602c9ab66f876e255555ff7/app/adapters/publishing_adapter.rb#L84).

## Some snaps of the app in action

<img width="1146" alt="Screenshot 2021-03-26 at 17 16 14" src="https://user-images.githubusercontent.com/24479188/112675576-3e1c2000-8e5f-11eb-80d6-c15ec210bc04.png">
<img width="1015" alt="Screenshot 2021-03-26 at 17 27 30" src="https://user-images.githubusercontent.com/24479188/112675582-407e7a00-8e5f-11eb-8ecf-e2d621b27b1a.png">

