### PR TITLE
Configure RabbitMQ for search APIs

### DIFF
--- a/projects/search-api-v2/docker-compose.yml
+++ b/projects/search-api-v2/docker-compose.yml
@@ -22,7 +22,9 @@ services:
     <<: *search-api-v2
     depends_on:
       - nginx-proxy
+      - rabbitmq
     environment:
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq
       RAILS_DEVELOPMENT_HOSTS: search-api-v2.dev.gov.uk
       VIRTUAL_HOST: search-api-v2.dev.gov.uk
       BINDING: 0.0.0.0

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -12,10 +12,7 @@ x-search-api: &search-api
     - root-home:/root
   working_dir: /govuk/search-api
   environment:
-    RABBITMQ_HOSTS: rabbitmq
-    RABBITMQ_VHOST: /
-    RABBITMQ_USER: guest
-    RABBITMQ_PASSWORD: guest
+    RABBITMQ_URL: amqp://guest:guest@rabbitmq
     REDIS_URL: redis://redis
     ELASTICSEARCH_URI: http://elasticsearch-6:9200
 
@@ -38,10 +35,7 @@ services:
       - search-api-listener-insert-data
       - search-api-listener-bulk-insert-data
     environment:
-      RABBITMQ_HOSTS: rabbitmq
-      RABBITMQ_VHOST: /
-      RABBITMQ_USER: guest
-      RABBITMQ_PASSWORD: guest
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq
       REDIS_URL: redis://redis
       ELASTICSEARCH_URI: http://elasticsearch-6:9200
       VIRTUAL_HOST: search-api.dev.gov.uk, search.dev.gov.uk


### PR DESCRIPTION
- Change `search-api` to use `RABBITMQ_URL` instead of deprecated individual environment variables
- Add `RABBITMQ_URL` and RabbitMQ dependency to `search-api-v2`