### PR TITLE
Remove mustache from Whitehall's Makefile

### DIFF
--- a/projects/whitehall/Makefile
+++ b/projects/whitehall/Makefile
@@ -2,4 +2,3 @@ whitehall: bundle-whitehall asset-manager publishing-api static
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn
-	$(GOVUK_DOCKER) run $@-lite bin/rake shared_mustache:compile


### PR DESCRIPTION
As of alphagov/whitehall#6624, Whitehall no longer has the `shared_mustache:compile` rake task.