### PR TITLE
Change content-data-admin to work with dart-sass

### DIFF
--- a/projects/content-data-admin/docker-compose.yml
+++ b/projects/content-data-admin/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - postgres-13
     expose:
       - "3000"
-    command: bin/rails s --restart
+    command: ./bin/dev
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/content-data-admin"
       VIRTUAL_HOST: content-data-admin.dev.gov.uk


### PR DESCRIPTION
The content-data-admin app has been migrated from libsass to dart-sass. It has a new `bin/dev` file which runs two processess in `Procfile.dev`, one which runs the rails server and another which runs `dart-sass` in watch mode. This updates the `docker-compose.yml` file accordingly.

Trello card: https://trello.com/c/kZ3qj2TI/3405-3-migrate-content-data-admin-to-dart-sass