### PR TITLE
Remove outdated comment about search-admin test database

### DIFF
--- a/projects/search-admin/docker-compose.yml
+++ b/projects/search-admin/docker-compose.yml
@@ -24,7 +24,6 @@ services:
     depends_on:
       - mysql-8
     environment:
-      # the app uses this URL to generate a test database URL
       DATABASE_URL: "mysql2://root:root@mysql-8/search_admin_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-8/search_admin_test"
       REDIS_URL: redis://redis


### PR DESCRIPTION
This comment should have been removed when the TEST_DATABASE_URL was
added.