### PR TITLE
Install Chromium browser and its webdriver

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -5,11 +5,8 @@
 # Install packages for building ruby
 FROM buildpack-deps
 
-# Install chrome and its dependencies
-RUN apt-get update -qq
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>&1 && \
-   apt-get install -y ./google-chrome*.deb && \
-    rm ./google-chrome*.deb
+# Install chromium browser and its webdriver
+RUN apt-get update -qq && apt-get install -y chromium chromium-driver
 
 # Enable no-sandbox for chrome so that it can run as a root user
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1

--- a/projects/asset-manager/Dockerfile
+++ b/projects/asset-manager/Dockerfile
@@ -1,11 +1,8 @@
 # Install packages for building ruby
 FROM buildpack-deps
 
-# Install chrome and its dependencies
-RUN apt-get update -qq
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>&1 && \
-   apt-get install -y ./google-chrome*.deb && \
-    rm ./google-chrome*.deb
+# Install chromium browser and its webdriver
+RUN apt-get update -qq && apt-get install -y chromium chromium-driver
 
 # Enable no-sandbox for chrome so that it can run as a root user
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1

--- a/projects/whitehall/Dockerfile
+++ b/projects/whitehall/Dockerfile
@@ -1,11 +1,8 @@
 # Install packages for building ruby
 FROM buildpack-deps
 
-# Install chrome and its dependencies
-RUN apt-get update -qq
-RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb 2>&1 && \
-   apt-get install -y ./google-chrome*.deb && \
-    rm ./google-chrome*.deb
+# Install chromium browser and its webdriver
+RUN apt-get update -qq && apt-get install -y chromium chromium-driver
 
 # Enable no-sandbox for chrome so that it can run as a root user
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1


### PR DESCRIPTION
This commit changes the base docker image to install Chromium browser instead of Google Chrome. This change should make the docker image compatible with the ARM architecture, making it possible for developers to use govuk-docker on Apple M1 MacBooks.

It also installs Chromium WebDriver (chromium-driver) alongside the browser, meaning applications will be able to run Selenium tests without having to install any additional dependencies.

Installing the browser and its associated webdriver as a pair – at the same time, and in the same way – should also avoid any potential for compatibility issues arising from mismatched versions between these two components.

This change should make it possible for us to update the [govuk_test] gem so that it no longer needs to install chromedriver by itself.

[govuk_test]: https://github.com/alphagov/govuk_test