### PR TITLE
Dependency fixes for RabbitMQ consumption

### DIFF
--- a/projects/govuk-chat/docker-compose.yml
+++ b/projects/govuk-chat/docker-compose.yml
@@ -66,8 +66,10 @@ services:
     <<: *govuk-chat
     depends_on:
       - opensearch-2
+      - postgres-13
       - rabbitmq
     environment:
+      DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
       RABBITMQ_URL: amqp://guest:guest@rabbitmq
       OPENSEARCH_URL: http://opensearch-2:9200
     command: bin/dev queue_consumer

--- a/projects/publishing-api/docker-compose.yml
+++ b/projects/publishing-api/docker-compose.yml
@@ -54,6 +54,7 @@ services:
     depends_on:
       - postgres-13
       - redis
+      - rabbitmq
     environment:
       RABBITMQ_EXCHANGE: published_documents
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672


### PR DESCRIPTION
Trello: https://trello.com/c/q6AqNW2t/1265-spike-into-what-is-needed-to-consume-publishing-api-queue-for-search-ingestion

This configures a couple of missing dependencies which were preventing queue consumption in GOV.UK Chat.