### PR TITLE
Add Redis to Release app

### DIFF
--- a/projects/release/docker-compose.yml
+++ b/projects/release/docker-compose.yml
@@ -23,20 +23,24 @@ services:
     <<: *release
     depends_on:
       - mysql-8
+      - redis
     environment:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       DATABASE_URL: "mysql2://root:root@mysql-8/release_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-8/release_test"
+      REDIS_URL: redis://redis
 
   release-app:
     <<: *release
     depends_on:
       - mysql-8
       - nginx-proxy
+      - redis
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/release_development"
       BINDING: 0.0.0.0
       VIRTUAL_HOST: release.dev.gov.uk
+      REDIS_URL: redis://redis
     expose:
       - "3000"
     command: bin/rails s --restart


### PR DESCRIPTION
We've added redis to the Release app in integration, staging and production to enable use of Sidekiq workers.  We want to be able to test them locally.

[Trello](https://trello.com/b/16mTLUnP/platform-security-reliability-doing)