### PR TITLE
Fix `make release`

### DIFF
--- a/projects/release/Makefile
+++ b/projects/release/Makefile
@@ -1,4 +1,5 @@
 release: bundle-release
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:schema:load
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn


### PR DESCRIPTION
Running `make release` was failing on this error:

```
StandardError: An error has occurred, this and all later migrations canceled:

Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class CreateUsers < ActiveRecord::Migration[4.2]
```

This has been noticed in other apps before, e.g. [in contacts-admin](https://github.com/alphagov/govuk-docker/issues/381). The fix in that case was to call `db:setup`. However, we changed all of our `db:setup` calls to `db:prepare` in #494.

I could have followed the advice of the error message by editing the migrations' code in `release`, as was done in Content Tagger [in 2018](https://github.com/alphagov/content-tagger/pull/639). However, most recently in [July 2020](https://github.com/alphagov/signon/pull/1457), this approach was declined in Signon. Instead, the issue in that case was resolved by a careful series of deployments. See https://github.com/alphagov/signon/pull/1458#issuecomment-655415079.

> Rails maintains a schema_migrations table based on the filenames under the db/migrations directory. This lets it keeps track of which migrations have to be run.
>
> We had deployed a branch with migrations removed, set up the database, and then tried deploying the app with migrations. This didn’t work, since rails thought the migrations were new/down and tried to run them (as above), which isn’t what we wanted.

By explicitly executing `db:schema:load` before running `db:prepare`, we're telling Rails that all migrations have been run at the time of creating the database. Since we have no data in our development DB that we have to worry about migrating to the latest schema, we can safely run this step.