### PR TITLE
Add TEST_DATABASE_URL for Release

### DIFF
--- a/projects/release/docker-compose.yml
+++ b/projects/release/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     environment:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       DATABASE_URL: "mysql2://root:root@mysql-8/release_development"
+      TEST_DATABASE_URL: "mysql2://root:root@mysql-8/release_test"
 
   release-app:
     <<: *release


### PR DESCRIPTION
`make release` was failing with:

    Mysql2::Error::ConnectionError: Can't connect to local MySQL server through
    socket '/run/mysqld/mysqld.sock'

in the `env RAILS_ENV=test bin/rake db:prepare` step as it couldn't connect to the release_test DB because it didn't exist.  This ensures the DB is created and we can connect to it with correct credentials.