### PR TITLE
Put dnsmasq config files in /opt/homebrew/etc

### DIFF
--- a/bin/doctor
+++ b/bin/doctor
@@ -14,7 +14,7 @@ puts GovukDocker::Doctor::Checkup.new(
 puts "\r\nChecking dnsmasq"
 puts GovukDocker::Doctor::Checkup.new(
   service_name: "dnsmasq",
-  checkups: %i[installed running dnsmasq_resolver running_as_different_user],
+  checkups: %i[installed running dnsmasq_config dnsmasq_resolver dnsmasq_resolving running_as_different_user],
   messages: GovukDocker::Doctor.messages[:dnsmasq],
 ).call
 puts "\r\nChecking docker"

--- a/bin/setup
+++ b/bin/setup
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+brew_root=$(brew --prefix)
+
 echo -e "✅ Installing dependencies via Homebrew...\n"
 brew bundle --file="$(dirname $0)/../Brewfile"
 echo
@@ -12,12 +14,12 @@ echo -e "You may need to enter your root password...\n"
 sudo mkdir -p /etc/resolver
 echo -e "nameserver 127.0.0.1\nport 53" | sudo tee /etc/resolver/dev.gov.uk >/dev/null
 
-echo -e "✅ Configuring dnsmasq [/usr/local/etc/dnsmasq.conf]\n"
-echo "conf-dir=/usr/local/etc/dnsmasq.d,*.conf" > /usr/local/etc/dnsmasq.conf
+echo -e "✅ Configuring dnsmasq [$brew_root/etc/dnsmasq.conf]\n"
+echo "conf-dir=$brew_root/etc/dnsmasq.d,*.conf" >> $brew_root/etc/dnsmasq.conf
 
-echo -e "✅ Configuring dnsmasq [/usr/local/etc/dnsmasq.d/development.conf]\n"
-mkdir -p /usr/local/etc/dnsmasq.d
-echo "address=/dev.gov.uk/127.0.0.1" > /usr/local/etc/dnsmasq.d/development.conf
+echo -e "✅ Configuring dnsmasq [$brew_root/etc/dnsmasq.d/development.conf]\n"
+mkdir -p $brew_root/etc/dnsmasq.d
+echo "address=/dev.gov.uk/127.0.0.1" > $brew_root/etc/dnsmasq.d/development.conf
 
 echo "✅ Restarting dnsmasq"
 echo -e "You may need to enter your root password...\n"

--- a/lib/govuk_docker/doctor/checkup.rb
+++ b/lib/govuk_docker/doctor/checkup.rb
@@ -18,7 +18,9 @@ module GovukDocker::Doctor
       installed? if checkups.include?(:installed)
       running? if checkups.include?(:running)
       running_as_different_user? if checkups.include?(:running_as_different_user)
+      dnsmasq_config? if checkups.include?(:dnsmasq_config)
       dnsmasq_resolver? if checkups.include?(:dnsmasq_resolver)
+      dnsmasq_resolving? if checkups.include?(:dnsmasq_resolving)
     end
 
     def up_to_date?
@@ -45,7 +47,9 @@ module GovukDocker::Doctor
       install_state_message if checkups.include?(:installed)
       run_state_message if checkups.include?(:running)
       running_user_message if checkups.include?(:running_as_different_user)
+      dnsmasq_config_message if checkups.include?(:dnsmasq_config)
       dnsmasq_resolver_message if checkups.include?(:dnsmasq_resolver)
+      dnsmasq_resolving_message if checkups.include?(:dnsmasq_resolving)
     end
 
     def up_to_date_state_message
@@ -84,6 +88,20 @@ module GovukDocker::Doctor
                         end
     end
 
+    def dnsmasq_config?
+      brew_prefix = `brew --prefix`.strip
+      File.exist?("#{brew_prefix}/etc/dnsmasq.conf") &&
+        File.exist?("#{brew_prefix}/etc/dnsmasq.d/development.conf")
+    end
+
+    def dnsmasq_config_message
+      return_message << if dnsmasq_config?
+                          messages[:dnsmasq_config]
+                        else
+                          messages[:not_dnsmasq_config]
+                        end
+    end
+
     def dnsmasq_resolver?
       File.read("/etc/resolver/dev.gov.uk").strip == "nameserver 127.0.0.1\nport 53"
     end
@@ -93,6 +111,18 @@ module GovukDocker::Doctor
                           messages[:dnsmasq_resolver]
                         else
                           messages[:not_dnsmasq_resolver]
+                        end
+    end
+
+    def dnsmasq_resolving?
+      `dig +short app.dev.gov.uk @127.0.0.1`.strip == "127.0.0.1"
+    end
+
+    def dnsmasq_resolving_message
+      return_message << if dnsmasq_resolving?
+                          messages[:dnsmasq_resolving]
+                        else
+                          messages[:not_dnsmasq_resolving]
                         end
     end
   end

--- a/lib/govuk_docker/doctor/doctor.rb
+++ b/lib/govuk_docker/doctor/doctor.rb
@@ -65,10 +65,20 @@ module GovukDocker::Doctor
         Dnsmasq needs to run as root.
         You should start it with `sudo brew services start dnsmasq`.
       HEREDOC
-      dnsmasq_resolver: "✅ Dnsmasq is resolving DNS requests",
+      dnsmasq_config: "✅ Dnsmasq config files are set up correctly",
+      not_dnsmasq_config: <<~HEREDOC,
+        ❌ One or more dnsmasq config files is missing.
+        Try running `bin/setup` again.
+      HEREDOC
+      dnsmasq_resolver: "✅ Dnsmasq resolver file is set up correctly",
       not_dnsmasq_resolver: <<~HEREDOC,
         ❌ Your DNS resolver file (/etc/resolver/dev.gov.uk) has unexpected content.
         Try running `bin/setup` again.
+      HEREDOC
+      dnsmasq_resolving: "✅ Dnsmasq is resolving app.dev.gov.uk correctly",
+      not_dnsmasq_resolving: <<~HEREDOC,
+        ❌ Dnsmasq is not resolving app.dev.gov.uk correctly.
+        Try running `bin/setup` again, and check system logs for dnsmasq.
       HEREDOC
     }
   end


### PR DESCRIPTION
### Why
On M1 machines, even when you can get an app running in govuk-docker, you can't currently access it via the .dev.gov.uk hostname in your browser. 

### What's the problem
We're using dnsmasq to resolve those hostnames into 127.0.0.1, which the nginx-docker proxy then picks up and routes to the backing app. The existing bin/setup script puts the configuration files for dnsmasq in /usr/local/etc. But on M1 machines /usr/local/etc doesn't exist, and homebrew dnsmasq looks in /opt/homebrew/etc, where the dnsmasq config files and directories already exist. This change updates those paths in bin/setup.

### Any other notes
This problem wasn't caught by Doctor, which only checks:
- is dnsmasq running
- does the first config file (/etc/resolver/dev.gov.uk) exist?
..in this case, both of those were true, but without the other two config files nothing would work. We could perhaps update doctor to make an actual dns request (via dig maybe?) to check that the configuration is working as expected.