### PR TITLE
Run local content-store on PostgreSQL, not MongoDB

### DIFF
--- a/docs/how-tos.md
+++ b/docs/how-tos.md
@@ -55,7 +55,7 @@ gds aws govuk-integration-readonly --assume-role-ttl 180m ./bin/replicate-postgr
 
 All the scripts, other than `replicate-elasticsearch.sh`, take the name of the app to replicate data for.
 
-Draft data can be replicated with `replicate-mongodb.sh draft-content-store` and `replicate-mongodb.sh draft-router`.
+Draft data can be replicated with `replicate-postgresql.sh draft-content-store` and `replicate-mongodb.sh draft-router`.
 
 If you want to download data without importing it, set the `SKIP_IMPORT` environment variable (to anything).
 

--- a/projects/content-store/docker-compose.yml
+++ b/projects/content-store/docker-compose.yml
@@ -20,20 +20,18 @@ services:
   content-store-lite:
     <<: *content-store
     depends_on:
-      # In production this uses Mongo 2.6, however there is not a published Mongo 2.6 image compatible with Arm64
-      - mongo-3.6
+      - postgres-13
     environment:
-      MONGODB_URI: "mongodb://mongo-3.6/content-store"
-      TEST_MONGODB_URI: "mongodb://mongo-3.6/content-store-test"
-
+      DATABASE_URL: "postgresql://postgres@postgres-13/content-store"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/content-store-test"
   content-store-app: &content-store-app
     <<: *content-store
     depends_on:
-      - mongo-3.6
+      - postgres-13
       - router-api-app
       - nginx-proxy
     environment:
-      MONGODB_URI: "mongodb://mongo-3.6/content-store"
+      DATABASE_URL: "postgresql://postgres@postgres-13/content-store"
       VIRTUAL_HOST: content-store.dev.gov.uk
       BINDING: 0.0.0.0
     expose:


### PR DESCRIPTION
As of Dec 18th 2023, Content Store runs only on PostgreSQL, not MongoDB.

This PR updates the govuk-docker config to reflect that when running locally.

[Trello card](https://trello.com/c/7ODSeoyu/990-update-govuk-docker-to-run-content-store-on-postgresql)