### PR TITLE
Replace MongoDB with Postgres for Router API

### DIFF
--- a/projects/router-api/Makefile
+++ b/projects/router-api/Makefile
@@ -1,1 +1,3 @@
 router-api: bundle-router-api router
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup

--- a/projects/router-api/docker-compose.yml
+++ b/projects/router-api/docker-compose.yml
@@ -20,20 +20,19 @@ services:
   router-api-lite:
     <<: *router-api
     depends_on:
-      # In production this uses Mongo 2.6, however there is not a published Mongo 2.6 image compatible with ARM64
-      - mongo-3.6
+      - postgres-14
     environment:
-      MONGODB_URI: "mongodb://mongo-3.6/router"
-      TEST_MONGODB_URI: "mongodb://mongo-3.6/router-test"
+      DATABASE_URL: "postgresql://postgres@postgres-14/router-api"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-14/router-api-test"
 
   router-api-app: &router-api-app
     <<: *router-api
     depends_on:
-      - mongo-3.6
+      - postgres-14
       - router-app
       - nginx-proxy
     environment:
-      MONGODB_URI: "mongodb://mongo-3.6/router"
+      DATABASE_URL: "postgresql://postgres@postgres-14/router-api"
       VIRTUAL_HOST: router-api.dev.gov.uk
       BINDING: 0.0.0.0
     expose:


### PR DESCRIPTION
To test the switch locally

https://trello.com/c/yfns2j8R/1749-use-postgres-for-router-api-in-govuk-docker-s