### PR TITLE
Update dockerfile for Router to GoLang 1.19

### DIFF
--- a/projects/router/Dockerfile
+++ b/projects/router/Dockerfile
@@ -1,1 +1,1 @@
-FROM golang:1.15.8
+FROM golang:1.19.1


### PR DESCRIPTION
Fix allows for the most recent major version of GoLang to be pulled. This is required for Router to build successfully due to updated dependencies.