### PR TITLE
Update Feedback to increase /dev/shm

### DIFF
--- a/projects/feedback/docker-compose.yml
+++ b/projects/feedback/docker-compose.yml
@@ -21,6 +21,7 @@ x-feedback: &feedback
 services:
   feedback-lite:
     <<: *feedback
+    shm_size: 128m
 
   feedback-app: &feedback-app
     <<: *feedback


### PR DESCRIPTION
Jasmine tests were consistently crashing. Research led to increasing the size for /dev/shm fixes the issue.

See https://stackoverflow.com/questions/53902507/unknown-error-session-deleted-because-of-page-crash-from-unknown-error-cannot#comment125897307_68557764

## Before

```
...
jasmine server started
rake aborted!
Selenium::WebDriver::Error::UnknownError: unknown error: session deleted because of page crash
from unknown error: cannot determine loading status
from tab crashed
  (Session info: headless chrome=99.0.4844.74)
#0 0x55c120c48c33 <unknown>
#1 0x55c12095f8b1 <unknown>
#2 0x55c12094952e <unknown>
#3 0x55c120948649 <unknown>
#4 0x55c120948c69 <unknown>
#5 0x55c12095c928 <unknown>
#6 0x55c12095d1c2 <unknown>
#7 0x55c12096797e <unknown>
#8 0x55c1209ce7c2 <unknown>
#9 0x55c1209bbd43 <unknown>
#10 0x55c12098b06b <unknown>
#11 0x55c12098c89e <unknown>
#12 0x55c120c745fd <unknown>
#13 0x55c120c86598 <unknown>
#14 0x55c120c862f6 <unknown>
#15 0x55c120c86b02 <unknown>
#16 0x55c120c75b1b <unknown>
#17 0x55c120c86d81 <unknown>
#18 0x55c120c6a619 <unknown>
#19 0x55c120c9d965 <unknown>
#20 0x55c120c9db03 <unknown>
#21 0x55c120cb7a41 <unknown>
#22 0x7fe6ae956ea7 <unknown>
/root/.rbenv/versions/2.7.5/bin/bundle:23:in `load'
/root/.rbenv/versions/2.7.5/bin/bundle:23:in `<main>'
Tasks: TOP => default => jasmine:ci
(See full trace by running task with --trace)
[305] ! Detected parent died, dying
[301] ! Detected parent died, dying
```

## After

```
...
Waiting for server on localhost:44009...
jasmine server started
Waiting for suite to finish in browser ...
.......
7 specs, 0 failures
Randomized with seed 65348 (rake jasmine:ci[true,65348])
...
```