### PR TITLE
Add `less` to project-specific Dockerfiles

### DIFF
--- a/projects/asset-manager/Dockerfile
+++ b/projects/asset-manager/Dockerfile
@@ -22,5 +22,6 @@ ENV PATH /root/.rbenv/shims:/rbenv/bin:$PATH
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 # Install virus scanner utility
-RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y clamav
+# and `less` for paginated output in 'rails console' and 'binding.pry'
+RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y clamav less
 RUN ln -sf /usr/bin/clamscan /usr/bin/govuk_clamscan

--- a/projects/whitehall/Dockerfile
+++ b/projects/whitehall/Dockerfile
@@ -22,4 +22,5 @@ ENV PATH /root/.rbenv/shims:/rbenv/bin:$PATH
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
 # Install Whitehall specific dependencies
-RUN apt-get update -qq && apt-get install -y default-mysql-client ghostscript
+# and `less` for paginated output in 'rails console' and 'binding.pry'
+RUN apt-get update -qq && apt-get install -y default-mysql-client ghostscript less


### PR DESCRIPTION
A follow-up from 8edfb8f037d128b1ef9828e1b14740d546527f3e / #614.

This adds the `less` command to projects which don't use the default `Dockerfile.govuk-base` as their base image.