### PR TITLE
Install `less` for scrolling in Rails consoles

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -25,5 +25,6 @@ RUN /rbenv/plugins/ruby-build/install.sh
 ENV PATH /root/.rbenv/shims:/rbenv/bin:$PATH
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
-# Install psql for 'rails dbconsole'
-RUN apt-get update -qq && apt-get install -y postgresql-client
+# Install `psql` for 'rails dbconsole'
+# and `less` for paginated output in 'rails console' and 'binding.pry'
+RUN apt-get update -qq && apt-get install -y postgresql-client less


### PR DESCRIPTION
This installs `less` which is a common utility on Linux systems used for scrolling up/down within large documents. But unfortunately it doesn't exist in the base image we're using.

In Rails applications, `rails console` and `binding.pry` commands both open a Pry session. When debugging something which is too large to fit in the terminal window, Pry will attempt to paginate the output using `less`. If that's not available on the local system, it'll fall back to a 'SimplePager' implementation which is weird and not nice to use.

To make the development environment more predictable, I've installed `less` so that we get pagination which is nice to use.