### PR TITLE
Add docs for mysql `caching_sha2_password` default

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -113,3 +113,19 @@ To check if you're using compose V2 and turn it off:
 - go to "Experimental Features"
 - check if the "Use Docker Compose V2 release candidate" checkbox is checked
 - uncheck it if it is checked and save
+
+## Cannot `rails db:prepare` or start console due to "Plugin caching_sha2_password could not be loaded"
+
+In MySQL 8.0 `caching_sha2_password` was made the default over the previous `mysql_native_password`.
+
+This can lead to the following error when ActiveRecord is attempting to connect to the database, for example when running `rails db:prepare` or trying to bring up a rails console.
+
+```
+ActiveRecord::ConnectionNotEstablished: Plugin caching_sha2_password could not be loaded: /usr/lib/x86_64-linux-gnu/mariadb19/plugin/caching_sha2_password.so: cannot open shared object file: No such file or directory
+```
+
+A workaround is to get MySQL to fall back to using `mysql_native_password` as follows:
+
+- Check that you can see `govuk-docker_mysql-8_1` when running `govuk-docker ps`, if not you will need to start a service that uses mysql (for example Whitehall).
+- Bring up a mysql console inside the container: `docker exec -it govuk-docker_mysql-8_1 mysql --user=root --password=root`
+- Alter the way the root user identifies itself. `ALTER USER 'root' IDENTIFIED WITH mysql_native_password BY 'root';`


### PR DESCRIPTION
This stumped me for a couple of days.

Since the mysql 8.0 update I had been unable to `make whitehall` seeing errors when i tried to run: `govuk-docker run whitehall-lite bundle exec rails db:prepare`.

The stack trace was as follows:

```
ActiveRecord::ConnectionNotEstablished: Plugin caching_sha2_password could not be loaded: /usr/lib/x86_64-linux-gnu/mariadb19/plugin/caching_sha2_password.so: cannot open shared object file: No such file or dire
ctory                                                                                                                                                                                                              
/govuk/whitehall/app/models/edition/translatable.rb:19:in `block in <module:Translatable>'                                                                                                                         
/govuk/whitehall/app/models/edition.rb:23:in `include'                                                                                                                                                             
/govuk/whitehall/app/models/edition.rb:23:in `<class:Edition>'                                                                                                                                                     
/govuk/whitehall/app/models/edition.rb:3:in `<main>'                                                                                                                                                               
/govuk/whitehall/app/models/publicationesque.rb:9:in `<main>'                                                                                                                                                      
/govuk/whitehall/app/models/publication.rb:8:in `<main>'                                                                                                                                                           
/govuk/whitehall/app/helpers/admin/edition_routes_helper.rb:4:in `<module:EditionRoutesHelper>'                                                                                                                    
/govuk/whitehall/app/helpers/admin/edition_routes_helper.rb:1:in `<main>'                                                                                                                                          
/govuk/whitehall/config/initializers/teaspoon.rb:2:in `<main>'                                                                                                                                                     
/govuk/whitehall/config/environment.rb:5:in `<main>'                                                                                                                                                               
                                                                                                                                                                                                                   
Caused by:                                                                                                                                                                                                         
Mysql2::Error::ConnectionError: Plugin caching_sha2_password could not be loaded: /usr/lib/x86_64-linux-gnu/mariadb19/plugin/caching_sha2_password.so: cannot open shared object file: No such file or directory   
/govuk/whitehall/app/models/edition/translatable.rb:19:in `block in <module:Translatable>'                                                                                                                         
/govuk/whitehall/app/models/edition.rb:23:in `include'                                                                                                                                                             
/govuk/whitehall/app/models/edition.rb:23:in `<class:Edition>'                                                                                                                                                     
/govuk/whitehall/app/models/edition.rb:3:in `<main>'                                                                                                                                                               
/govuk/whitehall/app/models/publicationesque.rb:9:in `<main>'                                                                                                                                                      
/govuk/whitehall/app/models/publication.rb:8:in `<main>'                                                                                                                                                           
/govuk/whitehall/app/helpers/admin/edition_routes_helper.rb:4:in `<module:EditionRoutesHelper>'                                                                                                                    
/govuk/whitehall/app/helpers/admin/edition_routes_helper.rb:1:in `<main>'                                                                                                                                          
/govuk/whitehall/config/initializers/teaspoon.rb:2:in `<main>'                                                                                                                                                     
/govuk/whitehall/config/environment.rb:5:in `<main>'                                                                                                                                                               
Tasks: TOP => db:prepare => db:load_config => environment                                                                                                                                                          
(See full trace by running task with --trace)
```

This seems to be related to a change in [MySQL password default config][1] in v8.
This documents a solution, (with massive thanks to @ChrisBAshton and @brucebolt)

We may want to find a more sustainable solution as part of the MySQL docker setup. 
[I have created an issue here for that](https://github.com/alphagov/govuk-docker/issues/551).

[1]: https://dev.mysql.com/doc/refman/8.0/en/caching-sha2-pluggable-authentication.html