### PR TITLE
Update the Plek service name for Search API

### DIFF
--- a/projects/collections/docker-compose.yml
+++ b/projects/collections/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       GOVUK_PROXY_STATIC_ENABLED: "true"
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
-      PLEK_SERVICE_SEARCH_URI: https://www.gov.uk/api
+      PLEK_SERVICE_SEARCH_API_URI: https://www.gov.uk/api
       PLEK_SERVICE_STATIC_URI: https://assets.publishing.service.gov.uk
       VIRTUAL_HOST: collections.dev.gov.uk
       BINDING: 0.0.0.0

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - account-api-app-live
       - nginx-proxy
     environment:
-      PLEK_SERVICE_SEARCH_URI: https://www.gov.uk/api
+      PLEK_SERVICE_SEARCH_API_URI: https://www.gov.uk/api
       PLEK_SERVICE_WHITEHALL_FRONTEND_URI: https://www.gov.uk
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       GOVUK_PROXY_STATIC_ENABLED: "true"

--- a/projects/licence-finder/docker-compose.yml
+++ b/projects/licence-finder/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     environment:
       ELASTICSEARCH_URI: http://elasticsearch-7:9200
       MONGODB_URI: "mongodb://mongo-3.6/licence-finder_development"
-      PLEK_SERVICE_SEARCH_URI: https://www.gov.uk/api
+      PLEK_SERVICE_SEARCH_API_URI: https://www.gov.uk/api
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       GOVUK_PROXY_STATIC_ENABLED: "true"
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api


### PR DESCRIPTION
A [change] was name to gds-api-adapters to use the canonical name for search-api, rather than the alias "search".

Plek uses the service name in it's [environment variables] to find the service. When the name of the service changed, Plek was unable to find service and errored with:

```
GdsApi::SocketErrorException - Failed to open TCP connection to search-api.www.gov.uk:443 (getaddrinfo: nodename nor servname provided, or not known)
```

[change]: https://github.com/alphagov/gds-api-adapters/pull/1170
[environment variables]: https://github.com/alphagov/plek#environment-variables