### PR TITLE
[WIP] Change how chrome is installed

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -6,10 +6,7 @@
 FROM buildpack-deps
 
 # Install chrome and its dependencies
-RUN apt-get update -qq
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>&1 && \
-   apt-get install -y ./google-chrome*.deb && \
-    rm ./google-chrome*.deb
+RUN apt-get update -qq && apt-get install -y chromium
 
 # Enable no-sandbox for chrome so that it can run as a root user
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1

--- a/projects/asset-manager/Dockerfile
+++ b/projects/asset-manager/Dockerfile
@@ -2,10 +2,7 @@
 FROM buildpack-deps
 
 # Install chrome and its dependencies
-RUN apt-get update -qq
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>&1 && \
-   apt-get install -y ./google-chrome*.deb && \
-    rm ./google-chrome*.deb
+RUN apt-get update -qq && apt-get install -y chromium
 
 # Enable no-sandbox for chrome so that it can run as a root user
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1

--- a/projects/whitehall/Dockerfile
+++ b/projects/whitehall/Dockerfile
@@ -2,10 +2,7 @@
 FROM buildpack-deps
 
 # Install chrome and its dependencies
-RUN apt-get update -qq
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>&1 && \
-   apt-get install -y ./google-chrome*.deb && \
-    rm ./google-chrome*.deb
+RUN apt-get update -qq && apt-get install -y chromium
 
 # Enable no-sandbox for chrome so that it can run as a root user
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1


### PR DESCRIPTION
Currently chrome is installed by downloading a specific amd64 version. This breaks on M1 macs as they do not have the same amd architecture.

To resolve this chromium is installed but with the additional support for both amd and arm architectures.