### PR TITLE
Upgrade MySQL to version 8

### DIFF
--- a/projects/signon/docker-compose.yml
+++ b/projects/signon/docker-compose.yml
@@ -22,21 +22,21 @@ services:
   signon-lite:
     <<: *signon
     depends_on:
-      - mysql-5.5
+      - mysql-8
       - redis
     environment:
-      DATABASE_URL: "mysql2://root:root@mysql-5.5/signon_development"
-      TEST_DATABASE_URL: "mysql2://root:root@mysql-5.5/signon_test"
+      DATABASE_URL: "mysql2://root:root@mysql-8/signon_development"
+      TEST_DATABASE_URL: "mysql2://root:root@mysql-8/signon_test"
       REDIS_URL: redis://redis
 
   signon-app:
     <<: *signon
     depends_on:
-      - mysql-5.5
+      - mysql-8
       - nginx-proxy
       - redis
     environment:
-      DATABASE_URL: "mysql2://root:root@mysql-5.5/signon_development"
+      DATABASE_URL: "mysql2://root:root@mysql-8/signon_development"
       VIRTUAL_HOST: signon.dev.gov.uk
       BINDING: 0.0.0.0
       REDIS_URL: redis://redis


### PR DESCRIPTION
This is the version we are planning to upgrade MySQL to in production, so we need to update our development environment too.

trello card: https://trello.com/c/btcm7JyB/83-work-out-how-much-effort-is-required-to-upgrade-mysql-databases-in-each-of-our-applications

