### PR TITLE
Add MySQL 8 service to the docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ volumes:
   postgres-9.6:
   postgres-13:
   mysql-5.5:
+  mysql-8:
   mongo-3.6:
   mongo-2.6:
   go:
@@ -48,6 +49,14 @@ services:
     image: mysql:5.5.58
     volumes:
       - mysql-5.5:/var/lib/mysql
+    command: --max_allowed_packet=1073741824
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+
+  mysql-8:
+    image: mysql:8
+    volumes:
+      - mysql-8:/var/lib/mysql
     command: --max_allowed_packet=1073741824
     environment:
       MYSQL_ROOT_PASSWORD: root


### PR DESCRIPTION
## Description

We need to upgrade our apps MySQL to version 8 before are forced to upgrade in the new year. This will allow us to drive out any issues that need to be fixed prior to the db upgrade.

## Trello card 

https://trello.com/c/btcm7JyB/83-work-out-how-much-effort-is-required-to-upgrade-mysql-databases-in-each-of-our-applications
