### PR TITLE
Update Release to work with Dart Sass

### DIFF
--- a/projects/release/docker-compose.yml
+++ b/projects/release/docker-compose.yml
@@ -43,4 +43,4 @@ services:
       REDIS_URL: redis://redis
     expose:
       - "3000"
-    command: bin/rails s --restart
+    command: ./bin/dev


### PR DESCRIPTION
The Release app has been migrated from libsass to dart-sass. It has a new `bin/dev` file which runs two processess in `Procfile.dev`, one which runs the rails server and another which runs `dart-sass` in watch mode. This updates the `docker-compose.yml` file accordingly.

Trello card: https://trello.com/c/cHty6Sfj/3403-3-migrate-release-app-to-dart-sass