### PR TITLE
Update Whitehall to use MySQL 8

### DIFF
--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -25,25 +25,26 @@ services:
   whitehall-lite:
     <<: *whitehall
     depends_on:
-      - mysql-5.5
+      # The version of MySQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/btcm7JyB/)
+      - mysql-8
       - redis
     environment:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
-      DATABASE_URL: "mysql2://root:root@mysql-5.5/whitehall_development"
-      TEST_DATABASE_URL: "mysql2://root:root@mysql-5.5/whitehall_test"
+      DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_development"
+      TEST_DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_test"
       REDIS_URL: redis://redis
 
   whitehall-app: &whitehall-app
     <<: *whitehall
     depends_on:
-      - mysql-5.5
+      - mysql-8
       - redis
       - static-app
       - nginx-proxy
       - asset-manager-app
       - publishing-api-app
     environment:
-      DATABASE_URL: "mysql2://root:root@mysql-5.5/whitehall_development"
+      DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_development"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: whitehall-admin.dev.gov.uk, whitehall-frontend.dev.gov.uk
       BINDING: 0.0.0.0


### PR DESCRIPTION
This is the version we are planning to upgrade MySQL to in production, so we need to update our development environment too.

trello card: https://trello.com/c/btcm7JyB

