### PR TITLE
Add PGHOST environment variable for Mapit

### DIFF
--- a/projects/mapit/docker-compose.yml
+++ b/projects/mapit/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     environment:
       DJANGO_SECRET_KEY: 'secret'
       MAPIT_DB_HOST: 'mapit-pg'
+      PGHOST: 'mapit-pg'
 
   mapit-app:
     <<: *mapit
@@ -34,6 +35,7 @@ services:
     environment:
       DJANGO_SECRET_KEY: 'secret'
       MAPIT_DB_HOST: 'mapit-pg'
+      PGHOST: 'mapit-pg'
       VIRTUAL_HOST: mapit.dev.gov.uk
     expose:
       - "8000"


### PR DESCRIPTION
This was removed in #482, but we now get an error when making Mapit:

```
createuser: could not connect to database template1: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
```

Therefore restoring this environment variable so Mapit can be built.

[Trello card](https://trello.com/c/IwakiikF)