### PR TITLE
Update Content Tagger to use PostgreSQL 13

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ volumes:
   root-home:
   rabbitmq:
   postgres-9.6:
+  postgres-13:
   mysql-5.5:
   mongo-3.6:
   mongo-2.6:
@@ -18,6 +19,13 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - postgres-9.6:/var/lib/postgresql/data
+
+  postgres-13:
+    image: postgres:13
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - postgres-13:/var/lib/postgresql/data
 
   memcached:
     image: memcached

--- a/projects/content-tagger/docker-compose.yml
+++ b/projects/content-tagger/docker-compose.yml
@@ -22,21 +22,21 @@ services:
   content-tagger-lite:
     <<: *content-tagger
     depends_on:
-      - postgres-9.6
+      - postgres-13
     environment:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/content-tagger"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/content-tagger-test"
+      DATABASE_URL: "postgresql://postgres@postgres-13/content-tagger"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/content-tagger-test"
 
   content-tagger-app: &content-tagger-app
     <<: *content-tagger
     depends_on:
-      - postgres-9.6
+      - postgres-13
       - publishing-api-app
       - nginx-proxy
       - redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/content-tagger"
+      DATABASE_URL: "postgresql://postgres@postgres-13/content-tagger"
       VIRTUAL_HOST: content-tagger.dev.gov.uk
       REDIS_URL: redis://redis
       BINDING: 0.0.0.0


### PR DESCRIPTION
This is the version we are planning to upgrade PostgreSQL to in production, so we need to update our development environment too.

Branched from https://github.com/alphagov/govuk-docker/pull/519.

[Trello card](https://trello.com/c/zVdVJqFM/62-work-out-how-much-effort-is-required-to-upgrade-postgresql-databases-in-each-of-our-applications)