### PR TITLE
Update `finder-frontend` stack for new search API

### DIFF
--- a/projects/finder-frontend/Makefile
+++ b/projects/finder-frontend/Makefile
@@ -1,2 +1,2 @@
-finder-frontend: bundle-finder-frontend account-api content-store frontend static search-api router email-alert-api
+finder-frontend: bundle-finder-frontend account-api content-store frontend static search-api search-api-v2 router email-alert-api
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - nginx-proxy
       - router-app
       - search-api-app
+      - search-api-v2-app
       - static-app
     environment:
       GOVUK_PROXY_STATIC_ENABLED: "true"


### PR DESCRIPTION
- Add `search-api-v2-app` as an additional dependency to `finder-frontend-app` in preparation for it being consumed from `finder-frontend`