### PR TITLE
Workaround selenium chromium binary detection failure resulting in SessionNotCreatedError when running Jasmine specs

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -9,6 +9,8 @@ FROM buildpack-deps:bullseye
 
 # Install chromium browser and its webdriver
 RUN apt-get update -qq && apt-get install -y chromium chromium-driver
+# Workaround selenium-webdriver failure to detect chromium browser binary
+RUN ln -sf /usr/bin/chromium /usr/bin/chrome
 
 # Enable no-sandbox for chrome so that it can run as a root user
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1


### PR DESCRIPTION
A number of people have been seeing the following error when running Jasmine specs (which use the selenium webdriver node package) in a govuk-docker container on Apple Silicon for a number of different apps:

    SessionNotCreatedError: session not created:
      Chrome failed to start: exited normally.

See [this gist][1] for an example of the full output. Note that the problem has *not* been happening:

* on non-Apple Silicon devices
* in Ruby tests which use the selenium-webdriver gem
* in CI builds which use [the govuk-infrastructure jasmine workflow][2]

Since v4.6, selenium has shipped with [a selenium-manager CLI app][3] written in Rust which aims to act as a fallback provider of browser and driver binaries if they aren't found in the `PATH`. I assume this is why this has only become an issue _relatively_ recently - I first saw it in Signon at least a couple of months ago and have been working around it since!

For some reason the selenium-manager CLI app is not finding the `chromium` binary installed from the `chromium` Debian package by [`Dockerfile.govuk-base`][4] even though it exists in `/usr/bin` which is in the `PATH`. However, it *does* find the `chromedriver` binary which I assume is also installed into `/usr/bin` from the `chromium-driver` Debian package. I can only assume this is due to the name including "chrome" rather than "chromium". You can see this in action by running the selenium-manager CLI app inside an app container as follows:

    root@c4d5514eee6a:/govuk/signon# node_modules/selenium-webdriver/bin/linux/selenium-manager --browser chrome --debug --clear-cache
    DEBUG	Clearing cache at: /root/.cache/selenium
    DEBUG	Found chromedriver 120.0.6099.224 in PATH: /usr/bin/chromedriver
    DEBUG	chrome not found in PATH
    DEBUG	chrome not found in the system
    DEBUG	Discovering versions from https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions-with-downloads.json
    DEBUG	Required browser: chrome 121.0.6167.85
    DEBUG	Downloading chrome 121.0.6167.85 from https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/121.0.6167.85/linux64/chrome-linux64.zip
    DEBUG	chrome 121.0.6167.85 has been downloaded at /root/.cache/selenium/chrome/linux64/121.0.6167.85/chrome
    DEBUG	Discovering versions from https://googlechromelabs.github.io/chrome-for-testing/known-good-versions-with-downloads.json
    DEBUG	Required driver: chromedriver 121.0.6167.85
    WARN	The chromedriver version (120.0.6099.224) detected in PATH at /usr/bin/chromedriver might not be compatible with the detected chrome version (121.0.6167.85); currently, chromedriver 121.0.6167.85 is recommended for chrome 121.*, so it is advised to delete the driver in PATH and retry
    INFO	Driver path: /usr/bin/chromedriver
    INFO	Browser path: /root/.cache/selenium/chrome/linux64/121.0.6167.85/chrome

You can see that while it does find `/usr/bin/chromedriver`, it does *not* find `/usr/bin/chromium`. This means that it downloads a chrome binary from [the Chrome for Testing website][5] and caches it in `/root/.cache/selenium/chrome/linux64/121.0.6167.85/chrome`. This binary does not work in a govuk-docker container running on Apple Silicon - I see the following error if I try to run it:

    qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory

This is the underlying cause of the `SessionNotCreatedError` when running the Jasmine specs.

Although it might not be the best solution, I've worked around the problem by creating a symbolic link for `/usr/bin chrome` (which is what selenium-manager seems to expect to find) to `/usr/bin/chromium` which is what is installed by the chromium Debian package.

I did try changing the `browser` value in `spec/support/jasmine-browser.json` in the relevant app from "headlessChrome" to e.g. "headlessChromium" or "chromium", but nothing seemed to work. And looking at the node package source code, it's not obvious that there is any _explicit_ support for "chromium" as opposed to "chrome". However, it might be worth pursuiing this with the maintainers of the jasmine-browser-runner and/or selenium webdriver node packages.

I also tried setting the `SE_BROWSER_PATH` environment variable mentioned in [these Selenium docs][6], but that didn't seem to work either.

Anyway, my workaround is the best option I've come up with so far, but I'd welcome any other suggestions!

I suspect the reason why this problem is not affecting non-Apple Silicon devices is that the downloaded chrome binary *does* work on those devices. However, it's worth noting that the same problem is almost certainly why the following warning message is appearing on those devices:

    The chromedriver version (120.0.6099.199) detected in PATH at
    /usr/bin/chromedriver might not be compatible with the detected chrome
    version (121.0.6167.85); currently, chromedriver 121.0.6167.85 is
    recommended for chrome 121.*, so it is advised to delete the driver in
    PATH and retry

My workaround should fix that warning too, because the Jasmine specs should use the chromium binary installed by the chromium Debian package as well as the chromedriver binary installed by the chromium-driver Debian package which are compatible versions.

I suspect the reason why this problem is not affecting Ruby tests which use the selenium-webdriver gem is that unlike the node pacakge it has [explicit support for chromium][7].

I suspect the reason why this problem is not affecting CI builds which use the govuk-infrastructure jasmine workflow is that it runs in a GitHub Action runner which runs on `ubuntu-latest` and I suspect that provides a `chrome` binary.

[1]: https://gist.github.com/floehopper/5531ac99ae615e9b5b03b97cb86dfdf0
[2]: https://github.com/alphagov/govuk-infrastructure/blob/af441f9eaab9afad7367f338b1d7e7b269f1642c/.github/workflows/jasmine.yml
[3]: https://www.selenium.dev/documentation/selenium_manager/
[4]: https://github.com/alphagov/govuk-docker/blob/a1bb1eb0f3e8fc415d26a1f4dc1d49a9bdf3e3ab/Dockerfile.govuk-base#L10-L11
[5]: https://googlechromelabs.github.io/chrome-for-testing
[6]: https://www.selenium.dev/documentation/selenium_manager/#configuration
[7]: https://github.com/SeleniumHQ/selenium/tree/trunk/rb/lib/selenium/webdriver/chromium