### PR TITLE
Build Licence Finder search on make and fix misconfigured dependencies

### DIFF
--- a/projects/licence-finder/Makefile
+++ b/projects/licence-finder/Makefile
@@ -1,3 +1,4 @@
 licence-finder: bundle-licence-finder static content-store
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env bin/rake search:index

--- a/projects/licence-finder/docker-compose.yml
+++ b/projects/licence-finder/docker-compose.yml
@@ -31,13 +31,11 @@ services:
     <<: *licence-finder
     depends_on:
       - mongo-3.6
-      - redis
       - static-app
       - elasticsearch-6
       - content-store-app
       - nginx-proxy
     environment:
-      REDIS_URL: redis://redis
       VIRTUAL_HOST: licence-finder.dev.gov.uk
       MONGODB_URI: "mongodb://mongo-3.6/licence-finder_development"
       ELASTICSEARCH_URI: http://elasticsearch-6:9200

--- a/projects/licence-finder/docker-compose.yml
+++ b/projects/licence-finder/docker-compose.yml
@@ -50,9 +50,11 @@ services:
   licence-finder-app-live:
     <<: *licence-finder-app
     depends_on:
+      - elasticsearch-6
       - mongo-3.6
       - nginx-proxy
     environment:
+      ELASTICSEARCH_URI: http://elasticsearch-6:9200
       MONGODB_URI: "mongodb://mongo-3.6/licence-finder_development"
       PLEK_SERVICE_SEARCH_URI: https://www.gov.uk/api
       GOVUK_WEBSITE_ROOT: https://www.gov.uk


### PR DESCRIPTION
This adds the `search:index` task as part of the make process for Licence Finder. This resolves a problem where search won't work until it has run (as the indexes didn't exist).

This also resolves some mistakes in the Licence Finder dependencies.