### PR TITLE
Build custom Elasticsearch 6 image

### DIFF
--- a/bin/replicate-elasticsearch.sh
+++ b/bin/replicate-elasticsearch.sh
@@ -5,7 +5,7 @@ set -eu
 replication_dir="${GOVUK_DOCKER_REPLICATION_DIR:-${GOVUK_DOCKER_DIR:-${GOVUK_ROOT_DIR:-$HOME/govuk}/govuk-docker}/replication}"
 
 bucket="govuk-integration-elasticsearch6-manual-snapshots"
-archive_path="${replication_dir}/elasticsearch-7"
+archive_path="${replication_dir}/elasticsearch-6"
 
 echo "Replicating elasticsearch"
 
@@ -34,7 +34,7 @@ echo "
 echo "stopping running govuk-docker containers..."
 govuk-docker down
 
-container=$(govuk-docker run -d --rm -v "$archive_path:/replication" -v "$cfg_path:/usr/share/elasticsearch/config/elasticsearch.yml" -p 9200:9200 elasticsearch-7 | tail -n1)
+container=$(govuk-docker run -d --rm -v "$archive_path:/replication" -v "$cfg_path:/usr/share/elasticsearch/config/elasticsearch.yml" -p 9200:9200 elasticsearch-6 | tail -n1)
 # we want $container and $cfg_path to be expanded now
 # shellcheck disable=SC2064
 trap "docker stop '$container'; rm '$cfg_path'" EXIT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,12 +77,11 @@ services:
       - rabbitmq:/var/lib/rabbitmq
 
   elasticsearch-6:
-    image: elasticsearch:6.7.0
+    build:
+      context: services/elasticsearch-6
+      dockerfile: Dockerfile
     environment:
-      - http.host=0.0.0.0
-      - transport.host=127.0.0.1
-      - xpack.security.enabled=false
-      - ES_JAVA_OPTS=-Xms1g -Xmx1g
+      ES_JAVA_OPTS: -Xms1g -Xmx1g
     volumes:
       - elasticsearch-6:/usr/share/elasticsearch/data
 

--- a/projects/licence-finder/docker-compose.yml
+++ b/projects/licence-finder/docker-compose.yml
@@ -22,25 +22,24 @@ services:
     depends_on:
       # In production this uses Mongo 2.6, however there is not a published Mongo 2.6 image compatible with ARM64
       - mongo-3.6
-      # In production this uses Elasticsearch 6, however there is not a published Elasticsearch 6 image compatible with ARM64
-      - elasticsearch-7
+      - elasticsearch-6
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/licence-finder_development"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/licence-finder_test"
-      ELASTICSEARCH_URI: http://elasticsearch-7:9200
+      ELASTICSEARCH_URI: http://elasticsearch-6:9200
 
   licence-finder-app: &licence-finder-app
     <<: *licence-finder
     depends_on:
       - mongo-3.6
       - static-app
-      - elasticsearch-7
+      - elasticsearch-6
       - content-store-app
       - nginx-proxy
     environment:
       VIRTUAL_HOST: licence-finder.dev.gov.uk
       MONGODB_URI: "mongodb://mongo-3.6/licence-finder_development"
-      ELASTICSEARCH_URI: http://elasticsearch-7:9200
+      ELASTICSEARCH_URI: http://elasticsearch-6:9200
       GOVUK_PROXY_STATIC_ENABLED: "true"
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       BINDING: 0.0.0.0
@@ -51,11 +50,11 @@ services:
   licence-finder-app-live:
     <<: *licence-finder-app
     depends_on:
-      - elasticsearch-7
+      - elasticsearch-6
       - mongo-3.6
       - nginx-proxy
     environment:
-      ELASTICSEARCH_URI: http://elasticsearch-7:9200
+      ELASTICSEARCH_URI: http://elasticsearch-6:9200
       MONGODB_URI: "mongodb://mongo-3.6/licence-finder_development"
       PLEK_SERVICE_SEARCH_API_URI: https://www.gov.uk/api
       GOVUK_WEBSITE_ROOT: https://www.gov.uk

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -17,7 +17,7 @@ x-search-api: &search-api
     RABBITMQ_USER: guest
     RABBITMQ_PASSWORD: guest
     REDIS_URL: redis://redis
-    ELASTICSEARCH_URI: http://elasticsearch-7:9200
+    ELASTICSEARCH_URI: http://elasticsearch-6:9200
 
 services:
   search-api-lite:
@@ -25,22 +25,21 @@ services:
     depends_on:
       - redis
       - rabbitmq
-      # In production this uses Elasticsearch 6, however there is not a published Elasticsearch 6 image compatible with ARM64
-      - elasticsearch-7
+      - elasticsearch-6
 
   search-api-app: &search-api-app
     <<: *search-api
     depends_on:
       - nginx-proxy
       - redis
-      - elasticsearch-7
+      - elasticsearch-6
       - search-api-worker
       - search-api-listener-publishing-queue
       - search-api-listener-insert-data
       - search-api-listener-bulk-insert-data
     environment:
       REDIS_URL: redis://redis
-      ELASTICSEARCH_URI: http://elasticsearch-7:9200
+      ELASTICSEARCH_URI: http://elasticsearch-6:9200
       VIRTUAL_HOST: search-api.dev.gov.uk, search.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -52,7 +51,7 @@ services:
     depends_on:
       - redis
       - rabbitmq
-      - elasticsearch-7
+      - elasticsearch-6
     command: bundle exec sidekiq -C ./config/sidekiq.yml
 
   search-api-listener-publishing-queue:

--- a/services/elasticsearch-6/Dockerfile
+++ b/services/elasticsearch-6/Dockerfile
@@ -1,0 +1,37 @@
+# search-api in its current state has a hard dependency on Elasticsearch 6, which doesn't have any
+# official images supporting arm64 and probably never will. Until it migrates away from v6, we need
+# to have a functioning development environment that has a reasonable degree of parity with the
+# production service, while working on both architectures that developers will commonly use.
+#
+# This Dockerfile allows us to have this by manually setting up Elasticsearch v6 using a JRE image
+# that supports both x86_64 and arm64.
+
+FROM eclipse-temurin:8-jre
+
+ARG ELASTICSEARCH_VERSION=6.7.2
+
+ARG USERNAME=elastic
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
+
+# Set up unprivileged local user
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME}
+
+# Install required tooling
+RUN apt update && apt install -y curl
+
+# Get Elasticsearch
+WORKDIR /usr
+RUN curl -L -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
+RUN tar -xvf elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
+RUN mv elasticsearch-${ELASTICSEARCH_VERSION} elasticsearch
+
+# Apply our custom configuration file
+ADD elasticsearch.yml /usr/elasticsearch/config/elasticsearch.yml
+
+# Ensure regular user owns Elasticsearch directory
+RUN chown -R ${USERNAME}: elasticsearch
+
+USER ${USERNAME}
+CMD /usr/elasticsearch/bin/elasticsearch

--- a/services/elasticsearch-6/elasticsearch.yml
+++ b/services/elasticsearch-6/elasticsearch.yml
@@ -1,0 +1,7 @@
+# Unsupported on ARM, and we don't need it anyway
+xpack.ml.enabled: false
+
+# Configuration settings from govuk-docker
+http.host: 0.0.0.0
+transport.host: 127.0.0.1
+xpack.security.enabled: false


### PR DESCRIPTION
The stacks for `search-api` and `licence-finder` have been updated to Elasticsearch v7 as v6 doesn't have arm64 images available, however `search-api` has a hard dependency on v6 and refuses to even start properly with v7 due to deprecations. Additionally, for the upcoming search improvement work we need to make sure we have a local development environment that more closely matches production.

- Add a custom Dockerfile for an Elasticsearch 6 image based off of a JRE8 image that supports both x86_64 and arm64.
- Revert `search-api` and `licence-finder` to use Elasticsearch 6
- Revert Elasticsearch replication script to import to Elasticsearch 6

> Notes:
> - I've created a `services` directory for the new custom ES6 service after considering a few options, happy to move things elsewhere if anyone thinks there's a better place for it to live.
> - I've tested this locally on both architectures and it works fine, but can someone else give it a quick spin to make sure I haven't inadverently broken anything else? It can't imagine it would impact any users who aren't working on `search-api` and `licence-finder` anyway as I've only switched these projects back, but don't want to cause headaches!