### PR TITLE
Update `search-admin` config to reflect app changes

### DIFF
--- a/projects/search-admin/Makefile
+++ b/projects/search-admin/Makefile
@@ -1,4 +1,4 @@
-search-admin: bundle-search-admin publishing-api search-api
+search-admin: bundle-search-admin publishing-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite bin/rails runner 'User.first || User.create'

--- a/projects/search-admin/docker-compose.yml
+++ b/projects/search-admin/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       DATABASE_URL: "mysql2://root:root@mysql-8/search_admin_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-8/search_admin_test"
       REDIS_URL: redis://redis
-      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
 
   search-admin-app: &search-admin-app
     <<: *search-admin-base
@@ -33,12 +32,13 @@ services:
       - mysql-8
       - nginx-proxy
       - publishing-api-app
-      - search-api-app
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/search_admin_development"
+      TEST_DATABASE_URL: "mysql2://root:root@mysql-8/search_admin_test"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: search-admin.dev.gov.uk
       BINDING: 0.0.0.0
+      PORT: 3000
     expose:
       - "3000"
-    command: bin/rails s --restart
+    command: bin/dev


### PR DESCRIPTION
- Remove `search-api` dependency
- Remove environment variable for `database_cleaner` configuration (this gem has been removed as we're not using Cucumber anymore and RSpec system tests run in transactions so don't need it)
- Change command in `app` stack to run conventional `bin/dev` that has been added to the application
- Add explicit port to `app` stack now that the application is run through Foreman
- Add `TEST_DATABASE_URL` to app stack to allow running tests on `app` stack too for convenience