### PR TITLE
Fix: New line syntax in make router

### DIFF
--- a/projects/router/Makefile
+++ b/projects/router/Makefile
@@ -1,13 +1,13 @@
 router: clone-router
 	$(GOVUK_DOCKER) up -d mongo-2.6
-	$(GOVUK_DOCKER) exec mongo-2.6 mongo --eval 'rs.initiate({ \
-		"_id" : "mongo-replica-set", \
-		"version" : 1, \
-		"members" : [ \
+	$(GOVUK_DOCKER) exec mongo-2.6 mongo --eval "rs.initiate({ \
+		'_id' : 'mongo-replica-set', \
+		'version' : 1, \
+		'members' : [ \
 			{ \
-				"_id" : 0, \
-				"host" : "mongo-2.6:27017" \
+				'_id' : 0, \
+				'host' : 'mongo-2.6:27017' \
 			} \
 		]\
-	}).ok || rs.status().ok'
+	}).ok || rs.status().ok"
 	$(GOVUK_DOCKER) run $@-lite make build


### PR DESCRIPTION
Before this commit on a linux machine I was encountering errors with
running:

```
make router
```

The error referenced illegal characters, apparently due to the `\` at
the end of each line of mongo db initiate configuration not being parsed
correctly.

I tested this by moving the entire statement onto a single (ugly) line,
after which it worked.

The solution here is to swap double and single quotes in the statement.
I'm unclear why I've found this to be an issue on my machine but
colleagues have not on MacOs.

However this should work on both operating systems so I am suggesting it
here.