### PR TITLE
Pin Dockerfiles to buildpacks-dep:bullseye

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -3,7 +3,7 @@
 # project and make any changes to it there.
 
 # Install packages for building ruby
-FROM buildpack-deps
+FROM buildpack-deps:bullseye
 
 # Install chromium browser and its webdriver
 RUN apt-get update -qq && apt-get install -y chromium chromium-driver

--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -3,6 +3,8 @@
 # project and make any changes to it there.
 
 # Install packages for building ruby
+# TODO: Change from bullseye to stable tag once we've resolved problems with Ruby and SSL
+#       See https://github.com/alphagov/govuk-docker/pull/666 for more info.
 FROM buildpack-deps:bullseye
 
 # Install chromium browser and its webdriver

--- a/projects/asset-manager/Dockerfile
+++ b/projects/asset-manager/Dockerfile
@@ -1,4 +1,6 @@
 # Install packages for building ruby
+# TODO: Change from bullseye to stable tag once we've resolved problems with Ruby and SSL
+#       See https://github.com/alphagov/govuk-docker/pull/666 for more info.
 FROM buildpack-deps:bullseye
 
 # Install chromium browser and its webdriver

--- a/projects/asset-manager/Dockerfile
+++ b/projects/asset-manager/Dockerfile
@@ -1,5 +1,5 @@
 # Install packages for building ruby
-FROM buildpack-deps
+FROM buildpack-deps:bullseye
 
 # Install chromium browser and its webdriver
 RUN apt-get update -qq && apt-get install -y chromium chromium-driver

--- a/projects/whitehall/Dockerfile
+++ b/projects/whitehall/Dockerfile
@@ -1,4 +1,6 @@
 # Install packages for building ruby
+# TODO: Change from bullseye to stable tag once we've resolved problems with Ruby and SSL
+#       See https://github.com/alphagov/govuk-docker/pull/666 for more info.
 FROM buildpack-deps:bullseye
 
 # Install chromium browser and its webdriver

--- a/projects/whitehall/Dockerfile
+++ b/projects/whitehall/Dockerfile
@@ -1,5 +1,5 @@
 # Install packages for building ruby
-FROM buildpack-deps
+FROM buildpack-deps:bullseye
 
 # Install chromium browser and its webdriver
 RUN apt-get update -qq && apt-get install -y chromium chromium-driver


### PR DESCRIPTION
I ran into a problem this morning when running `make publishing-api`. It was failing with the following error:

```
LoadError: libssl.so.1.1: cannot open shared object file: No such file or directory - /root/.rbenv/versions/3.1.2/lib/ruby/3.1.0/x86_64-linux/openssl.so
/govuk/publishing-api/config/application.rb:3:in `<main>'
/govuk/publishing-api/Rakefile:4:in `<main>'
(See full trace by running task with --trace)
make: ***
[/home/chrisroos/govuk/govuk-docker/projects/publishing-api/Makefile:2:publishing-api] Error 1
```

By not specifying a tag of the buildpack-deps image we were implicitly using `latest` which, [as far as I can tell][1], is the same as `stable`. The [`stable` tag was recently updated][2] from Debian 11 (Bullseye) to 12 (Bookwork). The upgrade from Debian 11 to 12 brings an upgrade of OpenSSL from 1.1.1n to 3.0.9 and this appears to be the cause of the problems I was seeing.

By specifying the `bullseye` tag I believe we should be retaining the behaviour from before the change to the `stable` tag.

Prior to this change running `make publishing-api`, `make asset-manager` and `make whitehall` all failed with similar SSL problems. After this change they all build successfully.

[1]: https://github.com/docker-library/buildpack-deps/blob/de709c6cb259198ef49cef48f395eac92e2288f2/generate-stackbrew-library.sh#L79
[2]: https://github.com/docker-library/buildpack-deps/commit/9109c788a9e2d5c2103fc74e3ebbf713b459a3fb