### PR TITLE
Add support for Bouncer web stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,8 @@ services:
           - account-api.dev.gov.uk
           - asset-manager.dev.gov.uk
           - authenticating-proxy.dev.gov.uk
+          - bouncer.dev.gov.uk
+          - bouncer-redirect.dev.gov.uk
           - collections-publisher.dev.gov.uk
           - collections.dev.gov.uk
           - contacts-admin.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -13,8 +13,7 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ account-api
    - ✅ asset-manager
    - ✅ authenticating-proxy
-   - ⚠ bouncer
-      * **TODO: Missing support for a webserver stack**
+   - ✅ bouncer
    - ✅ cache-clearing-service
    - ❌ ckan
       * Has a [separate](https://github.com/alphagov/docker-ckan) Docker project.

--- a/projects/bouncer/docker-compose.yml
+++ b/projects/bouncer/docker-compose.yml
@@ -20,3 +20,16 @@ services:
     environment:
       TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/transition_test"
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
+
+  bouncer-app:
+    <<: *bouncer
+    depends_on:
+      - postgres-9.6
+      - nginx-proxy
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres-9.6/transition"
+      VIRTUAL_HOST: bouncer.dev.gov.uk,bouncer-redirect.dev.gov.uk
+      BINDING: 0.0.0.0
+    expose:
+      - "8080"
+    command: bundle exec mr-sparkle --force-polling


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

This app is different to others on GOV.UK:

- It shares a DB with transition, so the DB name must match [1].

- It's purpose is to redirect third-party domains to transitioned
alternatives. In order to support testing, the app service has a
'bouncer-redirect' domain, in addition to the standard 'bouncer'
domain for testing routes like the healthcheck for the app [2].

- It uses a 'mr-sparkle' gem to support auto reloading (this is a
bare Rack app, so doesn't have this Rails-like feature itself).

[1]: https://github.com/alphagov/govuk-docker/blob/fd419bbee5e42a49e24f77f45ae534101c1cd657/projects/transition/docker-compose.yml#L27
[2]: https://github.com/alphagov/bouncer/blob/ec8022198d0be786c0d68427e4b366134cd2cc67/lib/bouncer/app.rb#L12