### PR TITLE
Set up Google environment for `search-api-v2`

### DIFF
--- a/projects/search-api-v2/Makefile
+++ b/projects/search-api-v2/Makefile
@@ -1,2 +1,22 @@
-search-api-v2: bundle-search-api-v2
+search-api-v2: prerequisites-search-api-v2 bundle-search-api-v2
 	$(GOVUK_DOCKER) run $@-lite bundle exec rake document_sync_worker:create_queue
+
+BOLD_RED=\033[1;31m
+REG_RED=\033[0;31m
+RESET=\033[0m
+
+define SEARCH_API_V2_WARN_GCLOUD
+\033[1;31mWarning: gcloud not found on PATH.\n\
+\033[0;31msearch-api-v2 requires credentials from the gcloud CLI to access Google Cloud Platform. \
+These are mounted into the container. See the README for details.\033[0m
+endef
+
+define SEARCH_API_V2_WARN_DATASTORE
+\033[1;31mWarning: DISCOVERY_ENGINE_DATASTORE environment variable is not set.\
+\n\033[0;31mYou need to set this environment variable locally before running govuk-docker up,\
+otherwise the app will not be able to access Discovery Engine. See the README for details.\033[0m
+endef
+
+prerequisites-search-api-v2:
+	@command -v gcloud >/dev/null 2>&1 || { echo "$(SEARCH_API_V2_WARN_GCLOUD)"; }
+	@[ -n "$${DISCOVERY_ENGINE_DATASTORE}" ] || { echo "$(SEARCH_API_V2_WARN_DATASTORE)"; }

--- a/projects/search-api-v2/docker-compose.yml
+++ b/projects/search-api-v2/docker-compose.yml
@@ -9,6 +9,9 @@ x-search-api-v2: &search-api-v2
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - search-api-v2-tmp:/govuk/search-api-v2/tmp
     - root-home:/root
+    # Mount the host's gcloud config directory into the container so that the app can use
+    # Application Default Credentials (required to use Discovery Engine locally)
+    - "~/.config/gcloud:/root/.config/gcloud:delegated"
   working_dir: /govuk/search-api-v2
 
 volumes:
@@ -30,11 +33,16 @@ services:
       - rabbitmq
       - search-api-v2-document-sync-worker
     environment:
-      RABBITMQ_URL: amqp://guest:guest@rabbitmq
-      PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: search_api_v2_published_documents
-      RAILS_DEVELOPMENT_HOSTS: search-api-v2.dev.gov.uk
-      VIRTUAL_HOST: search-api-v2.dev.gov.uk
-      BINDING: 0.0.0.0
+      RABBITMQ_URL: "amqp://guest:guest@rabbitmq"
+      PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: "search_api_v2_published_documents"
+      RAILS_DEVELOPMENT_HOSTS: "search-api-v2.dev.gov.uk"
+      VIRTUAL_HOST: "search-api-v2.dev.gov.uk"
+      BINDING: "0.0.0.0"
+      # The fully qualified ID of the datastore on Discovery Engine (required to use Discovery
+      # Engine locally, can be set on `govuk-docker up` invocation or permanently in your local
+      # environment)
+      # e.g. "projects/search-api-v2-dev/locations/global/collections/default_collection/dataStores/local-my-name"
+      DISCOVERY_ENGINE_DATASTORE: "${DISCOVERY_ENGINE_DATASTORE}"
     expose:
       - "3000"
     command: bin/rails server --restart
@@ -44,6 +52,11 @@ services:
     depends_on:
       - rabbitmq
     environment:
-      RABBITMQ_URL: amqp://guest:guest@rabbitmq
-      PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: search_api_v2_published_documents
+      RABBITMQ_URL: "amqp://guest:guest@rabbitmq"
+      PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: "search_api_v2_published_documents"
+      # The fully qualified ID of the datastore on Discovery Engine (required to use Discovery
+      # Engine locally, can be set on `govuk-docker up` invocation or permanently in your local
+      # environment)
+      # e.g. "projects/search-api-v2-dev/locations/global/collections/default_collection/dataStores/local-my-name"
+      DISCOVERY_ENGINE_DATASTORE: "${DISCOVERY_ENGINE_DATASTORE}"
     command: bin/rake document_sync_worker:run

--- a/spec/integration/make/dependencies_spec.rb
+++ b/spec/integration/make/dependencies_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Make dependencies" do
 
     it "has only valid dependencies in the #{project_name} Makefile" do
       app_dependencies = MakefileHelper.dependencies(project_name)
-        .reject { |dep| dep =~ /^(bundle|clone)/ }
+        .reject { |dep| dep =~ /^(bundle|clone|prerequisites)/ }
 
       expect((app_dependencies - ProjectsHelper.all_projects)).to eq([])
     end


### PR DESCRIPTION
This allows an engineer working on `search-api-v2` using GOV.UK Docker to authenticate on their host machine using `gcloud` and set an environment variable for their datastore in the dev GCP environment.

- Add mounting of `~/.config/gcloud` into the `search-api-v2` containers
- Add mirroring of local `DISCOVERY_ENGINE_DATASTORE` environment variable into containers
- Add checks to the Makefile to ensure user setup is correct
- Except `prerequisites` Make tasks from project name validation