### PR TITLE
Use Postgres 13 for Local Links Manager

### DIFF
--- a/projects/local-links-manager/docker-compose.yml
+++ b/projects/local-links-manager/docker-compose.yml
@@ -22,18 +22,18 @@ services:
   local-links-manager-lite:
     <<: *local-links-manager
     depends_on:
-      - postgres-9.6
+      - postgres-13
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/local-links-manager"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/local-links-manager-test"
+      DATABASE_URL: "postgresql://postgres@postgres-13/local-links-manager"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/local-links-manager-test"
 
   local-links-manager-app:
     <<: *local-links-manager
     depends_on:
-      - postgres-9.6
+      - postgres-13
       - nginx-proxy
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/local-links-manager"
+      DATABASE_URL: "postgresql://postgres@postgres-13/local-links-manager"
       VIRTUAL_HOST: local-links-manager.dev.gov.uk
       BINDING: 0.0.0.0
     expose:


### PR DESCRIPTION
We've tested that Local Links Manager can run on Postgres 13, locally.
All the tests passed, the app boots up and all the commands / flows we tried
succeeded.

Trello:

* https://trello.com/c/39dGaNA2/944-upgrade-local-links-manager-postgres-96-13

* https://trello.com/c/FJkSr1wN/6-local-links-manager