### PR TITLE
Force docker builds to use linux/amd64 platform

### DIFF
--- a/projects/account-api/docker-compose.yml
+++ b/projects/account-api/docker-compose.yml
@@ -8,6 +8,7 @@ x-account-api: &account-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: account-api
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/asset-manager/docker-compose.yml
+++ b/projects/asset-manager/docker-compose.yml
@@ -8,6 +8,7 @@ x-asset-manager: &asset-manager
     context: .
     dockerfile: projects/asset-manager/Dockerfile
   image: asset-manager
+  platform: linux/amd64
   tty: true
   stdin_open: true
   volumes:

--- a/projects/authenticating-proxy/docker-compose.yml
+++ b/projects/authenticating-proxy/docker-compose.yml
@@ -8,6 +8,7 @@ x-authenticating-proxy: &authenticating-proxy
     context: .
     dockerfile: Dockerfile.govuk-base
   image: authenticating-proxy
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/bouncer/docker-compose.yml
+++ b/projects/bouncer/docker-compose.yml
@@ -5,6 +5,7 @@ x-bouncer: &bouncer
     context: .
     dockerfile: Dockerfile.govuk-base
   image: bouncer
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/cache-clearing-service/docker-compose.yml
+++ b/projects/cache-clearing-service/docker-compose.yml
@@ -5,6 +5,7 @@ x-cache-clearing-service: &cache-clearing-service
     context: .
     dockerfile: Dockerfile.govuk-base
   image: cache-clearing-service
+  platform: linux/amd64
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root

--- a/projects/collections-publisher/docker-compose.yml
+++ b/projects/collections-publisher/docker-compose.yml
@@ -9,6 +9,7 @@ x-collections-publisher: &collections-publisher
     context: .
     dockerfile: Dockerfile.govuk-base
   image: collections-publisher
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/collections/docker-compose.yml
+++ b/projects/collections/docker-compose.yml
@@ -9,6 +9,7 @@ x-collections: &collections
     context: .
     dockerfile: Dockerfile.govuk-base
   image: collections
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/contacts-admin/docker-compose.yml
+++ b/projects/contacts-admin/docker-compose.yml
@@ -9,6 +9,7 @@ x-contacts-admin: &contacts-admin
     context: .
     dockerfile: Dockerfile.govuk-base
   image: contacts-admin
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/content-data-admin/docker-compose.yml
+++ b/projects/content-data-admin/docker-compose.yml
@@ -9,6 +9,7 @@ x-content-data-admin: &content-data-admin
     context: .
     dockerfile: Dockerfile.govuk-base
   image: content-data-admin
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/content-data-api/docker-compose.yml
+++ b/projects/content-data-api/docker-compose.yml
@@ -8,6 +8,7 @@ x-content-data-api: &content-data-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: content-data-api
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/content-publisher/docker-compose.yml
+++ b/projects/content-publisher/docker-compose.yml
@@ -9,6 +9,7 @@ x-content-publisher: &content-publisher
     context: .
     dockerfile: Dockerfile.govuk-base
   image: content-publisher
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/content-store/docker-compose.yml
+++ b/projects/content-store/docker-compose.yml
@@ -8,6 +8,7 @@ x-content-store: &content-store
     context: .
     dockerfile: Dockerfile.govuk-base
   image: content-store
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/content-tagger/docker-compose.yml
+++ b/projects/content-tagger/docker-compose.yml
@@ -9,6 +9,7 @@ x-content-tagger: &content-tagger
     context: .
     dockerfile: Dockerfile.govuk-base
   image: content-tagger
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/datagovuk_find/docker-compose.yml
+++ b/projects/datagovuk_find/docker-compose.yml
@@ -9,6 +9,7 @@ x-datagovuk_find: &datagovuk_find
     context: .
     dockerfile: Dockerfile.govuk-base
   image: datagovuk_find
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/datagovuk_publish/docker-compose.yml
+++ b/projects/datagovuk_publish/docker-compose.yml
@@ -8,6 +8,7 @@ x-datagovuk_publish: &datagovuk_publish
     context: .
     dockerfile: Dockerfile.govuk-base
   image: datagovuk_publish
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/email-alert-api/docker-compose.yml
+++ b/projects/email-alert-api/docker-compose.yml
@@ -8,6 +8,7 @@ x-email-alert-api: &email-alert-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: email-alert-api
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/email-alert-frontend/docker-compose.yml
+++ b/projects/email-alert-frontend/docker-compose.yml
@@ -9,6 +9,7 @@ x-email-alert-frontend: &email-alert-frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: email-alert-frontend
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/email-alert-service/docker-compose.yml
+++ b/projects/email-alert-service/docker-compose.yml
@@ -5,6 +5,7 @@ x-email-alert-service: &email-alert-service
     context: .
     dockerfile: Dockerfile.govuk-base
   image: email-alert-service
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/feedback/docker-compose.yml
+++ b/projects/feedback/docker-compose.yml
@@ -9,6 +9,7 @@ x-feedback: &feedback
     context: .
     dockerfile: Dockerfile.govuk-base
   image: feedback
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -9,6 +9,7 @@ x-finder-frontend: &finder-frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: finder-frontend
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -9,6 +9,7 @@ x-frontend: &frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: frontend
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/generic-ruby-library/docker-compose.yml
+++ b/projects/generic-ruby-library/docker-compose.yml
@@ -5,6 +5,7 @@ x-generic-ruby-library: &generic-ruby-library
     context: .
     dockerfile: Dockerfile.govuk-base
   image: generic-ruby-library
+  platform: linux/amd64
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root

--- a/projects/government-frontend/docker-compose.yml
+++ b/projects/government-frontend/docker-compose.yml
@@ -9,6 +9,7 @@ x-government-frontend: &government-frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: government-frontend
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/govuk-content-schemas/docker-compose.yml
+++ b/projects/govuk-content-schemas/docker-compose.yml
@@ -8,6 +8,7 @@ x-govuk-content-schemas: &govuk-content-schemas
     context: .
     dockerfile: Dockerfile.govuk-base
   image: govuk-content-schemas
+  platform: linux/amd64
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root

--- a/projects/govuk-developer-docs/docker-compose.yml
+++ b/projects/govuk-developer-docs/docker-compose.yml
@@ -5,6 +5,7 @@ x-govuk-developer-docs: &govuk-developer-docs
     context: .
     dockerfile: Dockerfile.govuk-base
   image: govuk-developer-docs
+  platform: linux/amd64
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root

--- a/projects/govuk_crawler_worker/docker-compose.yml
+++ b/projects/govuk_crawler_worker/docker-compose.yml
@@ -5,6 +5,7 @@ x-govuk_crawler_worker: &govuk_crawler_worker
     context: .
     dockerfile: projects/govuk_crawler_worker/Dockerfile
   image: govuk_crawler_worker
+  platform: linux/amd64
   volumes:
     - go:/go
     - ${GOVUK_ROOT_DIR:-~/govuk}/govuk_crawler_worker:/go/src/github.com/alphagov/govuk_crawler_worker:delegated

--- a/projects/govuk_publishing_components/docker-compose.yml
+++ b/projects/govuk_publishing_components/docker-compose.yml
@@ -9,6 +9,7 @@ x-govuk_publishing_components: &govuk_publishing_components
     context: .
     dockerfile: Dockerfile.govuk-base
   image: govuk_publishing_components
+  platform: linux/amd64
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root

--- a/projects/hmrc-manuals-api/docker-compose.yml
+++ b/projects/hmrc-manuals-api/docker-compose.yml
@@ -8,6 +8,7 @@ x-hmrc-manuals-api: &hmrc-manuals-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: hmrc-manuals-api
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/imminence/docker-compose.yml
+++ b/projects/imminence/docker-compose.yml
@@ -8,6 +8,7 @@ x-imminence: &imminence
     context: .
     dockerfile: Dockerfile.govuk-base
   image: imminence
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/info-frontend/docker-compose.yml
+++ b/projects/info-frontend/docker-compose.yml
@@ -8,6 +8,7 @@ x-tmp: &info-frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: info-frontend
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/licence-finder/docker-compose.yml
+++ b/projects/licence-finder/docker-compose.yml
@@ -8,6 +8,7 @@ x-licence-finder: &licence-finder
     context: .
     dockerfile: Dockerfile.govuk-base
   image: licence-finder
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/link-checker-api/docker-compose.yml
+++ b/projects/link-checker-api/docker-compose.yml
@@ -8,6 +8,7 @@ x-link-checker-api: &link-checker-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: link-checker-api
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/local-links-manager/docker-compose.yml
+++ b/projects/local-links-manager/docker-compose.yml
@@ -9,6 +9,7 @@ x-local-links-manager: &local-links-manager
     context: .
     dockerfile: Dockerfile.govuk-base
   image: local-links-manager
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/locations-api/docker-compose.yml
+++ b/projects/locations-api/docker-compose.yml
@@ -8,6 +8,7 @@ x-locations-api: &locations-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: locations-api
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/manuals-frontend/docker-compose.yml
+++ b/projects/manuals-frontend/docker-compose.yml
@@ -9,6 +9,7 @@ x-manuals-frontend: &manuals-frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: manuals-frontend
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/manuals-publisher/docker-compose.yml
+++ b/projects/manuals-publisher/docker-compose.yml
@@ -9,6 +9,7 @@ x-manuals-publisher: &manuals-publisher
     context: .
     dockerfile: Dockerfile.govuk-base
   image: manuals-publisher
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/mapit/docker-compose.yml
+++ b/projects/mapit/docker-compose.yml
@@ -8,6 +8,7 @@ x-mapit: &mapit
     context: .
     dockerfile: projects/mapit/Dockerfile
   image: mapit
+  platform: linux/amd64
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
   working_dir: /govuk/mapit

--- a/projects/maslow/docker-compose.yml
+++ b/projects/maslow/docker-compose.yml
@@ -9,6 +9,7 @@ x-maslow: &maslow
     context: .
     dockerfile: Dockerfile.govuk-base
   image: maslow
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/publisher/docker-compose.yml
+++ b/projects/publisher/docker-compose.yml
@@ -9,6 +9,7 @@ x-publisher: &publisher
     context: .
     dockerfile: Dockerfile.govuk-base
   image: publisher
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/publishing-api/docker-compose.yml
+++ b/projects/publishing-api/docker-compose.yml
@@ -8,6 +8,7 @@ x-publishing-api: &publishing-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: publishing-api
+  platform: linux/amd64
   tty: true
   stdin_open: true
   volumes:

--- a/projects/release/docker-compose.yml
+++ b/projects/release/docker-compose.yml
@@ -9,6 +9,7 @@ x-release: &release
     context: .
     dockerfile: Dockerfile.govuk-base
   image: release
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/router-api/docker-compose.yml
+++ b/projects/router-api/docker-compose.yml
@@ -8,6 +8,7 @@ x-router-api: &router-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: router-api
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/router/docker-compose.yml
+++ b/projects/router/docker-compose.yml
@@ -5,6 +5,7 @@ x-router: &router
     context: .
     dockerfile: projects/router/Dockerfile
   image: router
+  platform: linux/amd64
   volumes:
     - go:/go
     - ${GOVUK_ROOT_DIR:-~/govuk}/router:/go/src/github.com/alphagov/router:delegated

--- a/projects/search-admin/docker-compose.yml
+++ b/projects/search-admin/docker-compose.yml
@@ -9,6 +9,7 @@ x-search-admin: &search-admin-base
     context: .
     dockerfile: Dockerfile.govuk-base
   image: search-admin
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -5,6 +5,7 @@ x-search-api: &search-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: search-api
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/service-manual-frontend/docker-compose.yml
+++ b/projects/service-manual-frontend/docker-compose.yml
@@ -9,6 +9,7 @@ x-service-manual-frontend: &service-manual-frontend
     context: .
     dockerfile: Dockerfile.govuk-base
   image: service-manual-frontend
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/service-manual-publisher/docker-compose.yml
+++ b/projects/service-manual-publisher/docker-compose.yml
@@ -9,6 +9,7 @@ x-service-manual-publisher: &service-manual-publisher
     context: .
     dockerfile: Dockerfile.govuk-base
   image: service-manual-publisher
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/short-url-manager/docker-compose.yml
+++ b/projects/short-url-manager/docker-compose.yml
@@ -9,6 +9,7 @@ x-short-url-manager: &short-url-manager
     context: .
     dockerfile: Dockerfile.govuk-base
   image: short-url-manager
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/signon/docker-compose.yml
+++ b/projects/signon/docker-compose.yml
@@ -9,6 +9,7 @@ x-signon: &signon
     context: .
     dockerfile: Dockerfile.govuk-base
   image: signon
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/smart-answers/docker-compose.yml
+++ b/projects/smart-answers/docker-compose.yml
@@ -9,6 +9,7 @@ x-smart-answers: &smart-answers
     context: .
     dockerfile: Dockerfile.govuk-base
   image: smart-answers
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/special-route-publisher/docker-compose.yml
+++ b/projects/special-route-publisher/docker-compose.yml
@@ -5,6 +5,7 @@ x-special-route-publisher: &special-route-publisher
     context: .
     dockerfile: Dockerfile.govuk-base
   image: special-route-publisher
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/specialist-publisher/docker-compose.yml
+++ b/projects/specialist-publisher/docker-compose.yml
@@ -9,6 +9,7 @@ x-specialist-publisher: &specialist-publisher
     context: .
     dockerfile: Dockerfile.govuk-base
   image: specialist-publisher
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/static/docker-compose.yml
+++ b/projects/static/docker-compose.yml
@@ -9,6 +9,7 @@ x-static: &static
     context: .
     dockerfile: Dockerfile.govuk-base
   image: static
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/support-api/docker-compose.yml
+++ b/projects/support-api/docker-compose.yml
@@ -8,6 +8,7 @@ x-support-api: &support-api
     context: .
     dockerfile: Dockerfile.govuk-base
   image: support-api
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/support/docker-compose.yml
+++ b/projects/support/docker-compose.yml
@@ -9,6 +9,7 @@ x-support: &support
     context: .
     dockerfile: Dockerfile.govuk-base
   image: support
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/transition/docker-compose.yml
+++ b/projects/transition/docker-compose.yml
@@ -8,6 +8,7 @@ x-transition: &transition
     context: .
     dockerfile: Dockerfile.govuk-base
   image: transition
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/travel-advice-publisher/docker-compose.yml
+++ b/projects/travel-advice-publisher/docker-compose.yml
@@ -9,6 +9,7 @@ x-travel-advice-publisher: &travel-advice-publisher
     context: .
     dockerfile: Dockerfile.govuk-base
   image: travel-advice-publisher
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -9,6 +9,7 @@ x-whitehall: &whitehall
     context: .
     dockerfile: projects/whitehall/Dockerfile
   image: whitehall
+  platform: linux/amd64
   stdin_open: true
   tty: true
   volumes:


### PR DESCRIPTION
This change forces the builds to create images for linux/amd64 platform.

M1 Macs use a arm archtecture and this is generally not *currently* compatible with the packages we need to install, ie. Chrome.

This change allows builds to successfully complete.