### PR TITLE
Allow the Link Checker API tests to pass

### DIFF
--- a/projects/link-checker-api/docker-compose.yml
+++ b/projects/link-checker-api/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-9.6/link-checker-api"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/link-checker-api-test"
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       REDIS_URL: redis://redis
 
   link-checker-api-app: &link-checker-api-app


### PR DESCRIPTION
The Database Cleaner gem was failing because it won't work on remote databases by default.

Database Cleaner considers a remote database as any database which doesn't have a hostname of `localhost` or `127.0.0.1`. In this context, the Postgres database counts as remote because its hostname is `postgres-9.6`.

This change adds an environment variable so that Database Cleaner will work within this docker environment.

This is the same approach that other apps within govuk-docker take – e.g. [content-tagger](https://github.com/alphagov/govuk-docker/blob/9f02754b719ce32e20cbd3dd19e1692b7efc22e4/projects/content-tagger/docker-compose.yml#L27) and [service-manual-publisher](https://github.com/alphagov/govuk-docker/blob/b80ccb9a26c78592c4b71d9c9fae2f9bea7dc462/projects/service-manual-publisher/docker-compose.yml#L29). It looks like it was just miss off from this particular project.

More information about this environment variable can be found in the [Safeguards section of the Database Cleaner docs](https://github.com/DatabaseCleaner/database_cleaner#safeguards).