### PR TITLE
Fix MongoDB replication for 'other' apps

### DIFF
--- a/bin/replicate-mongodb.sh
+++ b/bin/replicate-mongodb.sh
@@ -34,7 +34,7 @@ case "$app" in
     database=govuk_assets_production
     ;;
   *)
-    hostname=mongo
+    hostname=mongo-normal
     database="${app//-/_}_production"
     ;;
 esac


### PR DESCRIPTION
Some apps have special rules defined in the MongoDB replication script because their database dumps are stored in a special location.

For everything else, there's a bucket called "mongo-normal" in the S3 bucket "govuk-integration-database-backups". For example, the database backups for Travel Advice Publisher are stored under "s3://govuk-integration-database-backups/mongo-normal/".

It looks like the "mongo-normal" directory used to be called "mongo". But that seems to have changed and the MongoDB replication script in this repo has fallen out of date.

Following this change, I'm now able to successfully replicate the Mongo database for Travel Advice Publisher using the command:

```
gds aws govuk-integration-readonly bin/replicate-mongodb.sh travel-advice-publisher
```