### PR TITLE
Fix data replication script for search-api

### DIFF
--- a/bin/replicate-elasticsearch.sh
+++ b/bin/replicate-elasticsearch.sh
@@ -28,7 +28,6 @@ echo "
   cluster.name: 'docker-cluster'
   network.host: 0.0.0.0
   discovery.zen.minimum_master_nodes: 1
-  path.repo: ['/replication']
 " > "$cfg_path"
 
 echo "stopping running govuk-docker containers..."

--- a/services/elasticsearch-6/elasticsearch.yml
+++ b/services/elasticsearch-6/elasticsearch.yml
@@ -5,3 +5,4 @@ xpack.ml.enabled: false
 http.host: 0.0.0.0
 transport.host: 127.0.0.1
 xpack.security.enabled: false
+path.repo: ["/replication"]


### PR DESCRIPTION
When trying to replicate `search-api` data locally via `$ gds aws govuk-integration-poweruser --assume-role-ttl 180m ./bin/replicate-elasticsearch.sh` - the result was an error...

```json
{"error":{"root_cause":[{"type":"repository_exception","reason":"[snapshots] location [/usr/share/replication] doesn't match any of the locations specified by path.repo because this setting is empty"}],"type":"repository_exception","reason":"[snapshots] failed to create repository","caused_by":{"type":"repository_exception","reason":"[snapshots] location [/usr/share/replication] doesn't match any of the locations specified by path.repo because this setting is empty"}},"status":500}
```

After a lot of trial-and-error and investigation where we saw the elasticesearch config YAML file reporting as a directory! And what appeared to be a user (docker image user) permissions issue. Finally, I found that by moving the `path.repo` config option into the dummy config file it resolved the issue.