### PR TITLE
Include additional apps: whitehall

### DIFF
--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       - nginx-proxy
       - asset-manager-app
       - publishing-api-app
+      - search-api-app
+      - content-store-app
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-5.5/whitehall_development"
       REDIS_URL: redis://redis


### PR DESCRIPTION
Draft

## What 

Updating Whitehall to include essential apps.

## Why

While working pages such as: `/world/france/news` certain apps needed to be running in parallel otherwise pages face rendering issues.
 