### PR TITLE
Add project for Smokey

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -92,4 +92,5 @@ These repos are used as part of running the live GOV.UK site. Since all of them 
    - ❌ govuk_taxonomy_helpers
    - ✅ plek
    - ❌ slimmer
+   - ✅ smokey
    - ❌ transition-config

--- a/projects/generic-ruby-library/Makefile
+++ b/projects/generic-ruby-library/Makefile
@@ -2,3 +2,4 @@ gds-api-adapters: bundle-gds-api-adapters
 govspeak: bundle-govspeak
 govuk_app_config: bundle-govuk_app_config
 plek: bundle-plek
+smokey: bundle-smokey

--- a/projects/generic-ruby-library/docker-compose.yml
+++ b/projects/generic-ruby-library/docker-compose.yml
@@ -25,3 +25,10 @@ services:
   plek-lite:
     <<: *generic-ruby-library
     working_dir: /govuk/plek
+
+  smokey-lite:
+    <<: *generic-ruby-library
+    working_dir: /govuk/smokey
+    environment:
+      NO_SANDBOX: "true"
+    shm_size: 512mb


### PR DESCRIPTION
This avoid adding a bunch of guidance to the README about how to
install Rbenv and Chromedriver, which we now expect to be managed
by the system package manager [^1]. Note that:

- "NO_SANDBOX" is similar to the setting we have in the base image
[^2], but specific to Smokey's test setup [^3].

- "shm_size" is necessary to avoid Chrome crashing on certain tests
[^4]. "watch"ing /dev/shm locally, the highest I saw was 81Mb.*

Running the tests through Docker is slightly slower - locally the
tests take around 20s longer, with a baseline of 3 mins. This is
similar to the tradeoff we have for other apps.

*This is previously what deterred me from adding support for this
repo [^5], noting that the error I saw came later on.

[^1]: https://github.com/alphagov/govuk_test/commit/50ed673b1bd278a51f45eb241d7949918ce77d8e
[^2]: https://github.com/alphagov/govuk-docker/blob/32449a69301f20770e9606f22467658efa948eb0/Dockerfile.govuk-base#L12
[^3]: https://github.com/alphagov/smokey/blob/2017266b906ec7f8f96fb164cf3d8ba03c587296/features/support/env.rb#L40
[^4]: https://stackoverflow.com/questions/53902507/unknown-error-session-deleted-because-of-page-crash-from-unknown-error-cannot
[^5]: https://github.com/alphagov/smokey/pull/936