### PR TITLE
Add `search-v2-evaluator` app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -147,6 +147,7 @@ services:
           - search-admin.dev.gov.uk
           - search-api.dev.gov.uk
           - search-api-v2.dev.gov.uk
+          - search-v2-evaluator.dev.gov.uk
           - search.dev.gov.uk
           - service-manual-publisher.dev.gov.uk
           - short-url-manager.dev.gov.uk

--- a/projects/search-v2-evaluator/Makefile
+++ b/projects/search-v2-evaluator/Makefile
@@ -1,0 +1,2 @@
+search-v2-evaluator: bundle-search-v2-evaluator search-api-v2
+	$(GOVUK_DOCKER) run $@-lite yarn install

--- a/projects/search-v2-evaluator/docker-compose.yml
+++ b/projects/search-v2-evaluator/docker-compose.yml
@@ -1,0 +1,34 @@
+volumes:
+  search-v2-evaluator-tmp:
+  search-v2-evaluator-node-modules:
+
+x-search-v2-evaluator: &search-v2-evaluator
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: search-v2-evaluator
+  tty: true
+  stdin_open: true
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - root-home:/root
+    - search-v2-evaluator-tmp:/govuk/search-v2-evaluator/tmp
+    - search-v2-evaluator-node-modules:/govuk/search-v2-evaluator/node_modules
+  working_dir: /govuk/search-v2-evaluator
+
+services:
+  search-v2-evaluator-lite:
+    <<: *search-v2-evaluator
+
+  search-v2-evaluator-app: &search-v2-evaluator-app
+    <<: *search-v2-evaluator
+    depends_on:
+      - nginx-proxy
+      - search-api-v2-app
+    environment:
+      VIRTUAL_HOST: search-v2-evaluator.dev.gov.uk
+      RAILS_DEVELOPMENT_HOSTS: "search-v2-evaluator.dev.gov.uk,search-v2-evaluator"
+      BINDING: 0.0.0.0
+    expose:
+      - "3000"
+    command: bin/rails server --restart


### PR DESCRIPTION
This is a short-lived app that will be used internally to try out and rate the new search engine used by `search-api-v2`.