### PR TITLE
Fix transition import remote API call

### DIFF
--- a/projects/transition/docker-compose.yml
+++ b/projects/transition/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - postgres-9.6
       - redis
     environment:
+      GOVUK_WEBSITE_ROOT: https://www.gov.uk
       DATABASE_URL: "postgresql://postgres@postgres-9.6/transition"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/transition-test"
       REDIS_URL: redis://redis


### PR DESCRIPTION
Running 'import:all:orgs_sites_hosts' requires the organisations
API, which is publicly available, and requires no extra setup.