### PR TITLE
[DO NOT MERGE] Remove mongo 2.6 container, replace 2.6 references with 3.6

### DIFF
--- a/bin/replicate-mongodb.sh
+++ b/bin/replicate-mongodb.sh
@@ -23,7 +23,6 @@ case "$app" in
   "router"|"draft-router")
     hostname=router_backend
     database="${app//-/_}"
-    mongo_version=2.6
     wait_for_rs=1
     ;;
   "asset-manager")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ volumes:
   postgres-13:
   mysql-8:
   mongo-3.6:
-  mongo-2.6:
   go:
   elasticsearch-6:
   elasticsearch-7:
@@ -40,12 +39,6 @@ services:
     ports:
       - "27017:27017"
       - "28017:28017"
-
-  mongo-2.6:
-    image: mongo:2.6
-    volumes:
-      - mongo-2.6:/data/db
-    command: ["--replSet", "mongo-replica-set"]
 
   mysql-8:
     image: mysql:8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ volumes:
   postgres-13:
   mysql-8:
   mongo-3.6:
+  mongo-2.6:
   go:
   elasticsearch-6:
   elasticsearch-7:
@@ -39,6 +40,7 @@ services:
     ports:
       - "27017:27017"
       - "28017:28017"
+    command: ["--replSet", "mongo-replica-set"]
 
   mysql-8:
     image: mysql:8

--- a/projects/router-api/docker-compose.yml
+++ b/projects/router-api/docker-compose.yml
@@ -20,19 +20,19 @@ services:
   router-api-lite:
     <<: *router-api
     depends_on:
-      - mongo-2.6
+      - mongo-3.6
     environment:
-      MONGODB_URI: "mongodb://mongo-2.6/router"
-      TEST_MONGODB_URI: "mongodb://mongo-2.6/router-test"
+      MONGODB_URI: "mongodb://mongo-3.6/router"
+      TEST_MONGODB_URI: "mongodb://mongo-3.6/router-test"
 
   router-api-app: &router-api-app
     <<: *router-api
     depends_on:
-      - mongo-2.6
+      - mongo-3.6
       - router-app
       - nginx-proxy
     environment:
-      MONGODB_URI: "mongodb://mongo-2.6/router"
+      MONGODB_URI: "mongodb://mongo-3.6/router"
       VIRTUAL_HOST: router-api.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/router/Makefile
+++ b/projects/router/Makefile
@@ -1,12 +1,12 @@
 router: clone-router
-	$(GOVUK_DOCKER) up -d mongo-2.6
-	$(GOVUK_DOCKER) exec mongo-2.6 mongo --eval "rs.initiate({ \
+	$(GOVUK_DOCKER) up -d mongo-3.6
+	$(GOVUK_DOCKER) exec mongo-3.6 mongo --eval "rs.initiate({ \
 		'_id' : 'mongo-replica-set', \
 		'version' : 1, \
 		'members' : [ \
 			{ \
 				'_id' : 0, \
-				'host' : 'mongo-2.6:27017' \
+				'host' : 'mongo-3.6:27017' \
 			} \
 		]\
 	}).ok || rs.status().ok"

--- a/projects/router/docker-compose.yml
+++ b/projects/router/docker-compose.yml
@@ -15,17 +15,17 @@ services:
   router-lite:
     <<: *router
     depends_on:
-      - mongo-2.6
+      - mongo-3.6
     environment:
       BINARY: /go/src/github.com/alphagov/router/router
       DEBUG: "true"
-      ROUTER_MONGO_URL: mongo-2.6
+      ROUTER_MONGO_URL: mongo-3.6
       ROUTER_MONGO_DB: router
 
   router-app: &router-app
     <<: *router
     depends_on:
-      - mongo-2.6
+      - mongo-3.6
       - nginx-proxy
     expose:
       - "8080"
@@ -33,7 +33,7 @@ services:
     environment:
       VIRTUAL_HOST: router.dev.gov.uk,www.dev.gov.uk,www-origin.dev.gov.uk
       VIRTUAL_PORT: 8080
-      ROUTER_MONGO_URL: mongo-2.6
+      ROUTER_MONGO_URL: mongo-3.6
       ROUTER_MONGO_DB: router
       ROUTER_APIADDR: :3055
       ROUTER_BACKEND_HEADER_TIMEOUT: 60s
@@ -44,7 +44,7 @@ services:
     environment:
       VIRTUAL_HOST: draft-router.dev.gov.uk,draft-origin.dev.gov.uk
       VIRTUAL_PORT: 8080
-      ROUTER_MONGO_URL: mongo-2.6
+      ROUTER_MONGO_URL: mongo-3.6
       ROUTER_MONGO_DB: draft-router
       ROUTER_APIADDR: :3055
       ROUTER_BACKEND_HEADER_TIMEOUT: 60s


### PR DESCRIPTION
## WHAT

- Remove the mongo 2.6 container
- Fixup router and router-api to use the 3.6 container.

## WHY

M1 laptops can't run mongo 2.6 in arm64 mode, and since router and router-api are due to be moved soon to a Mongo 3.6-compliant DocumentDB cluster, they won't be using it in production. The other apps that currently use 2.6 (imminence / authenticating proxy) already use mongo 3.6 in govuk-docker, so there's precedent for the docker image preceding production in the versions of backing apps used.