### PR TITLE
Move transition-config to non-runnable list

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -75,7 +75,6 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ support
    - ✅ support-api
    - ✅ transition
-   - ❌ transition-config
    - ✅ travel-advice-publisher
    - ✅ whitehall
 
@@ -95,3 +94,4 @@ These repos are used as part of running the live GOV.UK site. Since all of them 
    - ✅ govuk-content-schemas
    - ✅ plek
    - ❌ slimmer
+   - ❌ transition-config


### PR DESCRIPTION
It's not possible to run this repo as an application process.