### PR TITLE
Add Redis to account-api

### DIFF
--- a/projects/account-api/docker-compose.yml
+++ b/projects/account-api/docker-compose.yml
@@ -26,10 +26,12 @@ services:
       #
       # https://trello.com/c/ZMFOPaCl/1176-upgrade-our-app-databases
       - postgres-13
+      - redis
     environment:
       MEMCACHE_SERVERS: memcached
       DATABASE_URL: "postgresql://postgres@postgres-13/account-api"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/account-api-test"
+      REDIS_URL: redis://redis
 
   account-api-app:
     <<: *account-api
@@ -38,6 +40,7 @@ services:
       - memcached
       - nginx-proxy
       - postgres-13
+      - redis
     environment:
       MEMCACHE_SERVERS: memcached
       DATABASE_URL: "postgresql://postgres@postgres-13/account-api"
@@ -45,6 +48,7 @@ services:
       BINDING: 0.0.0.0
       GOVUK_ACCOUNT_OAUTH_CLIENT_ID: client-id
       GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: client-secret
+      REDIS_URL: redis://redis
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -55,9 +59,11 @@ services:
       - memcached
       - nginx-proxy
       - postgres-13
+      - redis
     environment:
       BINDING: 0.0.0.0
       DATABASE_URL: "postgresql://postgres@postgres-13/account-api"
+      REDIS_URL: redis://redis
       GOVUK_ACCOUNT_OAUTH_CLIENT_ID: client-id
       GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: client-secret
       GOVUK_WEBSITE_ROOT: https://www.gov.uk


### PR DESCRIPTION
In https://github.com/alphagov/account-api/pull/412 Redis became a core
part of the Account API. We now use it to store JWT IDs for two minutes
to guard againts JWT Replay attacks in a backchannel logout scenario
(see PR: https://github.com/alphagov/account-api/pull/405).

But in #412 we also start using Redis as a performant store of
LogoutNotices. Somewhere we can record that a sub has been ordered to be
logged out the next time they pay a visit.

Tests now fail without Redis, so they are added here.