### PR TITLE
Add support for web stack for Imminence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
           - govuk-developer-docs.dev.gov.uk
           - govuk-publishing-components.dev.gov.uk
           - hmrc-manuals-api.dev.gov.uk
+          - imminence.dev.gov.uk
           - info-frontend.dev.gov.uk
           - licence-finder.dev.gov.uk
           - link-checker-api.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -43,8 +43,7 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ govuk-account-manager-prototype
    - ✅ govuk-developer-docs
    - ✅ hmrc-manuals-api
-   - ⚠ imminence
-      * **TODO: Missing support for a webserver stack**
+   - ✅ imminence
    - ✅ info-frontend
    - ✅ licence-finder
    - ❌ licensify

--- a/projects/imminence/Makefile
+++ b/projects/imminence/Makefile
@@ -1,3 +1,3 @@
-imminence: bundle-imminence
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:create
+imminence: bundle-imminence mapit
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:mongoid:create_indexes

--- a/projects/imminence/docker-compose.yml
+++ b/projects/imminence/docker-compose.yml
@@ -24,3 +24,17 @@ services:
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/imminence"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/imminence-test"
+
+  imminence-app:
+    <<: *imminence
+    depends_on:
+      - mongo-3.6
+      - mapit-app
+      - nginx-proxy
+    environment:
+      MONGODB_URI: "mongodb://mongo-3.6/imminence"
+      VIRTUAL_HOST: imminence.dev.gov.uk
+      BINDING: 0.0.0.0
+    expose:
+      - "3000"
+    command: bin/rails s --restart


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

Depends on: https://github.com/alphagov/imminence/pull/632

I've tested this locally and am able to create a service via the
web UI, as well as make an API call to /areas/EUR. Note that the
API call fails due to a 500 from Mapit, which I'm assuming is just
because I don't have data setup for it locally.