### PR TITLE
Set `shm_size` to fix Transition's browser tests

### DIFF
--- a/projects/transition/docker-compose.yml
+++ b/projects/transition/docker-compose.yml
@@ -19,6 +19,7 @@ x-transition: &transition
 services:
   transition-lite:
     <<: *transition
+    shm_size: 512mb
     depends_on:
       - postgres-13
       - redis


### PR DESCRIPTION
Increase the amount of shared memory allocated to transition-lite containers to enable its browser-based tests to run.

I've made this change after encountering a load of `Selenium::WebDriver::Error::InvalidSessionIdError`s and following the the advice in the docs[^1] and the changes made for other projects[^2].

[^1]: https://github.com/alphagov/govuk-docker/blob/e99212cafd034fcabd2d5a6c52086388ac983e2e/docs/troubleshooting.md#browser-based-tests-fail-with-nosuchsessionerror-invalid-session-id
[^2]: https://github.com/alphagov/govuk-docker/pull/613/commits/11218f491346c408fd83702a5ba18f5c5a1dffad