### PR TITLE
Make in-browser Jasmine tests available for GOV.UK Publishing Components

### DIFF
--- a/projects/govuk_publishing_components/docker-compose.yml
+++ b/projects/govuk_publishing_components/docker-compose.yml
@@ -20,6 +20,12 @@ services:
   govuk_publishing_components-lite:
     <<: *govuk_publishing_components
 
+  govuk_publishing_components-jasmine:
+    <<: *govuk_publishing_components
+    ports:
+      - "8888:8888"
+    command: bundle exec rake app:jasmine
+
   govuk_publishing_components-app:
     <<: *govuk_publishing_components
     depends_on:


### PR DESCRIPTION
The GOV.UK Publishing Components gem has JavaScript tests that use Jasmine. This can be run in a CI environment and in the browser. This pull requests adds the ability to run the Jasmine server using GOV.UK Docker.

Using a non-`localhost` domain seems to result in certain Jasmine tests failing - so this has had to use Jasmine's usual `localhost:8888` as the virtual host instead of `govuk-publishing-components`.

To run the server:

```sh
govuk-docker up govuk_publishing_components-jasmine
```

and then visit `http://localhost:8888`