### PR TITLE
Add PostgreSQL 13 service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ volumes:
   root-home:
   rabbitmq:
   postgres-9.6:
+  postgres-13:
   mysql-5.5:
   mongo-3.6:
   mongo-2.6:
@@ -18,6 +19,13 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - postgres-9.6:/var/lib/postgresql/data
+
+  postgres-13:
+    image: postgres:13
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - postgres-13:/var/lib/postgresql/data
 
   memcached:
     image: memcached


### PR DESCRIPTION
This will allow us to do development work against the version of PostgreSQL we plan to upgrade all our apps to.

[Trello card](https://trello.com/c/zVdVJqFM/62-work-out-how-much-effort-is-required-to-upgrade-postgresql-databases-in-each-of-our-applications)