### PR TITLE
Add Whitehall-dbg run option for IDE debugging

### DIFF
--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -53,6 +53,25 @@ services:
       - "3000"
     command: bin/rails s --restart
 
+  whitehall-dbg: &whitehall-dbg
+    <<: *whitehall
+    depends_on:
+      - mysql-8
+      - redis
+      - static-app
+      - nginx-proxy
+      - asset-manager-app
+      - publishing-api-app
+    environment:
+      GOVUK_PROXY_STATIC_ENABLED: "true"
+      DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_development"
+      REDIS_URL: redis://redis
+      VIRTUAL_HOST: whitehall-admin.dev.gov.uk, whitehall-frontend.dev.gov.uk
+      BINDING: 0.0.0.0
+    expose:
+      - "3000"
+    command: bundle exec rdbg -n -O -- bin/rails server --restart
+
   whitehall-worker:
     <<: *whitehall
     depends_on:


### PR DESCRIPTION
* # What
* Added new run option for Whitehall-dbg that runs remote debug
* # Why
* Ease of Whitehall usage
* # Whitehall PR Link
* https://github.com/alphagov/whitehall/pull/7523