### PR TITLE
Add application stack for Service Manual Publisher

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,7 @@ services:
           - search-api.dev.gov.uk
           - search.dev.gov.uk
           - service-manual-frontend.dev.gov.uk
+          - service-manual-publisher.dev.gov.uk
           - short-url-manager.dev.gov.uk
           - signon.dev.gov.uk
           - smart-answers.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -63,8 +63,7 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ search-admin
    - ✅ search-api
    - ✅ service-manual-frontend
-   - ⚠ service-manual-publisher
-      * **TODO: Missing support for a webserver stack**
+   - ✅ service-manual-publisher
    - ✅ short-url-manager
    - ❌ sidekiq-monitoring
    - ✅ signon

--- a/projects/service-manual-publisher/Makefile
+++ b/projects/service-manual-publisher/Makefile
@@ -1,4 +1,4 @@
-service-manual-publisher: bundle-service-manual-publisher
+service-manual-publisher: bundle-service-manual-publisher publishing-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/service-manual-publisher/docker-compose.yml
+++ b/projects/service-manual-publisher/docker-compose.yml
@@ -27,3 +27,17 @@ services:
       DATABASE_URL: "postgresql://postgres@postgres-9.6/service-manual-publisher"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/service-manual-publisher-test"
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
+
+  service-manual-publisher-app: &service-manual-publisher-app
+    <<: *service-manual-publisher
+    depends_on:
+      - postgres-9.6
+      - publishing-api-app
+      - nginx-proxy
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres-9.6/service-manual-publisher"
+      VIRTUAL_HOST: service-manual-publisher.dev.gov.uk
+      BINDING: 0.0.0.0
+    expose:
+      - "3000"
+    command: bin/rails s --restart


### PR DESCRIPTION
This allows us to run the application and visit it in a web browser.