### PR TITLE
Add Opensearch 2 as a dependency of GOV.UK Chat

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ volumes:
   go:
   elasticsearch-6:
   elasticsearch-7:
+  opensearch-2:
 
 networks:
   default:
@@ -105,6 +106,16 @@ services:
       - ES_JAVA_OPTS=-Xms1g -Xmx1g
     volumes:
       - elasticsearch-7:/usr/share/elasticsearch/data
+
+  opensearch-2:
+    image: opensearchproject/opensearch:2
+    environment:
+      - discovery.type=single-node
+      - "OPENSEARCH_JAVA_OPTS=-Xms2g -Xmx2g"
+      - "DISABLE_INSTALL_DEMO_CONFIG=true" # Prevents execution of bundled demo script which installs demo certificates and security configurations to OpenSearch
+      - "DISABLE_SECURITY_PLUGIN=true"
+    volumes:
+      - opensearch-2:/usr/share/opensearch/data
 
   nginx-proxy:
     image: jwilder/nginx-proxy:latest

--- a/projects/govuk-chat/Makefile
+++ b/projects/govuk-chat/Makefile
@@ -3,3 +3,4 @@ govuk-chat: bundle-govuk-chat
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rails db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn
 	$(GOVUK_DOCKER) run $@-lite bundle exec rake message_queue:create_published_documents_queue
+	$(GOVUK_DOCKER) run $@-lite bundle exec rake search:create_chunked_content_index

--- a/projects/govuk-chat/docker-compose.yml
+++ b/projects/govuk-chat/docker-compose.yml
@@ -22,12 +22,14 @@ services:
   govuk-chat-lite:
     <<: *govuk-chat
     depends_on:
+      - opensearch-2
       - postgres-13
       - rabbitmq
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat-test"
       RABBITMQ_URL: amqp://guest:guest@rabbitmq
+      OPENSEARCH_URL: http://opensearch-2:9200
 
   govuk-chat-app:
     <<: *govuk-chat
@@ -63,7 +65,9 @@ services:
   govuk-chat-queue-consumer:
     <<: *govuk-chat
     depends_on:
+      - opensearch-2
       - rabbitmq
     environment:
       RABBITMQ_URL: amqp://guest:guest@rabbitmq
+      OPENSEARCH_URL: http://opensearch-2:9200
     command: bin/dev queue_consumer


### PR DESCRIPTION
Trello: https://trello.com/c/q6AqNW2t/1265-spike-into-what-is-needed-to-consume-publishing-api-queue-for-search-ingestion

GOV.UK Chat will be using this as a search index, this includes the running of a rake task to create the search index in the make task for the project.

This depends on: https://github.com/alphagov/govuk-chat/pull/78