### PR TITLE
Upgrades Release to use MySQL 8

### DIFF
--- a/projects/release/docker-compose.yml
+++ b/projects/release/docker-compose.yml
@@ -22,18 +22,18 @@ services:
   release-lite:
     <<: *release
     depends_on:
-      - mysql-5.5
+      - mysql-8
     environment:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
-      DATABASE_URL: "mysql2://root:root@mysql-5.5/release_development"
+      DATABASE_URL: "mysql2://root:root@mysql-8/release_development"
 
   release-app:
     <<: *release
     depends_on:
-      - mysql-5.5
+      - mysql-8
       - nginx-proxy
     environment:
-      DATABASE_URL: "mysql2://root:root@mysql-5.5/release_development"
+      DATABASE_URL: "mysql2://root:root@mysql-8/release_development"
       BINDING: 0.0.0.0
       VIRTUAL_HOST: release.dev.gov.uk
     expose:


### PR DESCRIPTION
Sister PR: https://github.com/alphagov/release/pull/902

Trellos:

- https://trello.com/c/CeTaZnfP/2808-test-latest-mysql-version-in-release-5
- https://trello.com/c/TGgNaDV8/19-test-release-with-new-database