### PR TITLE
Update MongoDB to work for Router

### DIFF
--- a/projects/router/Makefile
+++ b/projects/router/Makefile
@@ -1,4 +1,13 @@
 router: clone-router
 	$(GOVUK_DOCKER) up -d mongo-2.6
-	$(GOVUK_DOCKER) exec mongo-2.6 mongo --eval "rs.initiate()"
+	$(GOVUK_DOCKER) exec mongo-2.6 mongo --eval 'rs.initiate({ \
+		"_id" : "mongo-replica-set", \
+		"version" : 1, \
+		"members" : [ \
+			{ \
+				"_id" : 0, \
+				"host" : "mongo-2.6:27017" \
+			} \
+		]\
+	}).ok || rs.status().ok'
 	$(GOVUK_DOCKER) run $@-lite make build


### PR DESCRIPTION
This PR updates MongoDB 2.6 to work for Router, by specifying a replica set config using the name of the MongoDB container defined in `docker-compose.yml`. It also fixes the `replicate-mongodb.sh` script to correctly restore back-ups of `router` / `draft-router` (using MongoDB 2.6 and not 3.6).

The `sleep 60` added when restoring MongoDB 2.6 databases allows the replica set to initialise (see the following screenshot):

![Screenshot 2021-12-15 at 15 12 06](https://user-images.githubusercontent.com/5422487/146224518-2e3fcb5a-6ad2-4d5d-8d8d-d894a986f4ca.png)

This PR also addresses the issues raised in https://github.com/alphagov/govuk-docker/issues/533.