### PR TITLE
Upgrade MySQL to version 8 for search-admin

### DIFF
--- a/projects/search-admin/docker-compose.yml
+++ b/projects/search-admin/docker-compose.yml
@@ -22,23 +22,23 @@ services:
   search-admin-lite:
     <<: *search-admin-base
     depends_on:
-      - mysql-5.5
+      - mysql-8
     environment:
       # the app uses this URL to generate a test database URL
-      DATABASE_URL: "mysql2://root:root@mysql-5.5/search_admin_development"
-      TEST_DATABASE_URL: "mysql2://root:root@mysql-5.5/search_admin_test"
+      DATABASE_URL: "mysql2://root:root@mysql-8/search_admin_development"
+      TEST_DATABASE_URL: "mysql2://root:root@mysql-8/search_admin_test"
       REDIS_URL: redis://redis
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
 
   search-admin-app: &search-admin-app
     <<: *search-admin-base
     depends_on:
-      - mysql-5.5
+      - mysql-8
       - nginx-proxy
       - publishing-api-app
       - search-api-app
     environment:
-      DATABASE_URL: "mysql2://root:root@mysql-5.5/search_admin_development"
+      DATABASE_URL: "mysql2://root:root@mysql-8/search_admin_development"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: search-admin.dev.gov.uk
       BINDING: 0.0.0.0


### PR DESCRIPTION
Use MySQL 8 for local development of Search Admin via docker.

related PR: https://github.com/alphagov/search-admin/pull/709

Trello: https://trello.com/c/ILeGpfWH/24-test-search-admin-with-new-database