### PR TITLE
Make branch_checks.sh respect GOVUK_ROOT_DIR

### DIFF
--- a/bin/branch_checks.sh
+++ b/bin/branch_checks.sh
@@ -12,7 +12,7 @@ end_bold=$(tput sgr0)
 ul=$(tput smul)
 end_ul=$(tput sgr0)
 
-govuk_root_dir="$HOME/govuk"
+govuk_root_dir=${GOVUK_ROOT_DIR:-$HOME/govuk}
 app=$1
 
 echo "Fetching recent updates for ${bold}${app}${end_bold}" && git -C "${govuk_root_dir}/${app}" fetch --quiet


### PR DESCRIPTION
Noticed this when trying to set up `govuk-docker` with a custom `GOVUK_ROOT_DIR` (`~/Developer/govuk` instead of `~/govuk`).

The branch_checks.sh script currently has the root directory for GOV.UK repos hardcoded as `$HOME/govuk` and doesn't use the `GOVUK_ROOT_DIR` environment variable that the rest of the project does. This means `make [anyproject]` will fail on configurations where the user has a custom `GOVUK_ROOT_DIR` set up.

This sets the root directory to the value of `$GOVUK_ROOT_DIR` if set, or the existing default otherwise.