### PR TITLE
Install mongo-2.6 for router & router-api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ volumes:
   postgres-9.6:
   mysql-5.5:
   mongo-3.6:
+  mongo-2.6:
   go:
   elasticsearch-6:
   elasticsearch-7:
@@ -28,6 +29,12 @@ services:
     ports:
       - "27017:27017"
       - "28017:28017"
+
+  mongo-2.6:
+    image: mongo:2.6
+    volumes:
+      - mongo-2.6:/data/db
+    command: ["--replSet", "mongo-replica-set"]
 
   mysql-5.5:
     image: mysql:5.5.58

--- a/projects/router-api/docker-compose.yml
+++ b/projects/router-api/docker-compose.yml
@@ -20,19 +20,19 @@ services:
   router-api-lite:
     <<: *router-api
     depends_on:
-      - mongo-3.6
+      - mongo-2.6
     environment:
-      MONGODB_URI: "mongodb://mongo-3.6/router"
-      TEST_MONGODB_URI: "mongodb://mongo-3.6/router-test"
+      MONGODB_URI: "mongodb://mongo-2.6/router"
+      TEST_MONGODB_URI: "mongodb://mongo-2.6/router-test"
 
   router-api-app: &router-api-app
     <<: *router-api
     depends_on:
-      - mongo-3.6
+      - mongo-2.6
       - router-app
       - nginx-proxy
     environment:
-      MONGODB_URI: "mongodb://mongo-3.6/router"
+      MONGODB_URI: "mongodb://mongo-2.6/router"
       VIRTUAL_HOST: router-api.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/router/Makefile
+++ b/projects/router/Makefile
@@ -1,2 +1,4 @@
 router: clone-router
+	$(GOVUK_DOCKER) up -d mongo-2.6
+	$(GOVUK_DOCKER) exec mongo-2.6 mongo --eval "rs.initiate()"
 	$(GOVUK_DOCKER) run $@-lite make build

--- a/projects/router/docker-compose.yml
+++ b/projects/router/docker-compose.yml
@@ -15,17 +15,17 @@ services:
   router-lite:
     <<: *router
     depends_on:
-      - mongo-3.6
+      - mongo-2.6
     environment:
       BINARY: /go/src/github.com/alphagov/router/router
       DEBUG: "true"
-      ROUTER_MONGO_URL: mongo-3.6
+      ROUTER_MONGO_URL: mongo-2.6
       ROUTER_MONGO_DB: router
 
   router-app: &router-app
     <<: *router
     depends_on:
-      - mongo-3.6
+      - mongo-2.6
       - nginx-proxy
     expose:
       - "8080"
@@ -33,7 +33,7 @@ services:
     environment:
       VIRTUAL_HOST: router.dev.gov.uk,www.dev.gov.uk,www-origin.dev.gov.uk
       VIRTUAL_PORT: 8080
-      ROUTER_MONGO_URL: mongo-3.6
+      ROUTER_MONGO_URL: mongo-2.6
       ROUTER_MONGO_DB: router
       ROUTER_APIADDR: :3055
       ROUTER_BACKEND_HEADER_TIMEOUT: 60s
@@ -44,7 +44,7 @@ services:
     environment:
       VIRTUAL_HOST: draft-router.dev.gov.uk,draft-origin.dev.gov.uk
       VIRTUAL_PORT: 8080
-      ROUTER_MONGO_URL: mongo-3.6
+      ROUTER_MONGO_URL: mongo-2.6
       ROUTER_MONGO_DB: draft-router
       ROUTER_APIADDR: :3055
       ROUTER_BACKEND_HEADER_TIMEOUT: 60s


### PR DESCRIPTION
The route reloading mechanism in router relies on the output format of
`rs.status()`, which is different in 3.6.  Since we're using mongo 2.x
in production, downgrade the version used for router.