### PR TITLE
Mount /tmp as a tmpfs volume to work around #537

### DIFF
--- a/projects/content-publisher/docker-compose.yml
+++ b/projects/content-publisher/docker-compose.yml
@@ -17,6 +17,9 @@ x-content-publisher: &content-publisher
     - content-publisher-tmp:/govuk/content-publisher/tmp
     - content-publisher-node-modules:/govuk/content-publisher/node_modules
   working_dir: /govuk/content-publisher
+  # Mount /tmp as a tmpfs volume. This is a workaround until docker/for-linux#1015 is resolved.
+  # See alphagov/govuk-docker#537 for more info.
+  tmpfs: /tmp
 
 services:
   content-publisher-lite:

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -17,6 +17,9 @@ x-whitehall: &whitehall
     - whitehall-tmp:/govuk/whitehall/tmp
     - whitehall-node-modules:/govuk/whitehall/node_modules
   working_dir: /govuk/whitehall
+  # Mount /tmp as a tmpfs volume. This is a workaround until docker/for-linux#1015 is resolved.
+  # See alphagov/govuk-docker#537 for more info.
+  tmpfs: /tmp
 
 services:
   whitehall-lite:


### PR DESCRIPTION
This commit is a workaround for the issue #537. It allows the Content Publisher and Whitehall test suites to pass in the GOV.UK Docker development environment.

Once docker/for-linux#1015 has been fixed, this workaround will no longer be needed.