### PR TITLE
Add lite stack for mapit

### DIFF
--- a/projects/mapit/docker-compose.yml
+++ b/projects/mapit/docker-compose.yml
@@ -18,6 +18,14 @@ services:
     volumes:
       - mapit-pg:/var/lib/postgresql/data
 
+  mapit-lite:
+    <<: *mapit
+    depends_on:
+      - mapit-pg
+    environment:
+      DJANGO_SECRET_KEY: 'secret'
+      MAPIT_DB_HOST: 'mapit-pg'
+
   mapit-app:
     <<: *mapit
     depends_on:
@@ -26,7 +34,6 @@ services:
     environment:
       DJANGO_SECRET_KEY: 'secret'
       MAPIT_DB_HOST: 'mapit-pg'
-      PGHOST: "mapit-pg"
       VIRTUAL_HOST: mapit.dev.gov.uk
     expose:
       - "8000"


### PR DESCRIPTION
https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh

Tests run successfully:

   govuk-docker run mapit-lite ./manage.py test mapit mapit_gb

I've removed the "PGHOST" environment variable, as there's no use
of it in the repo itself, or in GOV.UK Docker scripts.