### PR TITLE
Add redis as dependancy for govuk-chat

### DIFF
--- a/projects/govuk-chat/docker-compose.yml
+++ b/projects/govuk-chat/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - govuk-chat-worker
       - nginx-proxy
       - postgres-13
+      - redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
       REDIS_URL: redis://redis


### PR DESCRIPTION
ActiveJobs have just been added so we need access to redis