### PR TITLE
Update rbenv github repo

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -22,8 +22,8 @@ RUN apt-get update -qq && apt-get install -y yarn nodejs
 RUN yarn config set cache-folder /root/.yarn/
 
 # Install rbenv to manage ruby versions
-RUN git clone https://github.com/sstephenson/rbenv.git /rbenv
-RUN git clone https://github.com/sstephenson/ruby-build.git /rbenv/plugins/ruby-build
+RUN git clone https://github.com/rbenv/rbenv.git /rbenv
+RUN git clone https://github.com/rbenv/ruby-build.git /rbenv/plugins/ruby-build
 RUN /rbenv/plugins/ruby-build/install.sh
 ENV PATH /root/.rbenv/shims:/rbenv/bin:$PATH
 ENV BUNDLE_SILENCE_ROOT_WARNING 1

--- a/projects/asset-manager/Dockerfile
+++ b/projects/asset-manager/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update -qq && apt-get install -y yarn nodejs
 RUN yarn config set cache-folder /root/.yarn/
 
 # Install rbenv to manage ruby versions
-RUN git clone https://github.com/sstephenson/rbenv.git /rbenv
-RUN git clone https://github.com/sstephenson/ruby-build.git /rbenv/plugins/ruby-build
+RUN git clone https://github.com/rbenv/rbenv.git /rbenv
+RUN git clone https://github.com/rbenv/ruby-build.git /rbenv/plugins/ruby-build
 RUN /rbenv/plugins/ruby-build/install.sh
 ENV PATH /root/.rbenv/shims:/rbenv/bin:$PATH
 ENV BUNDLE_SILENCE_ROOT_WARNING 1

--- a/projects/whitehall/Dockerfile
+++ b/projects/whitehall/Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get update -qq && apt-get install -y yarn nodejs
 RUN yarn config set cache-folder /root/.yarn/
 
 # Install rbenv to manage ruby versions
-RUN git clone https://github.com/sstephenson/rbenv.git /rbenv
-RUN git clone https://github.com/sstephenson/ruby-build.git /rbenv/plugins/ruby-build
+RUN git clone https://github.com/rbenv/rbenv.git /rbenv
+RUN git clone https://github.com/rbenv/ruby-build.git /rbenv/plugins/ruby-build
 RUN /rbenv/plugins/ruby-build/install.sh
 ENV PATH /root/.rbenv/shims:/rbenv/bin:$PATH
 ENV BUNDLE_SILENCE_ROOT_WARNING 1


### PR DESCRIPTION
github/sstephenson/rbenv is no longer the canonical repo for rbenv - currently it redirects there, but we should use the canonical directly