### PR TITLE
Adds sidekiq worker service to govuk-chat

### DIFF
--- a/projects/govuk-chat/docker-compose.yml
+++ b/projects/govuk-chat/docker-compose.yml
@@ -30,12 +30,24 @@ services:
   govuk-chat-app:
     <<: *govuk-chat
     depends_on:
+      - govuk-chat-worker
       - nginx-proxy
       - postgres-13
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
+      REDIS_URL: redis://redis
       VIRTUAL_HOST: govuk-chat.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/dev
+
+  govuk-chat-worker:
+    <<: *govuk-chat
+    depends_on:
+      - redis
+      - postgres-13
+    environment:
+      REDIS_URL: redis://redis
+      DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
+    command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
## Description

Adds sidekiq worker service to govuk-chat
- Adds redis and postgres as dependencies for starters

## Trello card

https://trello.com/c/B3ykgWFN/1191-background-worker-to-generate-an-answer-from-python-chat-api