### PR TITLE
Update Transition to use PostgreSQL 13

### DIFF
--- a/projects/transition/docker-compose.yml
+++ b/projects/transition/docker-compose.yml
@@ -20,22 +20,23 @@ services:
   transition-lite:
     <<: *transition
     depends_on:
-      - postgres-9.6
+      # The version of PostgreSQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/9PayaOSK)
+      - postgres-13
       - redis
     environment:
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/transition"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/transition-test"
+      DATABASE_URL: "postgresql://postgres@postgres-13/transition"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/transition-test"
       REDIS_URL: redis://redis
 
   transition-app: &transition-app
     <<: *transition
     depends_on:
       - nginx-proxy
-      - postgres-9.6
+      - postgres-13
       - redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/transition"
+      DATABASE_URL: "postgresql://postgres@postgres-13/transition"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: transition.dev.gov.uk
       BINDING: 0.0.0.0


### PR DESCRIPTION
This is the version we are planning to upgrade PostgreSQL to in
production, so we need to update our development environment too.

Trello card: https://trello.com/c/zVdVJqFM/62-work-out-how-much-effort-is-required-to-upgrade-postgresql-databases-in-each-of-our-applications