### PR TITLE
Add `ACCOUNT_API_DOORKEEPER_UID` env var for account-manager

### DIFF
--- a/projects/govuk-account-manager-prototype/docker-compose.yml
+++ b/projects/govuk-account-manager-prototype/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - postgres-9.6
       - memcached
     environment:
+      ACCOUNT_API_DOORKEEPER_UID: client-id
       MEMCACHE_SERVERS: memcached
       DATABASE_URL: "postgresql://postgres@postgres-9.6/govuk-account-manager-prototype"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/govuk-account-manager-prototype-test"
@@ -37,6 +38,7 @@ services:
       - govuk-attribute-service-prototype-app
       - govuk-account-manager-prototype-worker
     environment:
+      ACCOUNT_API_DOORKEEPER_UID: client-id
       ASSET_HOST: www.login.service.dev.gov.uk
       VIRTUAL_HOST: www.login.service.dev.gov.uk
       BINDING: 0.0.0.0
@@ -55,6 +57,7 @@ services:
       - redis
       - govuk-attribute-service-prototype-app
     environment:
+      ACCOUNT_API_DOORKEEPER_UID: client-id
       ATTRIBUTE_SERVICE_URL: http://attributes.login.service.dev.gov.uk
       REDIS_URL: redis://redis:6379/0
       REDIRECT_BASE_URL: http://www.login.service.dev.gov.uk


### PR DESCRIPTION
This is used by
https://github.com/alphagov/govuk-account-manager-prototype/pull/859

The value matches the `GOVUK_ACCOUNT_OAUTH_CLIENT_ID` var in the
account-api docker-compose file.

---

[Trello card](https://trello.com/c/UD2IR18h/830-make-account-manager-tell-account-api-about-email-address-changes)