### PR TITLE
Add assorted environment fixes for search development

### DIFF
--- a/projects/publishing-api/docker-compose.yml
+++ b/projects/publishing-api/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       - redis
       - nginx-proxy
     environment:
+      RABBITMQ_EXCHANGE: published_documents
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
       DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: publishing-api.dev.gov.uk
@@ -53,6 +55,8 @@ services:
       - postgres-13
       - redis
     environment:
+      RABBITMQ_EXCHANGE: published_documents
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
       DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/projects/router-api/docker-compose.yml
+++ b/projects/router-api/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - router-app
       - nginx-proxy
     environment:
+      ROUTER_NODES: router-app
       MONGODB_URI: "mongodb://mongo-3.6/router"
       VIRTUAL_HOST: router-api.dev.gov.uk
       BINDING: 0.0.0.0

--- a/projects/router/docker-compose.yml
+++ b/projects/router/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       # In production this uses Mongo 2.6, however there is not a published Mongo 2.6 image compatible with ARM64
       - mongo-3.6
     environment:
+      GOFLAGS: -buildvcs=false
       BINARY: /go/src/github.com/alphagov/router/router
       DEBUG: "true"
       ROUTER_MONGO_URL: mongo-3.6

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -39,6 +39,10 @@ services:
       - search-api-listener-insert-data
       - search-api-listener-bulk-insert-data
     environment:
+      RABBITMQ_HOSTS: rabbitmq
+      RABBITMQ_VHOST: /
+      RABBITMQ_USER: guest
+      RABBITMQ_PASSWORD: guest
       REDIS_URL: redis://redis
       ELASTICSEARCH_URI: http://elasticsearch-7:9200
       VIRTUAL_HOST: search-api.dev.gov.uk, search.dev.gov.uk

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - nginx-proxy
       - asset-manager-app
       - publishing-api-app
+      - whitehall-worker
     environment:
       GOVUK_PROXY_STATIC_ENABLED: "true"
       DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_development"


### PR DESCRIPTION
> Note: I've only just started working on search and it is _entirely_ possible that some of the things I've changed are intentional and I'm misunderstanding some parts (and this could break people's workflows). Please be extra vigilant and don't assume I must know what I'm doing! 🐛 

This is a set of changes I have had to make to get to a point where I can reliably publish a document in `whitehall` and get it to show up in `finder-frontend`. Several apps either intentionally or accidentally weren't able to talk to their service dependencies, or refused to build or start.

- Add missing RabbitMQ configuration to `publishing-api-app` and `publishing-api-worker`
  - This is causing `publishing-api-worker` to be unable to listen to the message queue, leading to errors and missing data
- Configure `router-app` to not require VCS information at build time using `GOFLAGS`
  - In some (possibly non-deterministic for me) circumstances, `router-app` refuses to build with a Go error: "error obtaining VCS status: exit status 128", which this works around
- Add missing `ROUTER_NODES` environment variable to `router-api-app`
  - This is causing `router-api-app` to be unable to talk to `router-app` running as part of GOV.UK Docker (it tries to find it on localhost), causing errors when upstream applications try to add new routes
- Add RabbitMQ configuration to main `search-api-app`
  - The lack of config (it's set in the `x-search-api` anchor template but overwritten by the `search-api-app` configuration) is causing some setup tasks to fail as the app cannot talk to RabbitMQ
- Add dependency on `whitehall-worker` to `whitehall-app`
  - This currently isn't a dependency, so it isn't starting the worker when starting the app, leading to background tasks never running