### PR TITLE
Fix BINARY path for router build again

### DIFF
--- a/projects/router/docker-compose.yml
+++ b/projects/router/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     depends_on:
       - mongo-3.6
     environment:
-      BINARY: router
+      BINARY: /go/src/github.com/alphagov/router/router
       DEBUG: "true"
       ROUTER_MONGO_URL: mongo-3.6
       ROUTER_MONGO_DB: router


### PR DESCRIPTION
This needs to be an absolute path for the tests [1].

[1]: https://github.com/alphagov/router/blob/20c3f646e63e854bb0e0c54f3be540573e984d8c/integration_tests/router_support.go#L50