### PR TITLE
Fix Mapit installation

### DIFF
--- a/projects/mapit/Dockerfile
+++ b/projects/mapit/Dockerfile
@@ -7,6 +7,6 @@ RUN git clone https://github.com/alphagov/mapit.git
 
 WORKDIR /mapit
 
-RUN pip install shapely
+RUN pip install shapely six
 RUN pip install --upgrade pip wheel setuptools
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Running `make mapit` was leading to the following error:

```
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
...
[...redacted for brevity...]
...
  File "/govuk/mapit/mapit/models.py", line 10, in <module>
    from django.utils.encoding import python_2_unicode_compatible, smart_text
ImportError: cannot import name 'python_2_unicode_compatible'
```

This appears to be down to a mismatch between the dependencies
`Django` and `six`. We have both dependencies listed in our
requirements.txt:
https://github.com/alphagov/mapit/blob/76c968f6e69cbe87c72ef2ce4d8050478f8e282b/requirements.txt#L9

Answers on StackOverflow suggest a few changes to the way `six` is
imported, but we already seem to be following the suggested
convention. If in doubt, attempt to `pip install` it, as suggested
here: https://stackoverflow.com/a/60720922. It solves the issue!