### PR TITLE
Fix compatibility issue with Docker Compose 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,9 @@ volumes:
   elasticsearch-6:
   elasticsearch-7:
 
+networks:
+  default:
+
 services:
   postgres-9.6:
     image: postgres:9.6

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -102,18 +102,6 @@ Error: It seems there is already an App at '/Applications/Docker.app'.
 
 This isn't a problem if you already have Docker/Compose installed, and the setup script will continue to run. If you like, you can remove your existing Docker/Compose and run `bin/setup` again.
 
-## Check if you are using Docker Compose V2
-
-At time of writing, [docker are trialing a version 2 of the compose command](https://docs.docker.com/compose/cli-command/). It's been observed that after updating Docker, some developers are opted into using this experimental feature. Also at time of writing, using compose V2 has been observed to cause problems when using govuk-docker. Specifically it seems to not work against the nginx image we use.
-
-To check if you're using compose V2 and turn it off:
-
-- open the docker dashboard UI
-- click the settings gear icon
-- go to "Experimental Features"
-- check if the "Use Docker Compose V2 release candidate" checkbox is checked
-- uncheck it if it is checked and save
-
 ## Cannot `rails db:prepare` or start console due to "Plugin caching_sha2_password could not be loaded"
 
 In MySQL 8.0 `caching_sha2_password` was made the default over the previous `mysql_native_password`.


### PR DESCRIPTION
The Docker Compose project has moved from v1 to v2.

For now, it's still possible to opt-out of v2 and revert to v1 when using Docker for Mac. However this option will likely go away at some point. It's therefore a good idea to ensure GOV.UK Docker works with both versions.

As far as I can see, the only compatibility issue that existed is that the `nginx` container attaches to the 'default' network. As I understand it, the network called `default` is no longer implicitly created with Docker Compose v2, so it needs to be defined in the docker compose file.

For more info, see: https://github.com/docker/compose/issues/9015

It's not clear when this change happened as it's not documented as a known change: https://docs.docker.com/compose/compose-file/compose-versioning/

## Demonstration of compatibility issue

The scripts `bin/replicate-mysql.sh` and `bin/replicate-postgres.sh` both run the command:

```
govuk-docker config
```

When running with Docker Compose v1, this command outputs a YAML document describing the current project config.

With Docker Compose v2, the command fails with an error:

```
$ govuk-docker config
docker-compose -f [...] config
service "nginx-proxy" refers to undefined network default: invalid compose project
```

However when the `default` network is explicitly defined in the main `docker-compose.yml` file, both v1 and v2 run correctly without error.

With this change applied, I'm now able to successfully run `bin/replicate-mysql.sh` and `bin/replicate-postgres.sh` regardless of the Docker Compose version I'm using.