### PR TITLE
M1 compatibility

### DIFF
--- a/bin/replicate-elasticsearch.sh
+++ b/bin/replicate-elasticsearch.sh
@@ -5,7 +5,7 @@ set -eu
 replication_dir="${GOVUK_DOCKER_REPLICATION_DIR:-${GOVUK_DOCKER_DIR:-${GOVUK_ROOT_DIR:-$HOME/govuk}/govuk-docker}/replication}"
 
 bucket="govuk-integration-elasticsearch6-manual-snapshots"
-archive_path="${replication_dir}/elasticsearch-6"
+archive_path="${replication_dir}/elasticsearch-7"
 
 echo "Replicating elasticsearch"
 
@@ -34,7 +34,7 @@ echo "
 echo "stopping running govuk-docker containers..."
 govuk-docker down
 
-container=$(govuk-docker run -d --rm -v "$archive_path:/replication" -v "$cfg_path:/usr/share/elasticsearch/config/elasticsearch.yml" -p 9200:9200 elasticsearch-6 | tail -n1)
+container=$(govuk-docker run -d --rm -v "$archive_path:/replication" -v "$cfg_path:/usr/share/elasticsearch/config/elasticsearch.yml" -p 9200:9200 elasticsearch-7 | tail -n1)
 # we want $container and $cfg_path to be expanded now
 # shellcheck disable=SC2064
 trap "docker stop '$container'; rm '$cfg_path'" EXIT

--- a/bin/replicate-mongodb.sh
+++ b/bin/replicate-mongodb.sh
@@ -23,7 +23,6 @@ case "$app" in
   "router"|"draft-router")
     hostname=router_backend
     database="${app//-/_}"
-    mongo_version=2.6
     wait_for_rs=1
     ;;
   "asset-manager")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ volumes:
   postgres-13:
   mysql-8:
   mongo-3.6:
-  mongo-2.6:
   go:
   elasticsearch-6:
   elasticsearch-7:
@@ -40,12 +39,6 @@ services:
     ports:
       - "27017:27017"
       - "28017:28017"
-
-  mongo-2.6:
-    image: mongo:2.6
-    volumes:
-      - mongo-2.6:/data/db
-    command: ["--replSet", "mongo-replica-set"]
 
   mysql-8:
     image: mysql:8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - "28017:28017"
 
   mysql-8:
-    image: mysql:8
+    image: mysql:8-oracle
     volumes:
       - mysql-8:/var/lib/mysql
     command: --max_allowed_packet=1073741824

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - "28017:28017"
 
   mysql-8:
+    # Using the orcale image because they are available in ARM64 and AMD64 variants
     image: mysql:8-oracle
     volumes:
       - mysql-8:/var/lib/mysql

--- a/projects/authenticating-proxy/docker-compose.yml
+++ b/projects/authenticating-proxy/docker-compose.yml
@@ -20,6 +20,7 @@ services:
   authenticating-proxy-lite:
     <<: *authenticating-proxy
     depends_on:
+      # In production this uses Mongo 2.6, however there is not a published Mongo 2.6 image compatible with ARM64
       - mongo-3.6
     environment:
       GOVUK_UPSTREAM_URI: http://government-frontend.dev.gov.uk

--- a/projects/content-store/docker-compose.yml
+++ b/projects/content-store/docker-compose.yml
@@ -20,6 +20,7 @@ services:
   content-store-lite:
     <<: *content-store
     depends_on:
+      # In production this uses Mongo 2.6, however there is not a published Mongo 2.6 image compatible with Arm64
       - mongo-3.6
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/content-store"

--- a/projects/imminence/docker-compose.yml
+++ b/projects/imminence/docker-compose.yml
@@ -20,6 +20,7 @@ services:
   imminence-lite:
     <<: *imminence
     depends_on:
+      # In production this uses Mongo 2.6, however there is not a published Mongo 2.6 image compatible with ARM64
       - mongo-3.6
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/imminence"

--- a/projects/licence-finder/docker-compose.yml
+++ b/projects/licence-finder/docker-compose.yml
@@ -21,24 +21,24 @@ services:
     <<: *licence-finder
     depends_on:
       - mongo-3.6
-      - elasticsearch-6
+      - elasticsearch-7
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/licence-finder_development"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/licence-finder_test"
-      ELASTICSEARCH_URI: http://elasticsearch-6:9200
+      ELASTICSEARCH_URI: http://elasticsearch-7:9200
 
   licence-finder-app: &licence-finder-app
     <<: *licence-finder
     depends_on:
       - mongo-3.6
       - static-app
-      - elasticsearch-6
+      - elasticsearch-7
       - content-store-app
       - nginx-proxy
     environment:
       VIRTUAL_HOST: licence-finder.dev.gov.uk
       MONGODB_URI: "mongodb://mongo-3.6/licence-finder_development"
-      ELASTICSEARCH_URI: http://elasticsearch-6:9200
+      ELASTICSEARCH_URI: http://elasticsearch-7:9200
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       BINDING: 0.0.0.0
     expose:
@@ -48,11 +48,11 @@ services:
   licence-finder-app-live:
     <<: *licence-finder-app
     depends_on:
-      - elasticsearch-6
+      - elasticsearch-7
       - mongo-3.6
       - nginx-proxy
     environment:
-      ELASTICSEARCH_URI: http://elasticsearch-6:9200
+      ELASTICSEARCH_URI: http://elasticsearch-7:9200
       MONGODB_URI: "mongodb://mongo-3.6/licence-finder_development"
       PLEK_SERVICE_SEARCH_URI: https://www.gov.uk/api
       GOVUK_WEBSITE_ROOT: https://www.gov.uk

--- a/projects/licence-finder/docker-compose.yml
+++ b/projects/licence-finder/docker-compose.yml
@@ -20,7 +20,9 @@ services:
   licence-finder-lite: &licence-finder-lite
     <<: *licence-finder
     depends_on:
+      # In production this uses Mongo 2.6, however there is not a published Mongo 2.6 image compatible with ARM64
       - mongo-3.6
+      # In production this uses Elasticsearch 6, however there is not a published Elasticsearch 6 image compatible with ARM64
       - elasticsearch-7
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/licence-finder_development"

--- a/projects/router-api/docker-compose.yml
+++ b/projects/router-api/docker-compose.yml
@@ -20,19 +20,19 @@ services:
   router-api-lite:
     <<: *router-api
     depends_on:
-      - mongo-2.6
+      - mongo-3.6
     environment:
-      MONGODB_URI: "mongodb://mongo-2.6/router"
-      TEST_MONGODB_URI: "mongodb://mongo-2.6/router-test"
+      MONGODB_URI: "mongodb://mongo-3.6/router"
+      TEST_MONGODB_URI: "mongodb://mongo-3.6/router-test"
 
   router-api-app: &router-api-app
     <<: *router-api
     depends_on:
-      - mongo-2.6
+      - mongo-3.6
       - router-app
       - nginx-proxy
     environment:
-      MONGODB_URI: "mongodb://mongo-2.6/router"
+      MONGODB_URI: "mongodb://mongo-3.6/router"
       VIRTUAL_HOST: router-api.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/router-api/docker-compose.yml
+++ b/projects/router-api/docker-compose.yml
@@ -20,6 +20,7 @@ services:
   router-api-lite:
     <<: *router-api
     depends_on:
+      # In production this uses Mongo 2.6, however there is not a published Mongo 2.6 image compatible with ARM64
       - mongo-3.6
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/router"

--- a/projects/router/Makefile
+++ b/projects/router/Makefile
@@ -1,12 +1,12 @@
 router: clone-router
-	$(GOVUK_DOCKER) up -d mongo-2.6
-	$(GOVUK_DOCKER) exec mongo-2.6 mongo --eval "rs.initiate({ \
+	$(GOVUK_DOCKER) up -d mongo-3.6
+	$(GOVUK_DOCKER) exec mongo-3.6 mongo --eval "rs.initiate({ \
 		'_id' : 'mongo-replica-set', \
 		'version' : 1, \
 		'members' : [ \
 			{ \
 				'_id' : 0, \
-				'host' : 'mongo-2.6:27017' \
+				'host' : 'mongo-3.6:27017' \
 			} \
 		]\
 	}).ok || rs.status().ok"

--- a/projects/router/docker-compose.yml
+++ b/projects/router/docker-compose.yml
@@ -15,17 +15,17 @@ services:
   router-lite:
     <<: *router
     depends_on:
-      - mongo-2.6
+      - mongo-3.6
     environment:
       BINARY: /go/src/github.com/alphagov/router/router
       DEBUG: "true"
-      ROUTER_MONGO_URL: mongo-2.6
+      ROUTER_MONGO_URL: mongo-3.6
       ROUTER_MONGO_DB: router
 
   router-app: &router-app
     <<: *router
     depends_on:
-      - mongo-2.6
+      - mongo-3.6
       - nginx-proxy
     expose:
       - "8080"
@@ -33,7 +33,7 @@ services:
     environment:
       VIRTUAL_HOST: router.dev.gov.uk,www.dev.gov.uk,www-origin.dev.gov.uk
       VIRTUAL_PORT: 8080
-      ROUTER_MONGO_URL: mongo-2.6
+      ROUTER_MONGO_URL: mongo-3.6
       ROUTER_MONGO_DB: router
       ROUTER_APIADDR: :3055
       ROUTER_BACKEND_HEADER_TIMEOUT: 60s
@@ -44,7 +44,7 @@ services:
     environment:
       VIRTUAL_HOST: draft-router.dev.gov.uk,draft-origin.dev.gov.uk
       VIRTUAL_PORT: 8080
-      ROUTER_MONGO_URL: mongo-2.6
+      ROUTER_MONGO_URL: mongo-3.6
       ROUTER_MONGO_DB: draft-router
       ROUTER_APIADDR: :3055
       ROUTER_BACKEND_HEADER_TIMEOUT: 60s

--- a/projects/router/docker-compose.yml
+++ b/projects/router/docker-compose.yml
@@ -15,6 +15,7 @@ services:
   router-lite:
     <<: *router
     depends_on:
+      # In production this uses Mongo 2.6, however there is not a published Mongo 2.6 image compatible with ARM64
       - mongo-3.6
     environment:
       BINARY: /go/src/github.com/alphagov/router/router

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -17,7 +17,7 @@ x-search-api: &search-api
     RABBITMQ_USER: guest
     RABBITMQ_PASSWORD: guest
     REDIS_URL: redis://redis
-    ELASTICSEARCH_URI: http://elasticsearch-6:9200
+    ELASTICSEARCH_URI: http://elasticsearch-7:9200
 
 services:
   search-api-lite:
@@ -25,21 +25,21 @@ services:
     depends_on:
       - redis
       - rabbitmq
-      - elasticsearch-6
+      - elasticsearch-7
 
   search-api-app: &search-api-app
     <<: *search-api
     depends_on:
       - nginx-proxy
       - redis
-      - elasticsearch-6
+      - elasticsearch-7
       - search-api-worker
       - search-api-listener-publishing-queue
       - search-api-listener-insert-data
       - search-api-listener-bulk-insert-data
     environment:
       REDIS_URL: redis://redis
-      ELASTICSEARCH_URI: http://elasticsearch-6:9200
+      ELASTICSEARCH_URI: http://elasticsearch-7:9200
       VIRTUAL_HOST: search-api.dev.gov.uk, search.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -51,7 +51,7 @@ services:
     depends_on:
       - redis
       - rabbitmq
-      - elasticsearch-6
+      - elasticsearch-7
     command: bundle exec sidekiq -C ./config/sidekiq.yml
 
   search-api-listener-publishing-queue:

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -25,6 +25,7 @@ services:
     depends_on:
       - redis
       - rabbitmq
+      # In production this uses Elasticsearch 6, however there is not a published Elasticsearch 6 image compatible with ARM64
       - elasticsearch-7
 
   search-api-app: &search-api-app


### PR DESCRIPTION
This PR tries to pull together all the fixes we know are needed for using GOV.UK docker on an M1 mac using information from: https://github.com/alphagov/govuk-docker/issues/561

~~This is marked as a draft as I'm not sure if we'll merge these things in directly, I expect we'd probably do some more testing and then consider adding some explanatory comments to code.~~

I've done some testing now and other M1 mac users are making use of this branch. I've also confirmed it allows database restores for MySQL, MongoDB and Elasticsearch.