### PR TITLE
Separate govuk-chat processes to individual services

### DIFF
--- a/projects/govuk-chat/docker-compose.yml
+++ b/projects/govuk-chat/docker-compose.yml
@@ -30,6 +30,7 @@ services:
   govuk-chat-app:
     <<: *govuk-chat
     depends_on:
+      - govuk-chat-css
       - govuk-chat-worker
       - nginx-proxy
       - postgres-13
@@ -41,7 +42,11 @@ services:
       BINDING: 0.0.0.0
     expose:
       - "3000"
-    command: bin/dev
+    command: bin/dev web
+
+  govuk-chat-css:
+    <<: *govuk-chat
+    command: bin/dev css
 
   govuk-chat-worker:
     <<: *govuk-chat
@@ -51,4 +56,4 @@ services:
     environment:
       REDIS_URL: redis://redis
       DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
-    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    command: bin/dev worker


### PR DESCRIPTION
This change resolves an issue where govuk-chat-app and govuk-chat-worker both ran a sidekiq process, due to a worker process being registered on Procfile.dev [1].

The approach taken is to move the processes of Procfile.dev to each be individual services in docker compose, which has led to the creation of the govuk-chat-css service that runs the dartsass compilation process.

This allows each process to have individual logs and resolves an issue where it was previously very difficult to isolate the app logs as they were mushed in with CSS.

Alternatives considered were:

1. Remove sidekiq from the Procfile.dev and have web / css handled by govuk-chat-app and worker be separate, this is rejected as there doesn't seem to be a logical reason - besides existing precedent - why we'd have have 2 of the 3 processes for app. Separate out CSS and web to be separate processes so there is
2. Run bin/dev on govuk-chat-app and have that cover all processes. This was the first approach tried [2] however after discussions with colleagues we agreed it felt strange to have 3 processes running for one container.

[1]: https://github.com/alphagov/govuk-chat/blob/e1d33470985f8a6c3690538b949bd36961e9bd57/Procfile.dev#L3
[2]: https://github.com/alphagov/govuk-docker/pull/735