### PR TITLE
Remove DATABASE_URL from Travel Advice Publisher Worker

### DIFF
--- a/projects/travel-advice-publisher/docker-compose.yml
+++ b/projects/travel-advice-publisher/docker-compose.yml
@@ -55,6 +55,5 @@ services:
       - publishing-api-app
       - asset-manager-app
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/travel-advice-publisher"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
The Travel Advice Publisher uses mongo and so does not need this 
postgresql DATABASE_URL