### PR TITLE
Switch RabbitMQ to image with management tools

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,9 @@ services:
     image: redis
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:management
+    ports:
+      - 15672:15672
     volumes:
       - rabbitmq:/var/lib/rabbitmq
 


### PR DESCRIPTION
RabbitMQ Docker images offer a `management` tag, which is equivalent to `latest` but comes with the first party RabbitMQ [management plugin](https://www.rabbitmq.com/management.html) installed.

This change means developers using `govuk-docker` can now access the RabbitMQ management interface to inspect and debug RabbitMQ on `http://localhost:15672` whenever using part of the stack that depends on RabbitMQ.