### PR TITLE
Set `shm_size: 512mb` so Chrome browser tests run

### DIFF
--- a/projects/collections-publisher/docker-compose.yml
+++ b/projects/collections-publisher/docker-compose.yml
@@ -21,6 +21,7 @@ x-collections-publisher: &collections-publisher
 services:
   collections-publisher-lite:
     <<: *collections-publisher
+    shm_size: 512mb
     depends_on:
       - mysql-8
       - redis

--- a/projects/contacts-admin/docker-compose.yml
+++ b/projects/contacts-admin/docker-compose.yml
@@ -21,6 +21,7 @@ x-contacts-admin: &contacts-admin
 services:
   contacts-admin-lite:
     <<: *contacts-admin
+    shm_size: 512mb
     depends_on:
       - mysql-8
       - redis

--- a/projects/content-publisher/docker-compose.yml
+++ b/projects/content-publisher/docker-compose.yml
@@ -24,6 +24,7 @@ x-content-publisher: &content-publisher
 services:
   content-publisher-lite:
     <<: *content-publisher
+    shm_size: 512mb
     depends_on:
       - postgres-13
       - redis

--- a/projects/content-tagger/docker-compose.yml
+++ b/projects/content-tagger/docker-compose.yml
@@ -21,6 +21,7 @@ x-content-tagger: &content-tagger
 services:
   content-tagger-lite:
     <<: *content-tagger
+    shm_size: 512mb
     depends_on:
       - postgres-13
     environment:

--- a/projects/govspeak-preview/docker-compose.yml
+++ b/projects/govspeak-preview/docker-compose.yml
@@ -19,6 +19,7 @@ x-govspeak-preview: &govspeak-preview
 services:
   govspeak-preview-lite:
     <<: *govspeak-preview
+    shm_size: 512mb
 
   govspeak-preview-app: &govspeak-preview-app
     <<: *govspeak-preview

--- a/projects/local-links-manager/docker-compose.yml
+++ b/projects/local-links-manager/docker-compose.yml
@@ -21,6 +21,7 @@ x-local-links-manager: &local-links-manager
 services:
   local-links-manager-lite:
     <<: *local-links-manager
+    shm_size: 512mb
     depends_on:
       - postgres-13
     environment:

--- a/projects/manuals-publisher/docker-compose.yml
+++ b/projects/manuals-publisher/docker-compose.yml
@@ -21,6 +21,7 @@ x-manuals-publisher: &manuals-publisher
 services:
   manuals-publisher-lite:
     <<: *manuals-publisher
+    shm_size: 512mb
     depends_on:
       - redis
       - mongo-3.6

--- a/projects/maslow/docker-compose.yml
+++ b/projects/maslow/docker-compose.yml
@@ -21,6 +21,7 @@ x-maslow: &maslow
 services:
   maslow-lite:
     <<: *maslow
+    shm_size: 512mb
     depends_on:
       - mongo-3.6
     environment:

--- a/projects/publisher/docker-compose.yml
+++ b/projects/publisher/docker-compose.yml
@@ -21,6 +21,7 @@ x-publisher: &publisher
 services:
   publisher-lite:
     <<: *publisher
+    shm_size: 512mb
     depends_on:
       - redis
       - mongo-3.6

--- a/projects/service-manual-publisher/docker-compose.yml
+++ b/projects/service-manual-publisher/docker-compose.yml
@@ -21,6 +21,7 @@ x-service-manual-publisher: &service-manual-publisher
 services:
   service-manual-publisher-lite:
     <<: *service-manual-publisher
+    shm_size: 512mb
     depends_on:
       - postgres-13
     environment:

--- a/projects/short-url-manager/docker-compose.yml
+++ b/projects/short-url-manager/docker-compose.yml
@@ -21,6 +21,7 @@ x-short-url-manager: &short-url-manager
 services:
   short-url-manager-lite:
     <<: *short-url-manager
+    shm_size: 512mb
     depends_on:
       - redis
       - mongo-3.6

--- a/projects/signon/docker-compose.yml
+++ b/projects/signon/docker-compose.yml
@@ -21,6 +21,7 @@ x-signon: &signon
 services:
   signon-lite:
     <<: *signon
+    shm_size: 512mb
     depends_on:
       - mysql-8
       - redis

--- a/projects/specialist-publisher/docker-compose.yml
+++ b/projects/specialist-publisher/docker-compose.yml
@@ -21,6 +21,7 @@ x-specialist-publisher: &specialist-publisher
 services:
   specialist-publisher-lite:
     <<: *specialist-publisher
+    shm_size: 512mb
     depends_on:
       - mongo-3.6
       - redis

--- a/projects/travel-advice-publisher/docker-compose.yml
+++ b/projects/travel-advice-publisher/docker-compose.yml
@@ -21,6 +21,7 @@ x-travel-advice-publisher: &travel-advice-publisher
 services:
   travel-advice-publisher-lite:
     <<: *travel-advice-publisher
+    shm_size: 512mb
     depends_on:
       - mongo-3.6
       - redis

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -24,6 +24,7 @@ x-whitehall: &whitehall
 services:
   whitehall-lite:
     <<: *whitehall
+    shm_size: 512mb
     depends_on:
       - mysql-8
       - redis


### PR DESCRIPTION
This PR sets `shm_size: 512mb` so that browser based tests run correctly (e.g. Jasmine unit tests and Capybara feature specs).

Docker allocates 64mb shared memory to containers by default, but recent versions of Chrome require more than this. Otherwise you'll start to see error messages complaining about an "invalid session id". In a previous discussion on Slack, it was informally agreed that 512mb seems to be the 'right sized' amount to allocate – but this was anecdotal, so other values may work equally well for our needs.

If the `shm_size` is too small, you'll get error messages that look something like this in your terminal:

```
NoSuchSessionError: invalid session id
    at Object.throwDecodedError (/govuk/whitehall/node_modules/selenium-webdriver/lib/error.js:522:15)
    at parseHttpResponse (/govuk/whitehall/node_modules/selenium-webdriver/lib/http.js:548:13)
    at Executor.execute (/govuk/whitehall/node_modules/selenium-webdriver/lib/http.js:474:28)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
    at async thenableWebDriverProxy.execute (/govuk/whitehall/node_modules/selenium-webdriver/lib/webdriver.js:735:17)
    at async Object.runSpecs (/govuk/whitehall/node_modules/jasmine-browser-runner/index.js:116:9)
    at async Command.runSpecs (/govuk/whitehall/node_modules/jasmine-browser-runner/lib/command.js:187:5) {
  remoteStacktrace: '#0 0xaaaabaf6b1b0 <unknown>\n' +
    '#1 0xaaaabada13b0 <unknown>\n' +
    '#2 0xaaaabadc7fe4 <unknown>\n' +
    '#3 0xaaaabadc9864 <unknown>\n' +
    '#4 0xaaaabafa75f8 <unknown>\n' +
    '#5 0xaaaabafa9d98 <unknown>\n' +
    '#6 0xaaaabafa9acc <unknown>\n' +
    '#7 0xaaaabaf987e0 <unknown>\n' +
    '#8 0xaaaabafaa500 <unknown>\n' +
    '#9 0xaaaabaf8e080 <unknown>\n' +
    '#10 0xaaaabafc1790 <unknown>\n' +
    '#11 0xaaaabafc1950 <unknown>\n' +
    '#12 0xaaaabafdbbd4 <unknown>\n' +
    '#13 0xffffb0f28628 <unknown>\n' +
    '#14 0xffffb075501c <unknown>\n'
}
error Command failed with exit code 1.
```

This config needs to be applied to each service that needs to run Chrome. In this commit, I've added it to applications owned by the Publishing service. Other applications (including frontend applications) may also benefit from this config, but I didn't want to make assumptions about which applications need it and which don't.

More information about this problem is covered in this blog post:
https://thecurve.io/dealing-with-cryptic-seleniumwebdrivererrorinvalidsessioniderror-errors/