### PR TITLE
Chrome doesn't need libs anymore. And use apt-get

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -6,9 +6,9 @@
 FROM buildpack-deps
 
 # Install chrome and its dependencies
-RUN apt-get update -qq && apt-get install -y libxss1 libappindicator1 libindicator7
+RUN apt-get update -qq
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>&1 && \
-   apt install -y ./google-chrome*.deb && \
+   apt-get install -y ./google-chrome*.deb && \
     rm ./google-chrome*.deb
 
 # Enable no-sandbox for chrome so that it can run as a root user

--- a/projects/asset-manager/Dockerfile
+++ b/projects/asset-manager/Dockerfile
@@ -2,9 +2,9 @@
 FROM buildpack-deps
 
 # Install chrome and its dependencies
-RUN apt-get update -qq && apt-get install -y libxss1 libappindicator1 libindicator7
+RUN apt-get update -qq
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>&1 && \
-   apt install -y ./google-chrome*.deb && \
+   apt-get install -y ./google-chrome*.deb && \
     rm ./google-chrome*.deb
 
 # Enable no-sandbox for chrome so that it can run as a root user

--- a/projects/whitehall/Dockerfile
+++ b/projects/whitehall/Dockerfile
@@ -2,9 +2,9 @@
 FROM buildpack-deps
 
 # Install chrome and its dependencies
-RUN apt-get update -qq && apt-get install -y libxss1 libappindicator1 libindicator7
+RUN apt-get update -qq
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>&1 && \
-   apt install -y ./google-chrome*.deb && \
+   apt-get install -y ./google-chrome*.deb && \
     rm ./google-chrome*.deb
 
 # Enable no-sandbox for chrome so that it can run as a root user


### PR DESCRIPTION
- Chrome doesn't need those libraries (which are no longer available)
- also use `apt-get` in lieu of `apt` in non-interactive environments