### PR TITLE
Allow files in Asset Manager /tmp to be executed

### DIFF
--- a/projects/asset-manager/docker-compose.yml
+++ b/projects/asset-manager/docker-compose.yml
@@ -17,7 +17,7 @@ x-asset-manager: &asset-manager
   working_dir: /govuk/asset-manager
   # Mount /tmp as a tmpfs volume. This is a workaround until docker/for-linux#1015 is resolved.
   # See alphagov/govuk-docker#537 for more info.
-  tmpfs: /tmp
+  tmpfs: /tmp:exec
 
 services:
   asset-manager-lite:


### PR DESCRIPTION
This applies the same change made in #547 (commit: 74438a34c3e672926adc039b858887983f963d83) to the Asset Manager app.

Without this, `rbenv` isn't able to install the correct Ruby version in the `asset-manager` container, resulting in the error message:

```
ruby-build: TMPDIR=/tmp cannot hold executables (partition possibly mounted with `noexec`)
```