### PR TITLE
Switch to db:prepare from db:setup

### DIFF
--- a/projects/account-api/Makefile
+++ b/projects/account-api/Makefile
@@ -1,3 +1,3 @@
 account-api: bundle-account-api content-store govuk-account-manager-prototype
-	$(GOVUK_DOCKER) run $@-lite bin/rails db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rails db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rails db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rails db:prepare

--- a/projects/collections-publisher/Makefile
+++ b/projects/collections-publisher/Makefile
@@ -1,4 +1,4 @@
 collections-publisher: bundle-collections-publisher publishing-api content-store link-checker-api
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/contacts-admin/Makefile
+++ b/projects/contacts-admin/Makefile
@@ -1,4 +1,4 @@
 contacts-admin: bundle-contacts-admin publishing-api content-store whitehall
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/content-data-admin/Makefile
+++ b/projects/content-data-admin/Makefile
@@ -1,4 +1,4 @@
 content-data-admin: bundle-content-data-admin content-data-api
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/content-data-api/Makefile
+++ b/projects/content-data-api/Makefile
@@ -1,3 +1,3 @@
 content-data-api: bundle-content-data-api
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare

--- a/projects/content-publisher/Makefile
+++ b/projects/content-publisher/Makefile
@@ -1,4 +1,4 @@
 content-publisher: bundle-content-publisher asset-manager publishing-api content-store
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/content-store/Makefile
+++ b/projects/content-store/Makefile
@@ -1,3 +1,2 @@
 content-store: bundle-content-store router-api govuk-content-schemas
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:create
-	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup

--- a/projects/content-tagger/Makefile
+++ b/projects/content-tagger/Makefile
@@ -1,4 +1,4 @@
 content-tagger: bundle-content-tagger publishing-api
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/datagovuk_publish/Makefile
+++ b/projects/datagovuk_publish/Makefile
@@ -1,3 +1,3 @@
 datagovuk_publish: bundle-datagovuk_publish
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare

--- a/projects/email-alert-api/Makefile
+++ b/projects/email-alert-api/Makefile
@@ -1,3 +1,3 @@
 email-alert-api: bundle-email-alert-api
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare

--- a/projects/govuk-account-manager-prototype/Makefile
+++ b/projects/govuk-account-manager-prototype/Makefile
@@ -1,3 +1,3 @@
 govuk-account-manager-prototype: bundle-govuk-account-manager-prototype govuk-attribute-service-prototype
-	$(GOVUK_DOCKER) run $@-lite bin/rails db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rails db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare

--- a/projects/govuk-attribute-service-prototype/Makefile
+++ b/projects/govuk-attribute-service-prototype/Makefile
@@ -1,3 +1,3 @@
 govuk-attribute-service-prototype: bundle-govuk-attribute-service-prototype
-	$(GOVUK_DOCKER) run $@-lite bin/rails db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rails db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare

--- a/projects/link-checker-api/Makefile
+++ b/projects/link-checker-api/Makefile
@@ -1,3 +1,3 @@
 link-checker-api: bundle-link-checker-api
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare

--- a/projects/local-links-manager/Makefile
+++ b/projects/local-links-manager/Makefile
@@ -1,4 +1,4 @@
 local-links-manager: bundle-local-links-manager
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/maslow/Makefile
+++ b/projects/maslow/Makefile
@@ -1,4 +1,4 @@
 maslow: bundle-maslow publishing-api
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:create
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/publishing-api/Makefile
+++ b/projects/publishing-api/Makefile
@@ -1,5 +1,5 @@
 publishing-api: bundle-publishing-api govuk-content-schemas
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'
 	$(GOVUK_DOCKER) run $@-lite bin/rake setup_exchange

--- a/projects/release/Makefile
+++ b/projects/release/Makefile
@@ -1,4 +1,4 @@
 release: bundle-release
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/search-admin/Makefile
+++ b/projects/search-admin/Makefile
@@ -1,5 +1,5 @@
 search-admin: bundle-search-admin publishing-api search-api
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/service-manual-publisher/Makefile
+++ b/projects/service-manual-publisher/Makefile
@@ -1,4 +1,4 @@
 service-manual-publisher: bundle-service-manual-publisher
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/signon/Makefile
+++ b/projects/signon/Makefile
@@ -1,4 +1,4 @@
 signon: bundle-signon
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/support-api/Makefile
+++ b/projects/support-api/Makefile
@@ -1,3 +1,3 @@
 support-api: bundle-support-api
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare

--- a/projects/transition/Makefile
+++ b/projects/transition/Makefile
@@ -1,3 +1,3 @@
 transition: bundle-transition
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare

--- a/projects/whitehall/Makefile
+++ b/projects/whitehall/Makefile
@@ -1,5 +1,5 @@
 whitehall: bundle-whitehall asset-manager publishing-api static
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn
 	$(GOVUK_DOCKER) run $@-lite bin/rake shared_mustache:compile


### PR DESCRIPTION
Fixes: https://github.com/alphagov/govuk-docker/issues/491

In 1ec59d4 we simplified the command to initialise a DB for an app,
since Rails 6 requires we run it for the dev and test environments
separately. The only command swallowed any errors, which masked an
issue that 'db:setup' isn't idempotent for MySQL DBs.

This switches to 'db:prepare', which has roughly the same behaviour
as the old command (including running any seeds), but with the added
bonus of not swallowing any genuine errors. Tested with Collections
Publisher (MySQL) and Content Publisher (Postgres).