### PR TITLE
Adds govuk-chat repo to available apps

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,7 @@ services:
           - finder-frontend.dev.gov.uk
           - government-frontend.dev.gov.uk
           - govspeak-preview.dev.gov.uk
+          - govuk-chat.dev.gov.uk
           - govuk-developer-docs.dev.gov.uk
           - govuk-publishing-components.dev.gov.uk
           - hmrc-manuals-api.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -40,6 +40,7 @@ These are repos that can be started as a some kind of process, such as a web app
       * **TODO: Missing support for running the worker**
    - ✅ govuk_publishing_components
    - ✅ govuk-developer-docs
+   - ✅ govuk-chat
    - ✅ hmrc-manuals-api
    - ✅ imminence
    - ❌ licensify

--- a/projects/govuk-chat/Makefile
+++ b/projects/govuk-chat/Makefile
@@ -1,0 +1,4 @@
+govuk-chat: bundle-govuk-chat
+	$(GOVUK_DOCKER) run $@-lite bin/rails db:setup
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rails db:prepare
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/govuk-chat/docker-compose.yml
+++ b/projects/govuk-chat/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.7'
+
+volumes:
+  govuk-chat-tmp:
+  govuk-chat-node-modules:
+
+x-govuk-chat: &govuk-chat
+  build:
+    context: .
+    dockerfile: Dockerfile.govuk-base
+  image: govuk-chat
+  stdin_open: true
+  tty: true
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - root-home:/root
+    - govuk-chat-tmp:/govuk/govuk-chat/tmp
+    - govuk-chat-node-modules:/govuk/govuk-chat/node_modules
+  working_dir: /govuk/govuk-chat
+
+services:
+  govuk-chat-lite:
+    <<: *govuk-chat
+    depends_on:
+      - postgres-13
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat-test"
+
+  govuk-chat-app:
+    <<: *govuk-chat
+    depends_on:
+      - nginx-proxy
+      - postgres-13
+    environment:
+      DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
+      VIRTUAL_HOST: govuk-chat.dev.gov.uk
+      BINDING: 0.0.0.0
+    expose:
+      - "3000"
+    command: bin/dev


### PR DESCRIPTION
## Description

Adds govuk-chat repo to the available govuk-docker apps

- At the moment it only links the app and postgresSQL 13 for a basic dev environment
- Adds the db:prepare command to the Makefile, as per this commit: https://github.com/alphagov/govuk-docker/commit/b6eb8eb517fd18e9d97a0b7e6d4e0f2eef3f47e1

## Trello card

https://trello.com/c/h83meZak/1183-add-govuk-chat-to-govuk-docker