### PR TITLE
Upgrade Travel Advice Publisher to use postgres 13

### DIFF
--- a/projects/travel-advice-publisher/docker-compose.yml
+++ b/projects/travel-advice-publisher/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       - publishing-api-app
       - asset-manager-app
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/travel-advice-publisher"
+      # The version of PostgreSQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/9PayaOSK)
+      DATABASE_URL: "postgresql://postgres@postgres-13/travel-advice-publisher"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
This is the version we are planning to upgrade PostgreSQL to in
production, so we need to update our development environment too.

Trello card: https://trello.com/c/zVdVJqFM/62-work-out-how-much-effort-is-required-to-upgrade-postgresql-databases-in-each-of-our-applications