### PR TITLE
Add ability to run some frontends apps against integration data

### DIFF
--- a/projects/collections/docker-compose.yml
+++ b/projects/collections/docker-compose.yml
@@ -50,3 +50,16 @@ services:
       PLEK_SERVICE_STATIC_URI: https://assets.publishing.service.gov.uk
       VIRTUAL_HOST: collections.dev.gov.uk
       BINDING: 0.0.0.0
+
+  collections-app-integration:
+    <<: *collections-app
+    depends_on:
+      - nginx-proxy
+    environment:
+      GOVUK_WEBSITE_ROOT: https://www.integration.publishing.service.gov.uk
+      GOVUK_PROXY_STATIC_ENABLED: "true"
+      PLEK_SERVICE_CONTENT_STORE_URI: https://www.integration.publishing.service.gov.uk/api
+      PLEK_SERVICE_SEARCH_API_URI: https://www.integration.publishing.service.gov.uk/api
+      PLEK_SERVICE_STATIC_URI: https://assets.integration.publishing.service.gov.uk
+      VIRTUAL_HOST: collections.dev.gov.uk
+      BINDING: 0.0.0.0

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -61,3 +61,18 @@ services:
       PLEK_SERVICE_STATIC_URI: https://assets.publishing.service.gov.uk
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       BINDING: 0.0.0.0
+
+  finder-frontend-app-integration:
+    <<: *finder-frontend-app
+    depends_on:
+      - account-api-app-live
+      - nginx-proxy
+    environment:
+      PLEK_SERVICE_SEARCH_API_URI: https://www.integration.publishing.service.gov.uk/api
+      PLEK_SERVICE_WHITEHALL_FRONTEND_URI: https://www.integration.publishing.service.gov.uk
+      GOVUK_WEBSITE_ROOT: https://www.integration.publishing.service.gov.uk
+      GOVUK_PROXY_STATIC_ENABLED: "true"
+      PLEK_SERVICE_CONTENT_STORE_URI: https://www.integration.publishing.service.gov.uk/api
+      PLEK_SERVICE_STATIC_URI: https://assets.integration.publishing.service.gov.uk
+      VIRTUAL_HOST: finder-frontend.dev.gov.uk
+      BINDING: 0.0.0.0

--- a/projects/government-frontend/docker-compose.yml
+++ b/projects/government-frontend/docker-compose.yml
@@ -49,3 +49,16 @@ services:
       PLEK_SERVICE_SEARCH_API_URI: https://www.gov.uk/api
       VIRTUAL_HOST: government-frontend.dev.gov.uk
       BINDING: 0.0.0.0
+
+  government-frontend-app-integration:
+    <<: *government-frontend-app
+    depends_on:
+      - nginx-proxy
+    environment:
+      GOVUK_WEBSITE_ROOT: https://www.integration.publishing.service.gov.uk
+      GOVUK_PROXY_STATIC_ENABLED: "true"
+      PLEK_SERVICE_CONTENT_STORE_URI: https://www.integration.publishing.service.gov.uk/api
+      PLEK_SERVICE_STATIC_URI: https://assets.integration.publishing.service.gov.uk
+      PLEK_SERVICE_SEARCH_API_URI: https://www.integration.publishing.service.gov.uk/api
+      VIRTUAL_HOST: government-frontend.dev.gov.uk
+      BINDING: 0.0.0.0


### PR DESCRIPTION
This allows us to run Collections, Finder Frontend and Government Frontend against the data present in the integration environment.

We sometimes use integration to test the running of rake tasks or data migrations, so it is useful to have a local way of testing frontend changes against that data.

The integration app can be started using:

```
govuk-docker-up app-integration
```