### PR TITLE
Upgrade node to v18.16.0

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -12,7 +12,7 @@ RUN apt-get update -qq && apt-get install -y chromium chromium-driver
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1
 
 # Install node / yarn
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y yarn nodejs

--- a/projects/asset-manager/Dockerfile
+++ b/projects/asset-manager/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -qq && apt-get install -y chromium chromium-driver
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1
 
 # Install node / yarn
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y yarn nodejs

--- a/projects/whitehall/Dockerfile
+++ b/projects/whitehall/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update -qq && apt-get install -y chromium chromium-driver
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1
 
 # Install node / yarn
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
 RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq && apt-get install -y yarn nodejs


### PR DESCRIPTION
Node.js 16 support will end, therefore, an upgrade to v18.16.0 has been made. 

https://nodejs.org/en/blog/announcements/nodejs16-eol

`govuk-docker run govuk-docker-lite node -v` -> `v18.16.0`
`govuk-docker run asset-manager-lite node -v` -> `v18.16.0`
`govuk-docker run whitehall-lite node -v` -> `v18.16.0`

Trello: https://trello.com/c/SOmvaQgr/3135-upgrade-nodejs-from-v16-to-v18-3