### PR TITLE
Bump golang base image used for router

### DIFF
--- a/projects/router/Dockerfile
+++ b/projects/router/Dockerfile
@@ -1,1 +1,1 @@
-FROM golang:1.9.1
+FROM golang:1.15.8


### PR DESCRIPTION
We're currently using Go 1.15.8 in production.  Recently the router
dependencies got updated, and they no longer build with 1.9 (which is,
after all, from 2017).

To upgrade, you may need to delete your existing router image:

    docker image rm router

Then build again:

    make router