### PR TITLE
Document issue installing `dnsmasq` (incompatibility with SSH)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,5 +1,18 @@
 # Troubleshooting
 
+## `bin/setup` fails to succeed
+
+If `bin/setup` fails on installing `dnsmasq`, make sure you're not overriding the `USER` env variable anywhere.
+
+If you are (for setting the right SSH username), you'll want to remove that and set it in `~/.config/config.yaml` instead.
+
+```yaml
+# This is for govuk-connect: https://github.com/alphagov/govuk-connect/blob/1e14c58ce8e5d831aad3e2f8353d0e5204f83388/lib/govuk_connect/cli.rb#L230
+# Can't set `export USER="yourname"` as this causes some unix things to fail (e.g. `brew install dnsmasq`)
+# See https://github.com/alphagov/govuk-connect/issues/72
+ssh_username: "yourname"
+```
+
 ## Diagnose common issues when setting up GOV.UK Docker
 
 Run the following command in `~/govuk/govuk-docker`. Since this script makes use of Ruby Gems, you will need to [install some additional dependencies](../CONTRIBUTING.md#testing) in order to do this.


### PR DESCRIPTION
My new Macbook has my username separated with a dot, i.e.
`christopher.ashton`. My SSH username is set as `christopherashton`.
For SSH commands to work, I'd set `export USER="christopherashton"`
in my `~/.zshrc`, but setting this variable caused the govuk-docker
`bin/setup` script to fail - specifically on the `dnsmasq`
postinstall step.

I am [not the only developer who has had this issue](https://github.com/alphagov/govuk-connect/issues/72),
and it is likely to catch people out again, so worth documenting
here.