### PR TITLE
Add postgres container with email-alert-api role

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ volumes:
   rabbitmq:
   postgres-12:
   postgres-13:
+  postgres-13-email-alert-api:
   postgres-14:
   postgres-14-postgis:
   mysql-8:
@@ -30,6 +31,14 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - postgres-13:/var/lib/postgresql/data
+
+  postgres-13-email-alert-api:
+    image: postgres:13
+    environment:
+      POSTGRES_USER: email-alert-api
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - postgres-13-email-alert-api:/var/lib/postgresql/data
 
   postgres-14:
     image: postgres:14

--- a/projects/email-alert-api/docker-compose.yml
+++ b/projects/email-alert-api/docker-compose.yml
@@ -20,25 +20,21 @@ services:
   email-alert-api-lite:
     <<: *email-alert-api
     depends_on:
-      # The version of PostgreSQL temporarily does not match
-      # production, as an upgrade in production is being worked on
-      #
-      # https://trello.com/c/ZMFOPaCl/1176-upgrade-our-app-databases
-      - postgres-13
+      - postgres-13-email-alert-api
       - redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/email-alert-api"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/email-alert-api-test"
+      DATABASE_URL: "postgresql://email-alert-api@postgres-13-email-alert-api/email-alert-api"
+      TEST_DATABASE_URL: "postgresql://email-alert-api@postgres-13-email-alert-api/email-alert-api-test"
       REDIS_URL: redis://redis
 
   email-alert-api-app: &email-alert-api-app
     <<: *email-alert-api
     depends_on:
       - nginx-proxy
-      - postgres-13
+      - postgres-13-email-alert-api
       - redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/email-alert-api"
+      DATABASE_URL: "postgresql://email-alert-api@postgres-13-email-alert-api/email-alert-api"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: email-alert-api.dev.gov.uk
       BINDING: 0.0.0.0
@@ -49,9 +45,9 @@ services:
   email-alert-api-worker:
     <<: *email-alert-api
     depends_on:
-      - postgres-13
+      - postgres-13-email-alert-api
       - redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/email-alert-api"
+      DATABASE_URL: "postgresql://email-alert-api@postgres-13-email-alert-api/email-alert-api"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
- allows container to run with role that matches the hygiene script
- remove obsolete comment

Not sure if there's a smoother way to do this.