### PR TITLE
Hardcode discovery engine environment variables in search-api-v2

### DIFF
--- a/projects/search-api-v2/Makefile
+++ b/projects/search-api-v2/Makefile
@@ -11,19 +11,5 @@ define SEARCH_API_V2_WARN_GCLOUD
 These are mounted into the container. See the README for details.\033[0m
 endef
 
-define SEARCH_API_V2_WARN_DATASTORE_BRANCH
-\033[1;31mWarning: DISCOVERY_ENGINE_DATASTORE_BRANCH environment variable is not set.\
-\n\033[0;31mYou need to set this environment variable locally before running govuk-docker up,\
-otherwise the app will not be able to access Discovery Engine. See the README for details.\033[0m
-endef
-
-define SEARCH_API_V2_WARN_SERVING_CONFIG
-\033[1;31mWarning: DISCOVERY_ENGINE_SERVING_CONFIG environment variable is not set.\
-\n\033[0;31mYou need to set this environment variable locally before running govuk-docker up,\
-otherwise the app will not be able to access Discovery Engine. See the README for details.\033[0m
-endef
-
 prerequisites-search-api-v2:
 	@command -v gcloud >/dev/null 2>&1 || { echo "$(SEARCH_API_V2_WARN_GCLOUD)"; }
-	@[ -n "$${DISCOVERY_ENGINE_DATASTORE_BRANCH}" ] || { echo "$(SEARCH_API_V2_WARN_DATASTORE_BRANCH)"; }
-	@[ -n "$${DISCOVERY_ENGINE_SERVING_CONFIG}" ] || { echo "$(SEARCH_API_V2_WARN_SERVING_CONFIG)"; }

--- a/projects/search-api-v2/docker-compose.yml
+++ b/projects/search-api-v2/docker-compose.yml
@@ -40,16 +40,11 @@ services:
       RAILS_DEVELOPMENT_HOSTS: "search-api-v2.dev.gov.uk,search-api-v2-app"
       VIRTUAL_HOST: "search-api-v2.dev.gov.uk"
       BINDING: "0.0.0.0"
-      # The fully qualified ID of the datastore branch and engine on the Discovery Engine dev
-      # environment (required to use Discovery Engine locally, can be set on `govuk-docker up`
-      # invocation or permanently in your local environment).
+      # The fully qualified ID of the datastore branch and engine on the Discovery Engine integration
+      # environment (required to use Discovery Engine locally).
       #
-      # e.g. "projects/search-api-v2-dev/locations/global/collections/default_collection/dataStores/
-      #       local-my-name/branches/default_branch"
-      DISCOVERY_ENGINE_DATASTORE_BRANCH: "${DISCOVERY_ENGINE_DATASTORE_BRANCH}"
-      # e.g. "projects/search-api-v2-dev/locations/global/collections/default_collection/dataStores/
-      #       local-my-name/servingConfigs/default_serving_config"
-      DISCOVERY_ENGINE_SERVING_CONFIG: "${DISCOVERY_ENGINE_SERVING_CONFIG}"
+      DISCOVERY_ENGINE_DATASTORE_BRANCH: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/branches/default_branch"
+      DISCOVERY_ENGINE_SERVING_CONFIG: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/servingConfigs/default_search"
     expose:
       - "3000"
     command: bin/rails server --restart
@@ -62,13 +57,8 @@ services:
       RABBITMQ_URL: "amqp://guest:guest@rabbitmq"
       PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: "search_api_v2_published_documents"
       # The fully qualified ID of the datastore branch and serving config on the Discovery Engine
-      # dev environment (required to use Discovery Engine locally, can be set on `govuk-docker up`
-      # invocation or permanently in your local environment).
+      # integration environment (required to use Discovery Engine locally).
       #
-      # e.g. "projects/search-api-v2-dev/locations/global/collections/default_collection/dataStores/
-      #       local-my-name/branches/default_branch"
-      DISCOVERY_ENGINE_DATASTORE_BRANCH: "${DISCOVERY_ENGINE_DATASTORE_BRANCH}"
-      # e.g. "projects/search-api-v2-dev/locations/global/collections/default_collection/dataStores/
-      #       local-my-name/servingConfigs/default_serving_config"
-      DISCOVERY_ENGINE_SERVING_CONFIG: "${DISCOVERY_ENGINE_SERVING_CONFIG}"
+      DISCOVERY_ENGINE_DATASTORE_BRANCH: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/branches/default_branch"
+      DISCOVERY_ENGINE_SERVING_CONFIG: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/servingConfigs/default_search"
     command: bin/rake document_sync_worker:run


### PR DESCRIPTION
We've decided it's easier for the local setup of search-api-v2 to pull in search results from integration whenever search results are needed for local testing rather than making everyone set up their own personal discovery engine on gcloud. Therefore the env var values can be hardcoded rather than being set in the local session.