### PR TITLE
Updates mongo replication script for new S3 locations and format

### DIFF
--- a/bin/replicate-mongodb.sh
+++ b/bin/replicate-mongodb.sh
@@ -11,46 +11,42 @@ app="${1//_/-}"
 
 replication_dir="${GOVUK_DOCKER_REPLICATION_DIR:-${GOVUK_DOCKER_DIR:-${GOVUK_ROOT_DIR:-$HOME/govuk}/govuk-docker}/replication}"
 
-bucket="govuk-integration-database-backups"
-
 mongo_version=3.6
 
 case "$app" in
   "router"|"draft-router")
-    hostname=mongo-router
+    instance=router-mongo
     database="${app//-/_}"
     wait_for_rs=1
     ;;
-  "licensify")
-    hostname=mongo-licensing
-    database=licensify
-    ;;
-  "content-store"|"draft-content-store")
-    hostname=mongo-api
-    database="${app//-/_}_production"
-    ;;
   "asset-manager")
-    hostname=mongo-normal
+    instance=shared-documentdb
     database=govuk_assets_production
     ;;
+  "publisher")
+    instance=shared-documentdb
+    database=govuk_content_production
+    ;;
   *)
-    hostname=mongo-normal
+    instance=shared-documentdb
     database="${app//-/_}_production"
     ;;
 esac
 
+folder="govuk-integration-database-backups/$instance"
+
 archive_dir="${replication_dir}/mongodb"
-archive_file="${hostname}.tar.gz"
+archive_file="${database}.gz"
 archive_path="${archive_dir}/${archive_file}"
 
-echo "Replicating mongodb for $app"
+echo "Replicating mongodb for $app from $folder"
 
 if [[ -e "$archive_path" ]]; then
   echo "Skipping download - remove ${archive_path} to force a new download on the next run"
 else
   mkdir -p "$archive_dir"
-  remote_file_name=$(aws s3 ls "s3://${bucket}/${hostname}/" | grep "[[:digit:]]-$database.gz" | tail -n1 | sed 's/^.* .* .* //')
-  aws s3 cp "s3://${bucket}/${hostname}/${remote_file_name}" "$archive_path"
+  remote_file_name=$(aws s3 ls "s3://${folder}/" | grep "[[:digit:]]Z-$database.gz" | tail -n1 | sed 's/^.* .* .* //')
+  aws s3 cp "s3://${folder}/${remote_file_name}" "$archive_path"
 fi
 
 if [[ -n "${SKIP_IMPORT:-}" ]]; then
@@ -58,19 +54,23 @@ if [[ -n "${SKIP_IMPORT:-}" ]]; then
   exit 0
 fi
 
-extract_path="${archive_path}-${app}"
+extract_dir="${archive_dir}/${app}"
+extract_file="${database}"
 
-if [[ -d "$extract_path" ]]; then
-  rm -r "$extract_path"
+if [[ -d "$extract_dir" ]]; then
+  rm -r "$extract_dir"
 fi
-mkdir -p "$extract_path"
+mkdir -p "$extract_dir"
 
-pv "$archive_path" | gunzip | tar -x -f - -C "$extract_path" "${database}"
+echo "Extracting to $extract_dir/$extract_file"
+
+gunzip --stdout "$archive_path" > "$extract_dir/$extract_file"
 
 echo "stopping running govuk-docker containers..."
 govuk-docker down
 
-container=$(govuk-docker run -d --rm -v "${extract_path}:/replication" --name "mongo-${mongo_version}" mongo-${mongo_version} | tail -n1)
+container=$(govuk-docker run --detach --rm --volume "${extract_dir}:/replication" --name "mongo-${mongo_version}" mongo-${mongo_version} | tail -n1)
+
 # we want $container to be expanded now
 # shellcheck disable=SC2064
 trap "docker stop '$container'" EXIT
@@ -86,7 +86,7 @@ until docker exec "$container" mongo --eval 1 &>/dev/null; do
   sleep 1
 done
 
-docker exec "$container" mongorestore --drop --db "$app" "/replication/${database}/"
+docker exec "$container" mongorestore --drop --nsFrom="${database}".* --nsTo="${app}".* --archive="/replication/${extract_file}"
 
 case "$app" in
   "router")
@@ -100,3 +100,4 @@ case "$app" in
       mongo --quiet --eval 'db = db.getSiblingDB("draft-router"); db.backends.find().forEach( function(b) { b.backend_url = b.backend_url.replace(".integration.govuk-internal.digital", ".dev.gov.uk").replace("https","http"); db.backends.save(b); } );'
     ;;
 esac
+


### PR DESCRIPTION
https://trello.com/c/v2WB7RzB/187-504-error-when-searching-and-filtering-in-mainstream-publisher-5631736

These updates are mostly what I needed to get the script to replicate publisher locally, I also removed content store as it's no longer on mongo and licensify as there doesn't appear to be a backup in S3 right now. These are the missing lines covering licensify, updated for what I think the instance should be;
```
    "licensify")
    instance=licensify-documentdb
    database=licensify
    ;;
```