### PR TITLE
Set TEST_DATABASE_URL for collections-publisher

### DIFF
--- a/projects/collections-publisher/docker-compose.yml
+++ b/projects/collections-publisher/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       - mysql-8
       - redis
     environment:
-      # the app uses this URL to generate a test database URL
       DATABASE_URL: "mysql2://root:root@mysql-8/collections_publisher_development"
+      TEST_DATABASE_URL: "mysql2://root:root@mysql-8/collections_publisher_test"
       REDIS_URL: redis://redis
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
 


### PR DESCRIPTION
The app does not use the DATABASE_URL env var to generate the test
one: https://github.com/alphagov/collections-publisher/blob/main/config/database.yml