### PR TITLE
Use static proxy on licence-finder and smart-answers

### DIFF
--- a/projects/licence-finder/docker-compose.yml
+++ b/projects/licence-finder/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       VIRTUAL_HOST: licence-finder.dev.gov.uk
       MONGODB_URI: "mongodb://mongo-3.6/licence-finder_development"
       ELASTICSEARCH_URI: http://elasticsearch-7:9200
+      GOVUK_PROXY_STATIC_ENABLED: "true"
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       BINDING: 0.0.0.0
     expose:

--- a/projects/smart-answers/docker-compose.yml
+++ b/projects/smart-answers/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - content-store-app
       - whitehall-app
     environment:
+      GOVUK_PROXY_STATIC_ENABLED: "true"
       VIRTUAL_HOST: smart-answers.dev.gov.uk
       BINDING: 0.0.0.0
     expose:


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

I missed these on https://github.com/alphagov/govuk-docker/pull/632