### PR TITLE
Remove unnecessary tap

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -3,7 +3,6 @@ brew "pv"
 brew "shellcheck"
 
 if OS.mac?
-  tap "homebrew/cask"
   cask "docker"
 else
   brew "docker"


### PR DESCRIPTION
When running `bin/setup` as documented [here][1], the error below is logged. Removing `tap "homebrew/cask"` this from the Brewfile allows `bin/setup` to run without issue

```
Error: Tapping homebrew/cask is no longer typically necessary.
Add --force if you are sure you need it done.
Tapping homebrew/cask has failed!
Using docker
Homebrew Bundle failed! 1 Brewfile dependency failed to install.
```

[1]: https://github.com/alphagov/govuk-docker/tree/main?tab=readme-ov-file#installation