### PR TITLE
Update Publishing API to use PostgreSQL 13

### DIFF
--- a/projects/publishing-api/docker-compose.yml
+++ b/projects/publishing-api/docker-compose.yml
@@ -20,26 +20,27 @@ services:
   publishing-api-lite:
     <<: *publishing-api
     depends_on:
-      - postgres-9.6
+      # The version of PostgreSQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/9PayaOSK)
+      - postgres-13
       - redis
       - rabbitmq
     environment:
       RABBITMQ_EXCHANGE: published_documents
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/publishing-api"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/publishing-api-test"
+      DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api-test"
       REDIS_URL: redis://redis
 
   publishing-api-app: &publishing-api-app
     <<: *publishing-api
     depends_on:
-      - postgres-9.6
+      - postgres-13
       - publishing-api-worker
       - redis
       - nginx-proxy
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/publishing-api"
+      DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: publishing-api.dev.gov.uk
       BINDING: 0.0.0.0
@@ -50,9 +51,9 @@ services:
   publishing-api-worker:
     <<: *publishing-api
     depends_on:
-      - postgres-9.6
+      - postgres-13
       - redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/publishing-api"
+      DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
This is the version we are planning to upgrade PostgreSQL to in production, so we need to update our development environment too.

[Trello card](https://trello.com/c/zVdVJqFM/62-work-out-how-much-effort-is-required-to-upgrade-postgresql-databases-in-each-of-our-applications)