### PR TITLE
Upgrade Node.js to version 16

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -12,7 +12,7 @@ RUN apt-get update -qq && apt-get install -y chromium chromium-driver
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1
 
 # Install node / yarn
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y yarn nodejs

--- a/projects/asset-manager/Dockerfile
+++ b/projects/asset-manager/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -qq && apt-get install -y chromium chromium-driver
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1
 
 # Install node / yarn
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y yarn nodejs

--- a/projects/whitehall/Dockerfile
+++ b/projects/whitehall/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -qq && apt-get install -y chromium chromium-driver
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1
 
 # Install node / yarn
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y yarn nodejs


### PR DESCRIPTION
Node.js 12 is no longer supported and 14 is only supported until April: https://github.com/nodejs/Release#release-schedule

I've tested a few apps on version 16 without any issues.

https://trello.com/c/PMsAXSoT/3029-review-govuks-usage-of-node-2