### PR TITLE
Change Signon app to work with dart-sass

### DIFF
--- a/projects/signon/docker-compose.yml
+++ b/projects/signon/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       REDIS_URL: redis://redis
     expose:
       - "3000"
-    command: bin/rails s --restart
+    command: ./bin/dev
 
   signon-worker:
     <<: *signon


### PR DESCRIPTION
When I [moved][1] the signon app from libsass to dart-sass following [these instructions][2], I created a new `bin/dev` file which runs two processes in `Procfile.dev`, one of which runs the rails server and another which runs `dart-sass` in watch mode. This updates the `docker-compose.yml` file accordingly.

c.f. https://github.com/alphagov/govuk-docker/pull/714

[1]: alphagov/signon#2709
[2]: https://docs.publishing.service.gov.uk/manual/migrate-to-dart-sass-from-libsass.html