### PR TITLE
Add govuk-content-schemas-app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,7 @@ services:
           - frontend.dev.gov.uk
           - finder-frontend.dev.gov.uk
           - government-frontend.dev.gov.uk
+          - govuk-content-schemas.dev.gov.uk
           - govuk-developer-docs.dev.gov.uk
           - govuk-publishing-components.dev.gov.uk
           - hmrc-manuals-api.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -42,6 +42,7 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ govuk_publishing_components
    - ✅ govuk-attribute-service-prototype
    - ✅ govuk-account-manager-prototype
+   - ✅ govuk-content-schemas
    - ✅ govuk-developer-docs
    - ✅ hmrc-manuals-api
    - ✅ imminence
@@ -91,7 +92,6 @@ These repos are used as part of running the live GOV.UK site. Since all of them 
    - ❌ govuk_schemas
    - ❌ govuk_sidekiq
    - ❌ govuk_taxonomy_helpers
-   - ✅ govuk-content-schemas
    - ✅ plek
    - ❌ slimmer
    - ❌ transition-config

--- a/projects/generic-ruby-library/Makefile
+++ b/projects/generic-ruby-library/Makefile
@@ -1,5 +1,4 @@
 gds-api-adapters: bundle-gds-api-adapters
 govspeak: bundle-govspeak
-govuk-content-schemas: bundle-govuk-content-schemas
 govuk_app_config: bundle-govuk_app_config
 plek: bundle-plek

--- a/projects/generic-ruby-library/docker-compose.yml
+++ b/projects/generic-ruby-library/docker-compose.yml
@@ -18,10 +18,6 @@ services:
     <<: *generic-ruby-library
     working_dir: /govuk/govspeak
 
-  govuk-content-schemas-lite:
-    <<: *generic-ruby-library
-    working_dir: /govuk/govuk-content-schemas
-
   govuk_app_config-lite:
     <<: *generic-ruby-library
     working_dir: /govuk/govuk_app_config

--- a/projects/govuk-content-schemas/Makefile
+++ b/projects/govuk-content-schemas/Makefile
@@ -1,0 +1,1 @@
+govuk-content-schemas: bundle-govuk-content-schemas

--- a/projects/govuk-content-schemas/docker-compose.yml
+++ b/projects/govuk-content-schemas/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.7'
+
+volumes:
+  govuk-content-schemas-tmp:
+
+x-govuk-content-schemas: &govuk-content-schemas
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: govuk-content-schemas
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - root-home:/root
+    - govuk-content-schemas-tmp:/govuk/govuk-content-schemas/tmp
+  working_dir: /govuk/govuk-content-schemas
+
+services:
+  govuk-content-schemas-lite:
+    <<: *govuk-content-schemas
+
+  govuk-content-schemas-app:
+    <<: *govuk-content-schemas
+    depends_on:
+      - nginx-proxy
+    environment:
+      VIRTUAL_HOST: govuk-content-schemas.dev.gov.uk
+    expose:
+      - "4567"
+    command: bundle exec ruby app.rb

--- a/spec/integration/make/dependencies_spec.rb
+++ b/spec/integration/make/dependencies_spec.rb
@@ -3,19 +3,19 @@ require "spec_helper"
 RSpec.describe "Make dependencies" do
   ProjectsHelper.all_projects.each do |project_name|
     it "mirrors docker-compose.yml for #{project_name}" do
-      expect(compose_dependencies(project_name))
-        .to match_array(makefile_dependencies(project_name))
+      expect(app_dependencies_in_compose_file(project_name))
+        .to match_array(app_dependencies_in_makefile(project_name))
     end
   end
 
-  def compose_dependencies(project_name)
+  def app_dependencies_in_compose_file(project_name)
     project_stacks = ComposeHelper.services(project_name).values
     dependencies = project_stacks.flat_map { |s| s["depends_on"].to_a }
     dependencies = compose_remove_stack_from_service_name(dependencies)
     (dependencies & ProjectsHelper.all_projects) - [project_name]
   end
 
-  def makefile_dependencies(project_name)
+  def app_dependencies_in_makefile(project_name)
     MakefileHelper.dependencies(project_name) &
       compose_remove_stack_from_service_name(ComposeHelper.app_services.keys)
   end

--- a/spec/integration/make/dependencies_spec.rb
+++ b/spec/integration/make/dependencies_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe "Make dependencies" do
       expect(app_dependencies_in_compose_file(project_name))
         .to match_array(app_dependencies_in_makefile(project_name))
     end
+
+    it "has only valid dependencies in the #{project_name} Makefile" do
+      app_dependencies = MakefileHelper.dependencies(project_name)
+        .reject { |dep| dep =~ /^(bundle|clone)/ }
+        .map { |dep| "#{dep}-app" }
+
+      expect((app_dependencies - ComposeHelper.all_services.keys)).to eq([])
+    end
   end
 
   def app_dependencies_in_compose_file(project_name)

--- a/spec/integration/make/dependencies_spec.rb
+++ b/spec/integration/make/dependencies_spec.rb
@@ -1,13 +1,15 @@
 require "spec_helper"
 
 RSpec.describe "Make dependencies" do
+  # rubocop:disable Lint/ConstantDefinitionInBlock
   # Some dependencies are only needed by the dependant app for their static files.
-  dependencies_that_do_not_need_to_be_running = %w[govuk-content-schemas]
+  DEPENDENCIES_THAT_DO_NOT_NEED_TO_BE_RUNNING = %w[govuk-content-schemas].freeze
+  # rubocop:enable Lint/ConstantDefinitionInBlock
 
   ProjectsHelper.all_projects.each do |project_name|
     it "mirrors docker-compose.yml for #{project_name}" do
-      expect(app_dependencies_in_compose_file(project_name) - dependencies_that_do_not_need_to_be_running)
-        .to match_array(app_dependencies_in_makefile(project_name) - dependencies_that_do_not_need_to_be_running)
+      expect(app_dependencies_in_compose_file(project_name))
+        .to match_array(app_dependencies_in_makefile(project_name))
     end
   end
 
@@ -15,12 +17,14 @@ RSpec.describe "Make dependencies" do
     project_stacks = ComposeHelper.services(project_name).values
     dependencies = project_stacks.flat_map { |s| s["depends_on"].to_a }
     dependencies = compose_remove_stack_from_service_name(dependencies)
-    (dependencies & ProjectsHelper.all_projects) - [project_name]
+    app_dependencies = (dependencies & ProjectsHelper.all_projects) - [project_name]
+    app_dependencies - DEPENDENCIES_THAT_DO_NOT_NEED_TO_BE_RUNNING
   end
 
   def app_dependencies_in_makefile(project_name)
-    MakefileHelper.dependencies(project_name) &
+    app_dependencies = MakefileHelper.dependencies(project_name) &
       compose_remove_stack_from_service_name(ComposeHelper.app_services.keys)
+    app_dependencies - DEPENDENCIES_THAT_DO_NOT_NEED_TO_BE_RUNNING
   end
 
   def compose_remove_stack_from_service_name(dependencies)

--- a/spec/integration/make/dependencies_spec.rb
+++ b/spec/integration/make/dependencies_spec.rb
@@ -1,10 +1,13 @@
 require "spec_helper"
 
 RSpec.describe "Make dependencies" do
+  # Some dependencies are only needed by the dependant app for their static files.
+  dependencies_that_do_not_need_to_be_running = %w[govuk-content-schemas]
+
   ProjectsHelper.all_projects.each do |project_name|
     it "mirrors docker-compose.yml for #{project_name}" do
-      expect(app_dependencies_in_compose_file(project_name))
-        .to match_array(app_dependencies_in_makefile(project_name))
+      expect(app_dependencies_in_compose_file(project_name) - dependencies_that_do_not_need_to_be_running)
+        .to match_array(app_dependencies_in_makefile(project_name) - dependencies_that_do_not_need_to_be_running)
     end
   end
 


### PR DESCRIPTION
This is to enable `govuk-docker-run` to work on govuk-content-schemas, so that we can remove the startup.sh script.

Sister PR: https://github.com/alphagov/govuk-content-schemas/pull/1065
Trello: https://trello.com/c/Psf7EzPB/204-move-away-from-startupsh