### PR TITLE
Add Whitehall worker

### DIFF
--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -51,3 +51,16 @@ services:
     expose:
       - "3000"
     command: bin/rails s --restart
+
+  whitehall-worker:
+    <<: *whitehall
+    depends_on:
+      - mysql-8
+      - redis
+      - nginx-proxy
+      - asset-manager-app
+      - publishing-api-app
+    environment:
+      DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_development"
+      REDIS_URL: redis://redis
+    command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
This allows us to start a Whitehall worker process, to locally run the contents of the queue.

The process won't start by default when the Whitehall app is launched in govuk-docker, as it is not needed in most occasions.

When required, the following can be used from the Whitehall directory to launch the worker:

```
govuk-docker-up worker
```