### PR TITLE
Replace MongoDB with Postgres for Imminence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ volumes:
   rabbitmq:
   postgres-12:
   postgres-13:
+  postgres-14-postgis:
   mysql-8:
   mongo-3.6:
   go:
@@ -28,6 +29,14 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - postgres-13:/var/lib/postgresql/data
+
+  postgres-14-postgis:
+    # Using the kartoza image because it supports ARM64 and AMD64
+    image: kartoza/postgis:14
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - postgres-14-postgis:/var/lib/postgresql/data
 
   memcached:
     image: memcached

--- a/projects/imminence/Makefile
+++ b/projects/imminence/Makefile
@@ -1,3 +1,3 @@
 imminence: bundle-imminence local-links-manager locations-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
-	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:mongoid:create_indexes
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup

--- a/projects/imminence/docker-compose.yml
+++ b/projects/imminence/docker-compose.yml
@@ -20,25 +20,24 @@ services:
   imminence-lite:
     <<: *imminence
     depends_on:
-      # In production this uses Mongo 2.6, however there is not a published Mongo 2.6 image compatible with ARM64
-      - mongo-3.6
+      - postgres-14-postgis
       - redis
     environment:
-      MONGODB_URI: "mongodb://mongo-3.6/imminence"
-      TEST_MONGODB_URI: "mongodb://mongo-3.6/imminence-test"
+      DATABASE_URL: "postgis://postgres@postgres-14-postgis/imminence"
+      TEST_DATABASE_URL: "postgis://postgres@postgres-14-postgis/imminence-test"
       REDIS_URL: redis://redis
 
   imminence-app: &imminence-app
     <<: *imminence
     depends_on:
-      - mongo-3.6
+      - postgres-14-postgis
       - local-links-manager-app
       - locations-api-app
       - nginx-proxy
       - redis
       - imminence-worker
     environment:
-      MONGODB_URI: "mongodb://mongo-3.6/imminence"
+      DATABASE_URL: "postgis://postgres@postgres-14-postgis/imminence"
       VIRTUAL_HOST: imminence.dev.gov.uk
       BINDING: 0.0.0.0
       REDIS_URL: redis://redis
@@ -49,12 +48,12 @@ services:
   imminence-worker:
     <<: *imminence
     depends_on:
-      - mongo-3.6
+      - postgres-14-postgis
       - local-links-manager-app
       - locations-api-app
       - nginx-proxy
       - redis
     environment:
-      MONGODB_URI: "mongodb://mongo-3.6/imminence"
+      DATABASE_URL: "postgis://postgres@postgres-14-postgis/imminence"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
Updates Imminence to use PG+PostGIS rather than MongoDB. 

Related PRS:
https://github.com/alphagov/imminence/pull/766

Trello:
https://trello.com/c/R6Lb3vYa/1611-move-imminence-away-from-mongodb-onto-postgres