### PR TITLE
Pass through the DISABLE_ASSETS_DEBUG env var

### DIFF
--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -50,6 +50,7 @@ services:
       REDIS_URL: redis://redis
       VIRTUAL_HOST: whitehall-admin.dev.gov.uk, whitehall-frontend.dev.gov.uk
       BINDING: 0.0.0.0
+      DISABLE_ASSETS_DEBUG:
     expose:
       - "3000"
     command: bin/rails s --restart


### PR DESCRIPTION
This change makes it possible to pass through the value of environment variable `DISABLE_ASSETS_DEBUG` from the host machine.

Setting this environment variable to "true" (or anything that is considered non-nil) will stop Whitehall from running the Asset Pipeline in 'debug' mode when in development.

As described in [the Whitehall config][1], the application runs significantly faster when debug mode is switched off. But it's switched on by default.

Debug mode is useful when you're making changes to CSS and JS files, and you want to be able to reload the page of your running app and see the results.

But if you're not changing CSS or JS files, you can speed things up by compiling the assets once using:

```
$ govuk-docker-run rails assets:precompile
```

and then booting your app with:

```
$ DISABLE_ASSETS_DEBUG=true govuk-docker-up
```

Changes to CSS and JS files won't be reflected until you re-compile the assets, or reboot the app with debug mode enabled.

[1]: https://github.com/alphagov/whitehall/blob/0327123c8f06fd73292be7869be40fd509027b59/config/environments/development.rb#L74-L77