### PR TITLE
Upgrade bouncer to use postgres 13

### DIFF
--- a/projects/bouncer/docker-compose.yml
+++ b/projects/bouncer/docker-compose.yml
@@ -16,18 +16,19 @@ services:
   bouncer-lite:
     <<: *bouncer
     depends_on:
-      - postgres-9.6
+      # The version of PostgreSQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/9PayaOSK)
+      - postgres-13
     environment:
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/transition_test"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/transition_test"
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
 
   bouncer-app:
     <<: *bouncer
     depends_on:
-      - postgres-9.6
+      - postgres-13
       - nginx-proxy
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/transition"
+      DATABASE_URL: "postgresql://postgres@postgres-13/transition"
       VIRTUAL_HOST: bouncer.dev.gov.uk,bouncer-redirect.dev.gov.uk
       BINDING: 0.0.0.0
     expose:


### PR DESCRIPTION
This is the version we are planning to upgrade PostgreSQL to in
production, so we need to update our development environment too.

trello card: https://trello.com/c/zVdVJqFM/62-work-out-how-much-effort-is-required-to-upgrade-postgresql-databases-in-each-of-our-applications