### PR TITLE
Fix building wrong binary in router tests

### DIFF
--- a/projects/govuk_crawler_worker/Makefile
+++ b/projects/govuk_crawler_worker/Makefile
@@ -1,2 +1,2 @@
 govuk_crawler_worker: clone-govuk_crawler_worker
-	$(GOVUK_DOCKER) run $@-lite sh -c "make build"
+	$(GOVUK_DOCKER) run $@-lite make build

--- a/projects/router/Makefile
+++ b/projects/router/Makefile
@@ -1,2 +1,2 @@
 router: clone-router
-	$(GOVUK_DOCKER) run $@-lite sh -c "BINARY=router make build"
+	$(GOVUK_DOCKER) run $@-lite make build

--- a/projects/router/docker-compose.yml
+++ b/projects/router/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     depends_on:
       - mongo-3.6
     environment:
+      BINARY: router
       DEBUG: "true"
       ROUTER_MONGO_URL: mongo-3.6
       ROUTER_MONGO_DB: router


### PR DESCRIPTION
Previously the tests were rebuilding the binary on a different path
[1], which meant any changes weren't picked up. This fixes that, and
also removes the unnecessary uses of "sh -c" in Makefiles.

[1]: https://github.com/alphagov/router/blob/20c3f646e63e854bb0e0c54f3be540573e984d8c/Makefile#L17