### PR TITLE
Update s3 bucket and file matching pattern for mongo replication

### DIFF
--- a/bin/replicate-mongodb.sh
+++ b/bin/replicate-mongodb.sh
@@ -30,11 +30,11 @@ case "$app" in
     database="${app//-/_}_production"
     ;;
   "asset-manager")
-    hostname=mongo-normal
+    hostname=shared-documentdb
     database=govuk_assets_production
     ;;
   *)
-    hostname=mongo-normal
+    hostname=shared-documentdb
     database="${app//-/_}_production"
     ;;
 esac
@@ -49,7 +49,7 @@ if [[ -e "$archive_path" ]]; then
   echo "Skipping download - remove ${archive_path} to force a new download on the next run"
 else
   mkdir -p "$archive_dir"
-  remote_file_name=$(aws s3 ls "s3://${bucket}/${hostname}/" | grep "[[:digit:]]-$database.gz" | tail -n1 | sed 's/^.* .* .* //')
+  remote_file_name=$(aws s3 ls "s3://${bucket}/${hostname}/" | grep -e "-$database.gz\>" | tail -n1 | sed 's/^.* .* .* //')
   aws s3 cp "s3://${bucket}/${hostname}/${remote_file_name}" "$archive_path"
 fi
 


### PR DESCRIPTION
We no longer have mongo-normal direcorty in the
[govuk-integration-database-backups](https://s3.console.aws.amazon.com/s3/buckets/govuk-integration-database-backups?region=eu-west-1&bucketType=general&prefix=shared-documentdb/&showversions=false) s3 bucket. Those are now in shared-documentdb.

The file matching also stopped returning file name. It was not updated to match the end of the expression with `\>`