### PR TITLE
Use tmpfs for Asset Manager temp directory

### DIFF
--- a/projects/asset-manager/docker-compose.yml
+++ b/projects/asset-manager/docker-compose.yml
@@ -15,6 +15,9 @@ x-asset-manager: &asset-manager
     - root-home:/root
     - asset-manager-tmp:/govuk/asset-manager/tmp
   working_dir: /govuk/asset-manager
+  # Mount /tmp as a tmpfs volume. This is a workaround until docker/for-linux#1015 is resolved.
+  # See alphagov/govuk-docker#537 for more info.
+  tmpfs: /tmp
 
 services:
   asset-manager-lite:


### PR DESCRIPTION
This application exhibits the same problems experienced in Whitehall and
Content Publisher where tests for uploaded files are reporting to be at
0 bytes.

Changing the tmp mount to tmpfs resolves this.

## Before:

```
Failures:

  1) AssetPresenter#as_json when the asset has been saved returns hash including asset size
     Failure/Error: expect(json).to include(size: 57_705)

       expected {:_response_info => {:status => "ok"}, :content_type => "image/png", :deleted => false, :draft => false, :file_...ic.dev.gov.uk/public-url-path", :id => "asset-url", :name => "asset.png", :size => 0, :state => "unscanned"} to include {:size => 57705}
       Diff:
       @@ -1,9 +1,17 @@
       -:size => 57705,
       +:_response_info => {:status=>"ok"},
       +:content_type => "image/png",
       +:deleted => false,
       +:draft => false,
       +:file_url => "http://static.dev.gov.uk/public-url-path",
       +:id => "asset-url",
       +:name => "asset.png",
       +:size => 0,
       +:state => "unscanned",

     # ./spec/presenters/asset_presenter_spec.rb:70:in `block (4 levels) in <top (required)>'

  2) Asset#size_from_file returns the size of the file
     Failure/Error: expect(asset.size_from_file).to eq(size)

       expected: 57705
            got: 0

       (compared using ==)
     # ./spec/models/asset_spec.rb:933:in `block (3 levels) in <top (required)>'

  3) Asset#md5_hexdigest_from_file returns MD5 hex digest for asset file content
     Failure/Error: expect(asset.md5_hexdigest_from_file).to eq(md5_hexdigest)

       expected: "a0d8aa55f6db670e38a14962c0652776"
            got: "d41d8cd98f00b204e9800998ecf8427e"

       (compared using ==)
     # ./spec/models/asset_spec.rb:985:in `block (3 levels) in <top (required)>'

Finished in 20.85 seconds (files took 9.51 seconds to load)
511 examples, 3 failures
```

## After:

```
Finished in 19.65 seconds (files took 9.95 seconds to load)
511 examples, 0 failures
```