### PR TITLE
Add Integration version for content-data-admin

### DIFF
--- a/projects/content-data-admin/docker-compose.yml
+++ b/projects/content-data-admin/docker-compose.yml
@@ -54,3 +54,6 @@ services:
       #CONTENT_DATA_API_BEARER_TOKEN: <get a content-data-api token from https://signon.integration.publishing.service.gov.uk/api_users>
       PLEK_SERVICE_CONTENT_DATA_API_URI: "https://content-data-api.integration.publishing.service.gov.uk"
       BINDING: 0.0.0.0
+      #SITE_IMPROVE_SITE_ID: <get a site id from SiteImprove Dashboard>
+      #SITE_IMPROVE_API_CLIENT_USERNAME: <email address of SiteImprove API Key>
+      #SITE_IMPROVE_API_CLIENT_PASSWORD: <password of SiteImprove API Key>

--- a/projects/content-data-admin/docker-compose.yml
+++ b/projects/content-data-admin/docker-compose.yml
@@ -54,6 +54,6 @@ services:
       #CONTENT_DATA_API_BEARER_TOKEN: <get a content-data-api token from https://signon.integration.publishing.service.gov.uk/api_users>
       PLEK_SERVICE_CONTENT_DATA_API_URI: "https://content-data-api.integration.publishing.service.gov.uk"
       BINDING: 0.0.0.0
-      #SITE_IMPROVE_SITE_ID: <get a site id from SiteImprove Dashboard>
-      #SITE_IMPROVE_API_CLIENT_USERNAME: <email address of SiteImprove API Key>
-      #SITE_IMPROVE_API_CLIENT_PASSWORD: <password of SiteImprove API Key>
+      #SITEIMPROVE_SITE_ID: <get a site id from Siteimprove Dashboard>
+      #SITEIMPROVE_API_CLIENT_USERNAME: <email address of Siteimprove API Key>
+      #SITEIMPROVE_API_CLIENT_PASSWORD: <password of Siteimprove API Key>

--- a/projects/content-data-admin/docker-compose.yml
+++ b/projects/content-data-admin/docker-compose.yml
@@ -41,3 +41,16 @@ services:
       DATABASE_URL: "postgresql://postgres@postgres-13/content-data-admin"
       VIRTUAL_HOST: content-data-admin.dev.gov.uk
       BINDING: 0.0.0.0
+
+  content-data-admin-app-integration:
+    <<: *content-data-admin-app
+    depends_on:
+      - content-data-api-app
+      - nginx-proxy
+      - postgres-13
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres-13/content-data-admin"
+      VIRTUAL_HOST: content-data-admin.dev.gov.uk
+      #CONTENT_DATA_API_BEARER_TOKEN: <get a content-data-api token from https://signon.integration.publishing.service.gov.uk/api_users>
+      PLEK_SERVICE_CONTENT_DATA_API_URI: "https://content-data-api.integration.publishing.service.gov.uk"
+      BINDING: 0.0.0.0


### PR DESCRIPTION
Adds in an integration version of content-data-admin ( since content-data-api DB is 23 Gb, and can't be easily grabbed for quick development).