### PR TITLE
Integrate a message queue with govuk-chat

### DIFF
--- a/projects/govuk-chat/Makefile
+++ b/projects/govuk-chat/Makefile
@@ -2,3 +2,4 @@ govuk-chat: bundle-govuk-chat
 	$(GOVUK_DOCKER) run $@-lite bin/rails db:setup
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rails db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn
+	$(GOVUK_DOCKER) run $@-lite bundle exec rake message_queue:create_published_documents_queue

--- a/projects/govuk-chat/docker-compose.yml
+++ b/projects/govuk-chat/docker-compose.yml
@@ -23,9 +23,11 @@ services:
     <<: *govuk-chat
     depends_on:
       - postgres-13
+      - rabbitmq
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat-test"
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq
 
   govuk-chat-app:
     <<: *govuk-chat
@@ -57,3 +59,11 @@ services:
       REDIS_URL: redis://redis
       DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
     command: bin/dev worker
+
+  govuk-chat-queue-consumer:
+    <<: *govuk-chat
+    depends_on:
+      - rabbitmq
+    environment:
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq
+    command: bin/dev queue_consumer


### PR DESCRIPTION
Trello: https://trello.com/c/q6AqNW2t/1265-spike-into-what-is-needed-to-consume-publishing-api-queue-for-search-ingestion

GOV.UK Chat will be listening to the Publishing API message queue for published messages.

This change depends on https://github.com/alphagov/govuk-chat/pull/69

I've added a rabbitmq dependency for lite so that rabbit is available for set-up commands.