### PR TITLE
Revert "Fix data replication script for search-api"

### DIFF
--- a/bin/replicate-elasticsearch.sh
+++ b/bin/replicate-elasticsearch.sh
@@ -28,6 +28,7 @@ echo "
   cluster.name: 'docker-cluster'
   network.host: 0.0.0.0
   discovery.zen.minimum_master_nodes: 1
+  path.repo: ['/replication']
 " > "$cfg_path"
 
 echo "stopping running govuk-docker containers..."

--- a/services/elasticsearch-6/elasticsearch.yml
+++ b/services/elasticsearch-6/elasticsearch.yml
@@ -5,4 +5,3 @@ xpack.ml.enabled: false
 http.host: 0.0.0.0
 transport.host: 127.0.0.1
 xpack.security.enabled: false
-path.repo: ["/replication"]


### PR DESCRIPTION
Reverts alphagov/govuk-docker#703

Turns out it fixes the data replication script, but breaks the container so that it is unusable for development 😠 