### PR TITLE
Use Postgres 13 for Support API

### DIFF
--- a/projects/support-api/docker-compose.yml
+++ b/projects/support-api/docker-compose.yml
@@ -20,21 +20,21 @@ services:
   support-api-lite:
     <<: *support-api
     depends_on:
-      - postgres-9.6
+      - postgres-13
       - redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/support-api"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/support-api-test"
+      DATABASE_URL: "postgresql://postgres@postgres-13/support-api"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/support-api-test"
       REDIS_URL: redis://redis
 
   support-api-app: &support-api-app
     <<: *support-api
     depends_on:
-      - postgres-9.6
+      - postgres-13
       - redis
       - nginx-proxy
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/support-api"
+      DATABASE_URL: "postgresql://postgres@postgres-13/support-api"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: support-api.dev.gov.uk
       BINDING: 0.0.0.0


### PR DESCRIPTION
Use postgres 13 when running support api locally with Docker.

- Update docker compose file and confirmed tests passed locally
- Spun up feedback app, support api and support and confirmed behaviour was same as prior to upgrade. Could create data locally in support-api database, and view that data on the support app. Could not replicate sending data from the feedback app and storing it in the support api database because there is a redis queue in between. But that was the same when using 9.6
- Updated CI to run tests against postgres-13 and confirmed they passed
- Confirmed CI on the [test](https://ci.integration.publishing.service.gov.uk/job/support-api/job/postgres_13_test/1/console) branch (`Dropped database 'support-api-test'`) was building a different database than on the [main](https://ci.integration.publishing.service.gov.uk/job/support-api/job/main/518/console) branch (`Dropped database 'support_api_test'`)


Trello:

https://trello.com/c/lYPj0Poj/7-support-api

https://trello.com/c/B21t1VAD/956-upgrade-support-api-from-postgres-96-to-postgres-13