### PR TITLE
Fix authenticating-proxy lite stack erroring

### DIFF
--- a/projects/authenticating-proxy/docker-compose.yml
+++ b/projects/authenticating-proxy/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     depends_on:
       - mongo-3.6
     environment:
+      GOVUK_UPSTREAM_URI: http://government-frontend.dev.gov.uk
       MONGODB_URI: "mongodb://mongo-3.6/authenticating-proxy"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/authenticating-proxy-test"
 


### PR DESCRIPTION
Without this I get the following error:

    docker-compose -f [...] run authenticating-proxy-lite bundle exec rake db:seed
    Creating govuk-docker_authenticating-proxy-lite_run ... done
    rake aborted!
    KeyError: key not found: "GOVUK_UPSTREAM_URI"
    /govuk/authenticating-proxy/config/initializers/proxy.rb:1:in `fetch'
    /govuk/authenticating-proxy/config/initializers/proxy.rb:1:in `<top (required)>'
    /govuk/authenticating-proxy/config/environment.rb:5:in `<top (required)>'
    /root/.rbenv/versions/2.7.2/bin/bundle:23:in `load'
    /root/.rbenv/versions/2.7.2/bin/bundle:23:in `<main>'
    Tasks: TOP => db:seed => environment
    (See full trace by running task with --trace)