### PR TITLE
Add an app-account stack for frontend

### DIFF
--- a/projects/frontend/Makefile
+++ b/projects/frontend/Makefile
@@ -1,2 +1,2 @@
-frontend: bundle-frontend content-store router static
+frontend: bundle-frontend account-api content-store router static
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -47,3 +47,17 @@ services:
       PLEK_SERVICE_STATIC_URI: assets.publishing.service.gov.uk
       VIRTUAL_HOST: frontend.dev.gov.uk
       BINDING: 0.0.0.0
+
+  frontend-app-account:
+    <<: *frontend-app
+    depends_on:
+      - account-api-app
+      - content-store-app
+      - router-app
+      - static-app
+      - nginx-proxy
+    environment:
+      ASSET_HOST: frontend.dev.gov.uk
+      PLEK_SERVICE_ACCOUNT_MANAGER_URI: "http://www.login.service.dev.gov.uk"
+      VIRTUAL_HOST: frontend.dev.gov.uk
+      BINDING: 0.0.0.0


### PR DESCRIPTION
I'm not sure yet when we'll want to merge the app-account stack into
the app stack; but for now we have two stacks.