### PR TITLE
Switch datagovuk_publish to use Postgres 12

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ volumes:
   root-home:
   rabbitmq:
   postgres-9.6:
+  postgres-12:
   postgres-13:
   mysql-5.5:
   mysql-8:
@@ -23,6 +24,13 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - postgres-9.6:/var/lib/postgresql/data
+
+  postgres-12:
+    image: postgres:12
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - postgres-12:/var/lib/postgresql/data
 
   postgres-13:
     image: postgres:13

--- a/projects/datagovuk_publish/docker-compose.yml
+++ b/projects/datagovuk_publish/docker-compose.yml
@@ -20,10 +20,10 @@ services:
   datagovuk_publish-lite:
     <<: *datagovuk_publish
     depends_on:
-      - postgres-9.6
+      - postgres-12
       - elasticsearch-7
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-9.6/datagovuk_publish"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-9.6/datagovuk_publish-test"
+      DATABASE_URL: "postgresql://postgres@postgres-12/datagovuk_publish"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-12/datagovuk_publish-test"
       ES_HOST: "http://elasticsearch-7:9200"
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"


### PR DESCRIPTION
Trello: https://trello.com/c/8c0pQLvD/58-delete-legacy-postgres-and-mysql-containers-from-govuk-docker

This application was configured to use Postgres 9.6 however the
application actually uses Postgres 12 [1].

Fixing this is a blocker before removing postgres-9.6 from this repo

[1]: https://github.com/alphagov/datagovuk_publish/commit/fff3a21f7f8c5025a012889b76e8fd806fbb7c0f