### PR TITLE
Use Postgres 13 for Content Data API

### DIFF
--- a/projects/content-data-api/docker-compose.yml
+++ b/projects/content-data-api/docker-compose.yml
@@ -20,10 +20,10 @@ services:
   content-data-api-lite: &content-data-api-lite
     <<: *content-data-api
     depends_on:
-      - postgres-9.6
+      - postgres-13
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/content-data-api"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/content-data-api-test"
+      DATABASE_URL: "postgresql://postgres@postgres-13/content-data-api"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/content-data-api-test"
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
 
   content-data-api-app: &content-data-api-app
@@ -32,9 +32,9 @@ services:
       - "3000"
     depends_on:
       - nginx-proxy
-      - postgres-9.6
+      - postgres-13
     command: bin/rails s --restart
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/content-data-api"
+      DATABASE_URL: "postgresql://postgres@postgres-13/content-data-api"
       VIRTUAL_HOST: content-data-api.dev.gov.uk
       BINDING: 0.0.0.0


### PR DESCRIPTION
Update Postgres 9.6 => 13 for Content Data API

[find and view trello](https://trello.com/c/zhH82ATS/955-upgrade-content-data-api-from-postgres-96-to-postgres-13)
[database upgrade trello](https://trello.com/c/hHuLcRMq/3-content-data-api)