### PR TITLE
Add search-api-v2 project

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,7 @@ services:
           - router.dev.gov.uk
           - search-admin.dev.gov.uk
           - search-api.dev.gov.uk
+          - search-api-v2.dev.gov.uk
           - search.dev.gov.uk
           - service-manual-publisher.dev.gov.uk
           - short-url-manager.dev.gov.uk

--- a/projects/search-api-v2/Makefile
+++ b/projects/search-api-v2/Makefile
@@ -1,0 +1,1 @@
+search-api-v2: bundle-search-api-v2

--- a/projects/search-api-v2/docker-compose.yml
+++ b/projects/search-api-v2/docker-compose.yml
@@ -1,0 +1,31 @@
+x-search-api-v2: &search-api-v2
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: search-api-v2
+  stdin_open: true
+  tty: true
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - search-api-v2-tmp:/govuk/search-api-v2/tmp
+    - root-home:/root
+  working_dir: /govuk/search-api-v2
+
+volumes:
+  search-api-v2-tmp:
+
+services:
+  search-api-v2-lite:
+    <<: *search-api-v2
+
+  search-api-v2-app:
+    <<: *search-api-v2
+    depends_on:
+      - nginx-proxy
+    environment:
+      RAILS_DEVELOPMENT_HOSTS: search-api-v2.dev.gov.uk
+      VIRTUAL_HOST: search-api-v2.dev.gov.uk
+      BINDING: 0.0.0.0
+    expose:
+      - "3000"
+    command: bin/rails server --restart


### PR DESCRIPTION
[search-api-v2](https://github.com/alphagov/search-api-v2) will be replacing parts of the existing search-api project in the short term (and possibly more of it in the long term).

This adds a trivial set of configuration to get it running locally and will be extended once the app starts doing useful things.