### PR TITLE
Remove reference to transition-config project

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -87,4 +87,3 @@ These repos are used as part of running the live GOV.UK site. Since all of them 
    - ✅ plek
    - ❌ slimmer
    - ✅ smokey
-   - ❌ transition-config


### PR DESCRIPTION
https://trello.com/c/8lQCsx3y/862-identify-all-things-related-to-transition-config-elsewhere-in-alphagov-and-update-or-remove-the-references

The transition-config project has been retired.

Contrary to what this doc says, it doesn't look like it was ever included in the generic-ruby-library project and I don't think there's anything else that needs updating to reflect this change.