### PR TITLE
Remove redundant govuk-chat-worker process

### DIFF
--- a/projects/govuk-chat/docker-compose.yml
+++ b/projects/govuk-chat/docker-compose.yml
@@ -30,7 +30,6 @@ services:
   govuk-chat-app:
     <<: *govuk-chat
     depends_on:
-      - govuk-chat-worker
       - nginx-proxy
       - postgres-13
     environment:
@@ -41,13 +40,3 @@ services:
     expose:
       - "3000"
     command: bin/dev
-
-  govuk-chat-worker:
-    <<: *govuk-chat
-    depends_on:
-      - redis
-      - postgres-13
-    environment:
-      REDIS_URL: redis://redis
-      DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
-    command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
This process is not needed because the worker is already ran as a result of govuk-chat-app via bin/dev (which uses the procfile.dev that runs to run sidekiq [1]). This does have the consequence that it's harder to work with the app log as it's mixed with the worker log too - however this already became complex when css was added as a process.

There's a couple of alternative ways we could do this, but I think this is the best option:

1) Remove sidekiq from the Procfile.dev and have web / css handled by
   govuk-chat-app and worker be separate, this is rejected as there
   doesn't seem to be a logical reason - besides existing precedent -
   why we'd have have 2 of the 3 processes for app.
2) Separate out CSS and web to be separate processes so there is
   a govuk-chat-app, a govuk-chat-css and a govuk-chat-worker process.
   This was rejected because it increases complexity and makes bin/dev
   somewhat redundant. However it does remain a compelling alternative
   if we were in need of easier access to logs.

[1]: https://github.com/alphagov/govuk-chat/blob/e1d33470985f8a6c3690538b949bd36961e9bd57/Procfile.dev