### PR TITLE
Fix static URL for assets

### DIFF
--- a/projects/asset-manager/docker-compose.yml
+++ b/projects/asset-manager/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - redis
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/asset-manager"
+      FAKE_S3_HOST: "http://asset-manager.dev.gov.uk"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/asset-manager-test"
       REDIS_URL: redis://redis
 
@@ -39,6 +40,7 @@ services:
       - asset-manager-worker
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/asset-manager"
+      FAKE_S3_HOST: "http://asset-manager.dev.gov.uk"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: asset-manager.dev.gov.uk
       BINDING: 0.0.0.0
@@ -55,6 +57,6 @@ services:
       MONGODB_URI: "mongodb://mongo-3.6/asset-manager"
       REDIS_URL: redis://redis
       ASSET_MANAGER_CLAMSCAN_PATH: /bin/true
-      FAKE_S3_HOST: http://127.0.0.1
+      FAKE_S3_HOST: "http://asset-manager.dev.gov.uk"
       ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS: "true"
     command: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -30,6 +30,7 @@ services:
       - redis
     environment:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
+      GOVUK_ASSET_ROOT: "http://asset-manager.dev.gov.uk"
       DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_test"
       REDIS_URL: redis://redis
@@ -46,6 +47,7 @@ services:
       - whitehall-worker
     environment:
       GOVUK_PROXY_STATIC_ENABLED: "true"
+      GOVUK_ASSET_ROOT: "http://asset-manager.dev.gov.uk"
       DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_development"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: whitehall-admin.dev.gov.uk, whitehall-frontend.dev.gov.uk


### PR DESCRIPTION
In local dev assets in Whitehall are currently served using a static domain
e.g.http://static.dev.gov.uk/government/uploads/system/uploads/image_data/file/15/Screenshot_2023-04-30_at_22.15.58.png. 
It should be served from asset manager instead.
i.e. http://asset-manager.dev.gov.uk. 
This will enable correct rendering correct of assets.