### PR TITLE
Enable production-like logging in development

### DIFF
--- a/docs/how-tos.md
+++ b/docs/how-tos.md
@@ -92,3 +92,8 @@ GOV.UK Docker should respect the following environment variables:
 - `$GOVUK_ROOT_DIR` - directory where app repositories live, defaults to `$HOME/govuk`
 - `$GOVUK_DOCKER_DIR` - directory where the govuk-docker repository lives, defaults to `$GOVUK_ROOT_DIR/govuk-docker`
 - `$GOVUK_DOCKER` - path of the govuk-docker script, defaults to `$GOVUK_DOCKER_DIR/bin/govuk-docker`
+
+
+## How to: enable production JSON logs in development
+
+- Set `GOVUK_RAILS_JSON_LOGGING` to `"true"` in `docker-compose.yml` for the application you would like to enable the logs' behaviour for.

--- a/nginx-proxy.conf
+++ b/nginx-proxy.conf
@@ -12,6 +12,13 @@ map $http_x_forwarded_host $proxy_x_forwarded_host {
 
 proxy_set_header X-Forwarded-Host $proxy_x_forwarded_host;
 
+map $http_govuk_request_id $govuk_request_id {
+  default $http_govuk_request_id;
+  ''      $request_id;
+}
+
+proxy_set_header GOVUK-Request-Id $govuk_request_id;
+
 # Required for external assets of frontend apps
 add_header 'Access-Control-Allow-Origin' '*';
 


### PR DESCRIPTION
We want to allow production-like logging behaviour in development. As part of this behaviour we are setting GOVUK-Request-Id header.

[Trello card](https://trello.com/c/niLCNflj/117-story-enable-production-like-logging-in-dev-environments)