### PR TITLE
Replace MongoDB with Postgres for Authenticating Proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ volumes:
   rabbitmq:
   postgres-12:
   postgres-13:
+  postgres-14:
   postgres-14-postgis:
   mysql-8:
   mongo-3.6:
@@ -29,6 +30,13 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - postgres-13:/var/lib/postgresql/data
+
+  postgres-14:
+    image: postgres:14
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - postgres-14:/var/lib/postgresql/data
 
   postgres-14-postgis:
     # Using the kartoza image because it supports ARM64 and AMD64

--- a/projects/authenticating-proxy/Makefile
+++ b/projects/authenticating-proxy/Makefile
@@ -1,3 +1,5 @@
 authenticating-proxy: bundle-authenticating-proxy government-frontend
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rails runner 'User.first || User.create'

--- a/projects/authenticating-proxy/docker-compose.yml
+++ b/projects/authenticating-proxy/docker-compose.yml
@@ -20,22 +20,21 @@ services:
   authenticating-proxy-lite:
     <<: *authenticating-proxy
     depends_on:
-      # In production this uses Mongo 2.6, however there is not a published Mongo 2.6 image compatible with ARM64
-      - mongo-3.6
+      - postgres-14
     environment:
       GOVUK_UPSTREAM_URI: http://government-frontend.dev.gov.uk
-      MONGODB_URI: "mongodb://mongo-3.6/authenticating-proxy"
-      TEST_MONGODB_URI: "mongodb://mongo-3.6/authenticating-proxy-test"
+      DATABASE_URL: "postgresql://postgres@postgres-14/authenticating-proxy"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-14/authenticating-proxy-test"
 
   authenticating-proxy-app: &authenticating-proxy-app
     <<: *authenticating-proxy
     depends_on:
-      - mongo-3.6
+      - postgres-14
       - nginx-proxy
       - government-frontend-app
     environment:
       GOVUK_UPSTREAM_URI: http://government-frontend.dev.gov.uk
-      MONGODB_URI: "mongodb://mongo-3.6/authenticating-proxy"
+      DATABASE_URL: "postgresql://postgres@postgres-14/authenticating-proxy"
       VIRTUAL_HOST: authenticating-proxy.dev.gov.uk
       BINDING: 0.0.0.0
     expose:


### PR DESCRIPTION
Updates Authenticating Proxy to use PG rather than MongoDB.

Related PRS:
https://github.com/alphagov/authenticating-proxy/pull/350