### PR TITLE
Update email-alert-api to use postgres-13

### DIFF
--- a/projects/email-alert-api/docker-compose.yml
+++ b/projects/email-alert-api/docker-compose.yml
@@ -20,21 +20,25 @@ services:
   email-alert-api-lite:
     <<: *email-alert-api
     depends_on:
-      - postgres-9.6
+      # The version of PostgreSQL temporarily does not match
+      # production, as an upgrade in production is being worked on
+      #
+      # https://trello.com/c/ZMFOPaCl/1176-upgrade-our-app-databases
+      - postgres-13
       - redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/email-alert-api"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/email-alert-api-test"
+      DATABASE_URL: "postgresql://postgres@postgres-13/email-alert-api"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/email-alert-api-test"
       REDIS_URL: redis://redis
 
   email-alert-api-app: &email-alert-api-app
     <<: *email-alert-api
     depends_on:
       - nginx-proxy
-      - postgres-9.6
+      - postgres-13
       - redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/email-alert-api"
+      DATABASE_URL: "postgresql://postgres@postgres-13/email-alert-api"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: email-alert-api.dev.gov.uk
       BINDING: 0.0.0.0
@@ -45,9 +49,9 @@ services:
   email-alert-api-worker:
     <<: *email-alert-api
     depends_on:
-      - postgres-9.6
+      - postgres-13
       - redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/email-alert-api"
+      DATABASE_URL: "postgresql://postgres@postgres-13/email-alert-api"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
This is the version we're planning to upgrade to in production.

---

[Trello card](https://trello.com/c/ZMFOPaCl/1176-upgrade-our-app-databases)