### PR TITLE
Add govspeak-preview

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,7 @@ services:
           - frontend.dev.gov.uk
           - finder-frontend.dev.gov.uk
           - government-frontend.dev.gov.uk
+          - govspeak-preview.dev.gov.uk
           - govuk-content-schemas.dev.gov.uk
           - govuk-developer-docs.dev.gov.uk
           - govuk-publishing-components.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -37,6 +37,7 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ finder-frontend
    - ✅ frontend
    - ✅ government-frontend
+   - ✅ govspeak-preview
    - ⚠ govuk_crawler_worker
       * **TODO: Missing support for running the worker**
    - ✅ govuk_publishing_components

--- a/projects/govspeak-preview/Makefile
+++ b/projects/govspeak-preview/Makefile
@@ -1,0 +1,1 @@
+govspeak-preview: bundle-govspeak-preview

--- a/projects/govspeak-preview/docker-compose.yml
+++ b/projects/govspeak-preview/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.7'
+
+volumes:
+  govspeak-preview-tmp:
+
+x-govspeak-preview: &govspeak-preview
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: govspeak-preview
+  stdin_open: true
+  tty: true
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - root-home:/root
+    - govspeak-preview-tmp:/govuk/govspeak-preview/tmp
+  working_dir: /govuk/govspeak-preview
+
+services:
+  govspeak-preview-lite:
+    <<: *govspeak-preview
+
+  govspeak-preview-app: &govspeak-preview-app
+    <<: *govspeak-preview
+    depends_on:
+      - nginx-proxy
+    environment:
+      VIRTUAL_HOST: govspeak-preview.dev.gov.uk
+      BINDING: 0.0.0.0
+    expose:
+      - "3000"
+    command: bin/rails s --restart


### PR DESCRIPTION
This should make it easier to keep [`govspeak-preview`](https://github.com/alphagov/govspeak-preview) up-to-date by enabling local development.