### PR TITLE
Pull MySQL dumps from new DB Admin instances

### DIFF
--- a/bin/replicate-mysql.sh
+++ b/bin/replicate-mysql.sh
@@ -51,7 +51,8 @@ until govuk-docker run "$mysql_container" mysql -h "$mysql_container" -u root --
   sleep 1
 done
 
-database="${app//-/_}_development"
+# Extract the local database name from the app's DATABASE_URL environment variable
+database="$(govuk-docker config | ruby -ryaml -e "puts YAML::load(STDIN.read).dig('services', '${app}-app', 'environment', 'DATABASE_URL').split('/').last")"
 
 govuk-docker run "$mysql_container" mysql -h "$mysql_container" -u root --password=root -e "DROP DATABASE IF EXISTS \`${database}\`"
 govuk-docker run "$mysql_container" mysql -h "$mysql_container" -u root --password=root -e "CREATE DATABASE \`${database}\`"

--- a/bin/replicate-mysql.sh
+++ b/bin/replicate-mysql.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+function try_find_file {
+  app="$1"
+  db_hostname="${app}-mysql"
+
+  set +e
+  # Find the most recent database dump from that host
+  out="$(aws s3 ls "s3://${bucket}/${db_hostname}/" | grep "\.gz$" | sed 's/.* //' | sort | tail -n1)"
+  set -e
+
+  if [[ -n "$out" ]]; then
+    echo "${db_hostname}/${out}"
+  fi
+}
+
 set -eu
 
 if [[ "$#" == "0" ]]; then
@@ -15,7 +29,6 @@ bucket="govuk-integration-database-backups"
 archive_dir="${replication_dir}/mysql"
 archive_file="${app//-/_}_production.dump.gz"
 archive_path="${archive_dir}/${archive_file}"
-date=$(date '+%Y-%m-%d')
 
 echo "Replicating mysql for $app"
 
@@ -24,14 +37,12 @@ if [[ -e "$archive_path" ]]; then
 else
   mkdir -p "$archive_dir"
 
-  # Get a list of all of the MySQL database dump files, exclude them all,
-  # include only the files that have the date and the app name in it.
-  # https://docs.aws.amazon.com/cli/latest/reference/s3/#use-of-exclude-and-include-filters
-  aws s3 cp "s3://${bucket}/mysql-backend/" "$archive_dir" --recursive --exclude "*" --include "$date*-${app//-/_}_production.gz"
-
-  # List the archive directory, find a file with the date and the app name in
-  # it, and rename that to a file that doesn't have a timestamp in its name.
-  mv "$(find "$archive_dir" -name "$date*${app//-/_}*.gz")" "$archive_path"
+  s3_file=$(try_find_file "$app")
+  if [[ -z "$s3_file" ]]; then
+    echo "couldn't figure out backup filename in S3 - if you're sure the app uses MySQL, file an issue in alphagov/govuk-docker."
+    exit 1
+  fi
+  aws s3 cp "s3://${bucket}/${s3_file}" "${archive_path}"
 fi
 
 if [[ -n "${SKIP_IMPORT:-}" ]]; then


### PR DESCRIPTION
This changes the MySQL replication script to expect database dump files to be present in a new location now that we've implemented [RFC-143] and have one RDS instance per application. It's effectively a carbon copy of the changes made to the Postgres replication script in #555.

Each MySQL server (RDS instance) is named with the app it serves.
    > e.g. the app `whitehall` uses RDS instance `whitehall-mysql`

Database dumps are now located inside a directory named after the RDS instance.
    > e.g. `whitehall` database dumps will now be located in the directory `s3://govuk-integration-database-backups/whitehall-mysql/`

The script will pick the most recent timestamped database dump from that instance's directory.

## Other changes

### Local database names

In the docker environment, most databases are conventionally named after their application.

> e.g. the database used by Content Tagger is called `content-tagger`:
>
> https://github.com/alphagov/govuk-docker/blob/e3958a7c273316a0d28fcd9dd985cfa5063c0569/projects/content-tagger/docker-compose.yml#L28

This isn't always the case, though. In particular, the [Transition](https://github.com/alphagov/govuk-docker/blob/e3958a7c273316a0d28fcd9dd985cfa5063c0569/projects/transition/docker-compose.yml#L28) and [Bouncer](https://github.com/alphagov/govuk-docker/blob/e3958a7c273316a0d28fcd9dd985cfa5063c0569/projects/bouncer/docker-compose.yml#L31) apps share a database called `transition`.

Previously the script assumed the database was named after the app. But this causes issues in the case of Transition/Bouncer. I've therefore tweaked the script to read the application's database name directly from the `DATABASE_URL` environment variable in the Docker Compose config.

Trello ticket: https://trello.com/c/33ZRtkXl/95-configure-govuk-docker-to-replicate-mysql-data-using-new-db-admin-machines

[RFC-143]: https://github.com/alphagov/govuk-rfcs/blob/main/rfc-143-split-database-instances.md