### PR TITLE
Upgrade collections publisher to use MySQL 8

### DIFF
--- a/projects/collections-publisher/docker-compose.yml
+++ b/projects/collections-publisher/docker-compose.yml
@@ -22,18 +22,19 @@ services:
   collections-publisher-lite:
     <<: *collections-publisher
     depends_on:
-      - mysql-5.5
+      # The version of MySQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/btcm7JyB/)
+      - mysql-8
       - redis
     environment:
       # the app uses this URL to generate a test database URL
-      DATABASE_URL: "mysql2://root:root@mysql-5.5/collections_publisher_development"
+      DATABASE_URL: "mysql2://root:root@mysql-8/collections_publisher_development"
       REDIS_URL: redis://redis
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
 
   collections-publisher-app: &collections-publisher-app
     <<: *collections-publisher
     depends_on:
-      - mysql-5.5
+      - mysql-8
       - redis
       - content-store-app
       - link-checker-api-app
@@ -41,7 +42,7 @@ services:
       - publishing-api-app
       - collections-publisher-worker
     environment:
-      DATABASE_URL: "mysql2://root:root@mysql-5.5/collections_publisher_development"
+      DATABASE_URL: "mysql2://root:root@mysql-8/collections_publisher_development"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: collections-publisher.dev.gov.uk
       BINDING: 0.0.0.0
@@ -53,9 +54,9 @@ services:
     <<: *collections-publisher
     depends_on:
       - redis
-      - mysql-5.5
+      - mysql-8
       - publishing-api-app
     environment:
-      DATABASE_URL: "mysql2://root:root@mysql-5.5/collections_publisher_development"
+      DATABASE_URL: "mysql2://root:root@mysql-8/collections_publisher_development"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
This is the version we are planning to upgrade MySQL to in production, so we need to update our development environment too.

trello card: https://trello.com/c/btcm7JyB/83-work-out-how-much-effort-is-required-to-upgrade-mysql-databases-in-each-of-our-applications