### PR TITLE
Remove warnings about db versions in production

### DIFF
--- a/projects/bouncer/docker-compose.yml
+++ b/projects/bouncer/docker-compose.yml
@@ -16,7 +16,6 @@ services:
   bouncer-lite:
     <<: *bouncer
     depends_on:
-      # The version of PostgreSQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/9PayaOSK)
       - postgres-13
     environment:
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/transition_test"

--- a/projects/collections-publisher/docker-compose.yml
+++ b/projects/collections-publisher/docker-compose.yml
@@ -22,7 +22,6 @@ services:
   collections-publisher-lite:
     <<: *collections-publisher
     depends_on:
-      # The version of MySQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/btcm7JyB/)
       - mysql-8
       - redis
     environment:

--- a/projects/content-publisher/docker-compose.yml
+++ b/projects/content-publisher/docker-compose.yml
@@ -25,7 +25,6 @@ services:
   content-publisher-lite:
     <<: *content-publisher
     depends_on:
-      # The version of PostgreSQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/9PayaOSK)
       - postgres-13
       - redis
     environment:

--- a/projects/link-checker-api/docker-compose.yml
+++ b/projects/link-checker-api/docker-compose.yml
@@ -20,7 +20,6 @@ services:
   link-checker-api-lite:
     <<: *link-checker-api
     depends_on:
-      # The version of PostgreSQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/9PayaOSK)
       - postgres-13
       - redis
     environment:

--- a/projects/publishing-api/docker-compose.yml
+++ b/projects/publishing-api/docker-compose.yml
@@ -20,7 +20,6 @@ services:
   publishing-api-lite:
     <<: *publishing-api
     depends_on:
-      # The version of PostgreSQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/9PayaOSK)
       - postgres-13
       - redis
       - rabbitmq

--- a/projects/service-manual-publisher/docker-compose.yml
+++ b/projects/service-manual-publisher/docker-compose.yml
@@ -22,7 +22,6 @@ services:
   service-manual-publisher-lite:
     <<: *service-manual-publisher
     depends_on:
-      # The version of PostgreSQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/9PayaOSK)
       - postgres-13
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/service-manual-publisher"

--- a/projects/transition/docker-compose.yml
+++ b/projects/transition/docker-compose.yml
@@ -20,7 +20,6 @@ services:
   transition-lite:
     <<: *transition
     depends_on:
-      # The version of PostgreSQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/9PayaOSK)
       - postgres-13
       - redis
     environment:

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -25,7 +25,6 @@ services:
   whitehall-lite:
     <<: *whitehall
     depends_on:
-      # The version of MySQL temporarily does not match production, as an upgrade in production is being worked on (tracked in https://trello.com/c/btcm7JyB/)
       - mysql-8
       - redis
     environment:


### PR DESCRIPTION
We added warnings about the database version in docker not matching 
those in production whilst we completed an upgrade. The upgrade has now 
been done so these warnings can be removed.