### PR TITLE
Add redis config to docker

### DIFF
--- a/projects/local-links-manager/docker-compose.yml
+++ b/projects/local-links-manager/docker-compose.yml
@@ -24,17 +24,21 @@ services:
     shm_size: 512mb
     depends_on:
       - postgres-13
+      - redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/local-links-manager"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/local-links-manager-test"
+      REDIS_URL: redis://redis
 
   local-links-manager-app:
     <<: *local-links-manager
     depends_on:
       - postgres-13
       - nginx-proxy
+      - redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/local-links-manager"
+      REDIS_URL: redis://redis
       VIRTUAL_HOST: local-links-manager.dev.gov.uk
       BINDING: 0.0.0.0
     expose:


### PR DESCRIPTION
Testing a [change] to how Redis is called in LLM failed because the Redis config is missing.

The "check-links" rake task failed with the following:

```
govuk-docker-run bundle exec rake check-links
docker-compose -f [...] run local-links-manager-lite bundle exec rake check-links
Creating govuk-docker_local-links-manager-lite_run ... done
rake aborted!
Redis::CannotConnectError: Cannot assign requested address - connect(2) for [::1]:6379
/govuk/local-links-manager/app/lib/local_links_manager/distributed_lock.rb:16:in `lock'
/govuk/local-links-manager/lib/tasks/check-links/link_checker.rake:7:in `block in <top (required)>'
/root/.rbenv/versions/2.7.6/bin/bundle:23:in `load'
/root/.rbenv/versions/2.7.6/bin/bundle:23:in `<main>'
```

Redis [config] already exists in govuk-puppet, so it looks like this was just missed previously.

[change]: https://github.com/alphagov/local-links-manager/pull/973
[config]: https://github.com/alphagov/govuk-puppet/blob/da425c2c8ffc72d419a7b2d09270580bb06de9c7/hieradata_aws/common.yaml#L640-L641