### PR TITLE
Pull Postgres dumps from new DB Admin instances

### DIFF
--- a/bin/replicate-postgresql.sh
+++ b/bin/replicate-postgresql.sh
@@ -81,4 +81,4 @@ database="$(govuk-docker config | ruby -ryaml -e "puts YAML::load(STDIN.read).di
 
 govuk-docker run "$postgres_container" /usr/bin/psql -h "$postgres_container" -U postgres -c "DROP DATABASE IF EXISTS \"${database}\""
 govuk-docker run "$postgres_container" /usr/bin/createdb -h "$postgres_container" -U postgres "$database"
-pv "$archive_path" | govuk-docker run "$postgres_container" /usr/bin/pg_restore -h "$postgres_container" -U postgres -d "$database" --no-owner
+pv "$archive_path" | govuk-docker run "$postgres_container" /usr/bin/pg_restore -h "$postgres_container" -U postgres -d "$database" --no-owner --no-privileges


### PR DESCRIPTION
This changes the Postgres replication script to expect database dump files to be present in a new location now that we've implemented [RFC-143] and have one RDS instance per application.

Each Postgres server (RDS instance) is named with the app it serves.
> e.g. the app `content-tagger` uses RDS instance `content-tagger-postgres`

Database dumps are now located inside a directory named after the RDS instance.
> e.g. `content-tagger` database dumps will now be located in the directory `s3://govuk-integration-database-backups/content-tagger-postgres/`

The script will pick the most recent timestamped database dump from that instance's directory.

## Other changes

### Fix for Support API

The Support API uses a non-conventional database name (`support_contacts_production` rather than `support_api_production`). The script previously tried to handle that as a special case (although it didn't actually work as expected). Now the script only relies on knowing the RDS instance name rather than the database name, so it no longer needs this exception to be hardcoded.

### Fix for Transition/Bouncer

The Transition/Bouncer database previously wasn't possible to import because its dumps existed outside the hardcoded `postgres-backend` directory in the S3 bucket. With the change to hostname-based directories, this should implicitly resolve the limitation of not being able to replicate this database.

### Local database names

In the docker environment, most databases are conventionally named after their application.

> e.g. the database used by Content Tagger is called `content-tagger`:
>
> https://github.com/alphagov/govuk-docker/blob/e3958a7c273316a0d28fcd9dd985cfa5063c0569/projects/content-tagger/docker-compose.yml#L28

This isn't always the case, though. In particular, the [Transition](https://github.com/alphagov/govuk-docker/blob/e3958a7c273316a0d28fcd9dd985cfa5063c0569/projects/transition/docker-compose.yml#L28) and [Bouncer](https://github.com/alphagov/govuk-docker/blob/e3958a7c273316a0d28fcd9dd985cfa5063c0569/projects/bouncer/docker-compose.yml#L31) apps share a database called `transition`.

Previously the script assumed the database was named after the app. But this causes issues in the case of Transition/Bouncer. I've therefore tweaked the script to read the application's database name directly from the `DATABASE_URL` environment variable in the Docker Compose config.

### Clean up Postgres 9.6 conditional

I've removed a conditional that did some special magic when restoring Postgres 9.3 dumps into a Postgres 13 instance. This shouldn't be needed any more since all environments are now running on Postgres 13.

Trello ticket: https://trello.com/c/RKe0EO4x/80-configure-govuk-docker-to-replicate-data-using-new-db-admin-machines

[RFC-143]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-143-split-database-instances.md