### PR TITLE
Remove Postgres 9.6 and MySQL 5.5 Databases

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,8 @@ version: '3.7'
 volumes:
   root-home:
   rabbitmq:
-  postgres-9.6:
   postgres-12:
   postgres-13:
-  mysql-5.5:
   mysql-8:
   mongo-3.6:
   mongo-2.6:
@@ -18,13 +16,6 @@ networks:
   default:
 
 services:
-  postgres-9.6:
-    image: postgres:9.6
-    environment:
-      POSTGRES_HOST_AUTH_METHOD: trust
-    volumes:
-      - postgres-9.6:/var/lib/postgresql/data
-
   postgres-12:
     image: postgres:12
     environment:
@@ -55,14 +46,6 @@ services:
     volumes:
       - mongo-2.6:/data/db
     command: ["--replSet", "mongo-replica-set"]
-
-  mysql-5.5:
-    image: mysql:5.5.58
-    volumes:
-      - mysql-5.5:/var/lib/mysql
-    command: --max_allowed_packet=1073741824
-    environment:
-      MYSQL_ROOT_PASSWORD: root
 
   mysql-8:
     image: mysql:8


### PR DESCRIPTION
Trello: https://trello.com/c/8c0pQLvD/58-delete-legacy-postgres-and-mysql-containers-from-govuk-docker

This removes the configuration for Postgres 9.6 and MySQL 5.5 as no
applications use these anymore.

Developers can perform some clean-up tasks to recover the space used by
these, if they wish. This is probably only of particular value if you
have cloned large databases.

The most space saving measure would be removing the volumes:

```
$ docker volume rm govuk-docker_postgres-9.6 govuk-docker_mysql-5.5
```

The containers and images can be removed to with:

Stop and remove the containers (these may error if all the containers
are already stopped):

```
$ docker container rm $(docker container ls -aq --filter "ancestor=mysql:5.5")
$ docker container rm $(docker container ls -aq --filter "ancestor=postgres:9.6")
```

Remove the images:

```
$ docker image rm postgres:9.6 mysql:5.5
```