### PR TITLE
Add a depends_on email-alert-api to content-data

### DIFF
--- a/projects/content-data-admin/Makefile
+++ b/projects/content-data-admin/Makefile
@@ -1,4 +1,4 @@
-content-data-admin: bundle-content-data-admin content-data-api
+content-data-admin: bundle-content-data-admin content-data-api email-alert-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/content-data-admin/docker-compose.yml
+++ b/projects/content-data-admin/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     <<: *content-data-admin
     depends_on:
       - content-data-api-app
+      - email-alert-api-app
       - nginx-proxy
       - postgres-13
     expose:


### PR DESCRIPTION
# Add a dependancy from content-data-admin to email-alert-api
`content-data-admin` now depends on `email-alert-api` to retrieve metrics about the number of email subscriptions.