### PR TITLE
Fix a regression which stopped Ruby from building

### DIFF
--- a/projects/content-publisher/docker-compose.yml
+++ b/projects/content-publisher/docker-compose.yml
@@ -19,7 +19,7 @@ x-content-publisher: &content-publisher
   working_dir: /govuk/content-publisher
   # Mount /tmp as a tmpfs volume. This is a workaround until docker/for-linux#1015 is resolved.
   # See alphagov/govuk-docker#537 for more info.
-  tmpfs: /tmp
+  tmpfs: /tmp:exec
 
 services:
   content-publisher-lite:

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -19,7 +19,7 @@ x-whitehall: &whitehall
   working_dir: /govuk/whitehall
   # Mount /tmp as a tmpfs volume. This is a workaround until docker/for-linux#1015 is resolved.
   # See alphagov/govuk-docker#537 for more info.
-  tmpfs: /tmp
+  tmpfs: /tmp:exec
 
 services:
   whitehall-lite:


### PR DESCRIPTION
This change fixes a regression in filesystem permissions introduced in #539, which stopped `ruby-build` from being able to build the Ruby version required by `rbenv`.

After #539 was merged, we started seeing the following error message when building the Whitehall and Content Publisher apps:

```
ruby-build: TMPDIR=/tmp cannot hold executables (partition possibly mounted with `noexec`)
```

The error was triggered by running `make whitehall` or `make content-publisher` to re-build the app's docker image. However it also dependended on the docker cache being empty, because otherwise the required Ruby version would already exist in a cached image layer and wouldn't need to be re-installed.

The cause for the error was the new `tmpfs` volume which was mounted at `/tmp`. By default, `docker-compose` mounts `tmpfs` volumes with the `noexec` flag, which means that files inside the `/tmp` directory cannot be executed. But `ruby-build` needs to execute files in `/tmp` in order to build Ruby.

This change re-enables execution of files inside `/tmp` by including the `exec` flag on the `tmpfs` volume mount.