### PR TITLE
Update Content Publisher to use PostgreSQL 13

### DIFF
--- a/projects/content-publisher/docker-compose.yml
+++ b/projects/content-publisher/docker-compose.yml
@@ -22,17 +22,18 @@ services:
   content-publisher-lite:
     <<: *content-publisher
     depends_on:
-      - postgres-9.6
+      # The version of PostgreSQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/9PayaOSK)
+      - postgres-13
       - redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/content-publisher"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/content-publisher-test"
+      DATABASE_URL: "postgresql://postgres@postgres-13/content-publisher"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/content-publisher-test"
       REDIS_URL: redis://redis
 
   content-publisher-app: &content-publisher-app
     <<: *content-publisher
     depends_on:
-      - postgres-9.6
+      - postgres-13
       - redis
       - content-publisher-worker
       - publishing-api-app
@@ -40,7 +41,7 @@ services:
       - nginx-proxy
       - content-store-app
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/content-publisher"
+      DATABASE_URL: "postgresql://postgres@postgres-13/content-publisher"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: content-publisher.dev.gov.uk
       BINDING: 0.0.0.0
@@ -51,11 +52,11 @@ services:
   content-publisher-worker:
     <<: *content-publisher
     depends_on:
-      - postgres-9.6
+      - postgres-13
       - redis
       - publishing-api-app
       - asset-manager-app
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/content-publisher"
+      DATABASE_URL: "postgresql://postgres@postgres-13/content-publisher"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
This is the version we are planning to upgrade PostgreSQL to in production, so we need to update our development environment too.

[Trello card][1]

**Note:** the test suite for this app doesn't currently pass in the docker environment. But the test failures seem to be unrelated to the database upgrade, as evidenced by the fact that [they pass in CI][2] with the same database upgrade.

We have a separate [Trello card][3] to resolve the failing tests in the docker environment.

[1]: https://trello.com/c/zVdVJqFM/
[2]: https://github.com/alphagov/content-publisher/pull/2431
[3]: https://trello.com/c/QZOaYQCH/