### PR TITLE
Simplify branch checks now that main is default branch in all repos

### DIFF
--- a/bin/branch_checks.sh
+++ b/bin/branch_checks.sh
@@ -15,17 +15,15 @@ end_ul=$(tput sgr0)
 govuk_root_dir="$HOME/govuk"
 app=$1
 
-root_branch=$(git -C "${govuk_root_dir}/${app}" branch -a | grep "remotes/origin/HEAD" | sed 's/ *remotes\/origin\/HEAD -> origin\///')
-
 echo "Fetching recent updates for ${bold}${app}${end_bold}" && git -C "${govuk_root_dir}/${app}" fetch --quiet
 
 current_branch=$(git -C  "${govuk_root_dir}/${app}" branch --show-current)
-if [ "$current_branch" != "$root_branch" ]; then
-  echo "You are not currently on the root branch (${ul}${root_branch}${end_ul}) for ${bold}${app}${end_bold} (your branch: ${ul}${current_branch}${end_ul})"
+if [ "$current_branch" != "main" ]; then
+  echo "You are not currently on the main branch for ${bold}${app}${end_bold} (your branch: ${ul}${current_branch}${end_ul})"
   echo "Choose an option"
-  select response in "Checkout $root_branch" "Ignore" "Quit"; do
+  select response in "Checkout main" "Ignore" "Quit"; do
     case $response in
-      "Checkout $root_branch" ) git -C "${govuk_root_dir}/${app}" checkout "${root_branch}"; break;;
+      "Checkout main" ) git -C "${govuk_root_dir}/${app}" checkout main; break;;
       Ignore ) break;;
       Quit ) exit 1;;
     esac
@@ -37,7 +35,7 @@ head_commit=$(git -C "${govuk_root_dir}/${app}" rev-parse HEAD)
 origin_head_commit=$(git -C "${govuk_root_dir}/${app}" rev-parse "@{u}")
 
 if [ "$head_commit" != "$origin_head_commit" ]; then
-  echo "Current branch for ${bold}${app}${end_bold} is not up to date with the origin (or does not match it)"
+  echo "Current branch (${ul}${current_branch}${end_ul}) for ${bold}${app}${end_bold} is not up to date with the origin (or does not match it)"
   select response in "Update" "Ignore" "Quit"; do
     case $response in
       Update ) git -C "${govuk_root_dir}/${app}" pull; break;;


### PR DESCRIPTION
All repos now have main as their default branch, so we can simplify the branch_checks script slightly.