### PR TITLE
Fix replicate-mongodb.sh to work on linux

### DIFF
--- a/bin/replicate-mongodb.sh
+++ b/bin/replicate-mongodb.sh
@@ -49,7 +49,7 @@ if [[ -e "$archive_path" ]]; then
   echo "Skipping download - remove ${archive_path} to force a new download on the next run"
 else
   mkdir -p "$archive_dir"
-  remote_file_name=$(aws s3 ls "s3://${bucket}/${hostname}/" | grep "\d-$database.gz" | tail -n1 | sed 's/^.* .* .* //')
+  remote_file_name=$(aws s3 ls "s3://${bucket}/${hostname}/" | grep "[[:digit:]]-$database.gz" | tail -n1 | sed 's/^.* .* .* //')
   aws s3 cp "s3://${bucket}/${hostname}/${remote_file_name}" "$archive_path"
 fi
 
@@ -65,7 +65,7 @@ if [[ -d "$extract_path" ]]; then
 fi
 mkdir -p "$extract_path"
 
-pv "$archive_path" | gunzip | tar -zx -f - -C "$extract_path" "${database}"
+pv "$archive_path" | gunzip | tar -x -f - -C "$extract_path" "${database}"
 
 echo "stopping running govuk-docker containers..."
 govuk-docker down


### PR DESCRIPTION
The `\d` in the regexp passed to grep isn't supported in the GNU version of grep. I understand that the equivalent `[[:digit:]]` should work in all implementations.

The `-z` option to `tar` results in the following error on linux:

```
gzip: stdin: not in gzip format
tar: Child died with signal 13
tar: Error is not recoverable: exiting now
```

The `-z` option filters the output through gzip but I don't believe this is necessary because we're explicitly `gunzip`ing the dump before passing it to `tar`.

With these two changes the script runs without error on my linux development environment.