### PR TITLE
Use $HOME in PATH for ZSH compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The aim of govuk-docker is to make it easy to develop any GOV.UK app. It achieve
 
 ```
 # in ~/.bashrc or ~/.zshrc
-export PATH=$PATH:~/govuk/govuk-docker/exe
+export PATH=$PATH:${HOME}/govuk/govuk-docker/exe
 ```
 
 Run `echo $SHELL` if you're not sure which shell you use. After saving, you will need to run `source ~/.bashrc` or `source ~/.zshrc` to apply this change to your current terminal session.


### PR DESCRIPTION
ZSH [doesn't expand `~` characters in `$PATH`](https://stackoverflow.com/questions/56951712/why-is-zsh-not-able-to-read-tilde-from-a-path-in-a-script) by default. 

Without this change I was getting the following error:

```sh
$ govuk-docker up
zsh: command not found: govuk-docker
```

This can be enabled (to match BASH behaviour) using `set -o magicequalsubst`, but `$HOME` is equivalent to `~`.
