### PR TITLE
Use static proxy for frontend *-app stacks

### DIFF
--- a/projects/collections/docker-compose.yml
+++ b/projects/collections/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - static-app
       - nginx-proxy
     environment:
+      GOVUK_PROXY_STATIC_ENABLED: "true"
       VIRTUAL_HOST: collections.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/collections/docker-compose.yml
+++ b/projects/collections/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - static-app
       - nginx-proxy
     environment:
-      ASSET_HOST: collections.dev.gov.uk
       VIRTUAL_HOST: collections.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/email-alert-frontend/docker-compose.yml
+++ b/projects/email-alert-frontend/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - email-alert-api-app
       - nginx-proxy
     environment:
+      GOVUK_PROXY_STATIC_ENABLED: "true"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: email-alert-frontend.dev.gov.uk
       BINDING: 0.0.0.0

--- a/projects/email-alert-frontend/docker-compose.yml
+++ b/projects/email-alert-frontend/docker-compose.yml
@@ -37,7 +37,6 @@ services:
       - nginx-proxy
     environment:
       REDIS_URL: redis://redis
-      ASSET_HOST: email-alert-frontend.dev.gov.uk
       VIRTUAL_HOST: email-alert-frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/feedback/docker-compose.yml
+++ b/projects/feedback/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - support-api-app
       - support-app
     environment:
+      GOVUK_PROXY_STATIC_ENABLED: "true"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: feedback.dev.gov.uk
       BINDING: 0.0.0.0

--- a/projects/feedback/docker-compose.yml
+++ b/projects/feedback/docker-compose.yml
@@ -33,7 +33,6 @@ services:
       - support-api-app
       - support-app
     environment:
-      ASSET_HOST: feedback.dev.gov.uk
       REDIS_URL: redis://redis
       VIRTUAL_HOST: feedback.dev.gov.uk
       BINDING: 0.0.0.0

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -39,7 +39,6 @@ services:
       - search-api-app
       - static-app
     environment:
-      ASSET_HOST: finder-frontend.dev.gov.uk
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       BINDING: 0.0.0.0
       MEMCACHE_SERVERS: memcached

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - search-api-app
       - static-app
     environment:
+      GOVUK_PROXY_STATIC_ENABLED: "true"
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       BINDING: 0.0.0.0
       MEMCACHE_SERVERS: memcached

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - router-app
       - static-app
     environment:
-      ASSET_HOST: frontend.dev.gov.uk
       VIRTUAL_HOST: frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/government-frontend/docker-compose.yml
+++ b/projects/government-frontend/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       - static-app
       - nginx-proxy
     environment:
-      ASSET_HOST: government-frontend.dev.gov.uk
       VIRTUAL_HOST: government-frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/government-frontend/docker-compose.yml
+++ b/projects/government-frontend/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - static-app
       - nginx-proxy
     environment:
+      GOVUK_PROXY_STATIC_ENABLED: "true"
       VIRTUAL_HOST: government-frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/info-frontend/docker-compose.yml
+++ b/projects/info-frontend/docker-compose.yml
@@ -28,7 +28,6 @@ services:
       - static-app
       - nginx-proxy
     environment:
-      ASSET_HOST: info-frontend.dev.gov.uk
       VIRTUAL_HOST: info-frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/info-frontend/docker-compose.yml
+++ b/projects/info-frontend/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       - static-app
       - nginx-proxy
     environment:
+      GOVUK_PROXY_STATIC_ENABLED: "true"
       VIRTUAL_HOST: info-frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/service-manual-frontend/docker-compose.yml
+++ b/projects/service-manual-frontend/docker-compose.yml
@@ -30,7 +30,6 @@ services:
       - static-app
       - nginx-proxy
     environment:
-      ASSET_HOST: service-manual-frontend.dev.gov.uk
       VIRTUAL_HOST: service-manual-frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/service-manual-frontend/docker-compose.yml
+++ b/projects/service-manual-frontend/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - static-app
       - nginx-proxy
     environment:
+      GOVUK_PROXY_STATIC_ENABLED: "true"
       VIRTUAL_HOST: service-manual-frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -44,6 +44,7 @@ services:
       - asset-manager-app
       - publishing-api-app
     environment:
+      GOVUK_PROXY_STATIC_ENABLED: "true"
       DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_development"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: whitehall-admin.dev.gov.uk, whitehall-frontend.dev.gov.uk


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

This removes the configuration of asset hosts for frontend applications and switches them to use the [static-proxy](https://github.com/alphagov/govuk_app_config/blob/7f060692720df50a27f6845f052b04eae2246226/lib/govuk_app_config/govuk_proxy/static_proxy.rb) as per the *-app-live stacks.

The motivation for this change is the [upcoming changes to the Content Security Policy](https://github.com/alphagov/govuk_app_config/pull/274) that expect assets to be served from the serving host. 

I'm expecting the impact of changing this to be low as I expect the usage of these *-app stacks to be low, with most developers favouring the *-app-live or `./startup.sh --live` scripts.

The only complication this presents is running apps behind router where additional proxying is needed. I did investigate setting up the nginx proxying to support this (details in first commit message) but concluded router usage was already sufficiently broken that clearly it's not part of anyone's current workflow. Should this be needed in future the details are in the commit.