### PR TITLE
Remove `version` property from Compose files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   root-home:
   rabbitmq:

--- a/projects/account-api/docker-compose.yml
+++ b/projects/account-api/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   account-api-tmp:
 

--- a/projects/asset-manager/docker-compose.yml
+++ b/projects/asset-manager/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   asset-manager-tmp:
 

--- a/projects/authenticating-proxy/docker-compose.yml
+++ b/projects/authenticating-proxy/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   authenticating-proxy-tmp:
 

--- a/projects/bouncer/docker-compose.yml
+++ b/projects/bouncer/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 x-bouncer: &bouncer
   build:
     context: .

--- a/projects/collections-publisher/docker-compose.yml
+++ b/projects/collections-publisher/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   collections-publisher-tmp:
   collections-publisher-node-modules:

--- a/projects/collections/docker-compose.yml
+++ b/projects/collections/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   collections-tmp:
   collections-node-modules:

--- a/projects/contacts-admin/docker-compose.yml
+++ b/projects/contacts-admin/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   contacts-admin-tmp:
   contacts-admin-node-modules:

--- a/projects/content-data-admin/docker-compose.yml
+++ b/projects/content-data-admin/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   content-data-admin-tmp:
   content-data-admin-node-modules:

--- a/projects/content-data-api/docker-compose.yml
+++ b/projects/content-data-api/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   content-data-api-tmp:
 

--- a/projects/content-publisher/docker-compose.yml
+++ b/projects/content-publisher/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   content-publisher-tmp:
   content-publisher-node-modules:

--- a/projects/content-store/docker-compose.yml
+++ b/projects/content-store/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   content-store-tmp:
 

--- a/projects/content-tagger/docker-compose.yml
+++ b/projects/content-tagger/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   content-tagger-tmp:
   content-tagger-node-modules:

--- a/projects/datagovuk_find/docker-compose.yml
+++ b/projects/datagovuk_find/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   datagovuk_find-node-modules:
   datagovuk_find-tmp:

--- a/projects/datagovuk_publish/docker-compose.yml
+++ b/projects/datagovuk_publish/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   datagovuk_publish-tmp:
 

--- a/projects/email-alert-api/docker-compose.yml
+++ b/projects/email-alert-api/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   email-alert-api-tmp:
 

--- a/projects/email-alert-frontend/docker-compose.yml
+++ b/projects/email-alert-frontend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   email-alert-frontend-tmp:
   email-alert-frontend-node-modules:

--- a/projects/email-alert-service/docker-compose.yml
+++ b/projects/email-alert-service/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 x-email-alert-service: &email-alert-service
   build:
     context: .

--- a/projects/feedback/docker-compose.yml
+++ b/projects/feedback/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   feedback-tmp:
   feedback-node-modules:

--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   finder-frontend-tmp:
   finder-frontend-node-modules:

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   frontend-tmp:
   frontend-node-modules:

--- a/projects/generic-ruby-library/docker-compose.yml
+++ b/projects/generic-ruby-library/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 x-generic-ruby-library: &generic-ruby-library
   build:
     context: .

--- a/projects/government-frontend/docker-compose.yml
+++ b/projects/government-frontend/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   government-frontend-tmp:
   government-frontend-node-modules:

--- a/projects/govspeak-preview/docker-compose.yml
+++ b/projects/govspeak-preview/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   govspeak-preview-tmp:
 

--- a/projects/govuk-chat/docker-compose.yml
+++ b/projects/govuk-chat/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   govuk-chat-tmp:
   govuk-chat-node-modules:

--- a/projects/govuk-developer-docs/docker-compose.yml
+++ b/projects/govuk-developer-docs/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 x-govuk-developer-docs: &govuk-developer-docs
   build:
     context: .

--- a/projects/govuk_crawler_worker/docker-compose.yml
+++ b/projects/govuk_crawler_worker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 x-govuk_crawler_worker: &govuk_crawler_worker
   build:
     context: .

--- a/projects/govuk_publishing_components/docker-compose.yml
+++ b/projects/govuk_publishing_components/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   govuk_publishing_components-tmp:
   govuk_publishing_components-node-modules:

--- a/projects/hmrc-manuals-api/docker-compose.yml
+++ b/projects/hmrc-manuals-api/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   hmrc-manuals-api-tmp:
 

--- a/projects/imminence/docker-compose.yml
+++ b/projects/imminence/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   imminence-tmp:
 

--- a/projects/link-checker-api/docker-compose.yml
+++ b/projects/link-checker-api/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   link-checker-api-tmp:
 

--- a/projects/local-links-manager/docker-compose.yml
+++ b/projects/local-links-manager/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   local-links-manager-tmp:
   local-links-manager-node-modules:

--- a/projects/locations-api/docker-compose.yml
+++ b/projects/locations-api/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   locations-api-tmp:
 

--- a/projects/manuals-publisher/docker-compose.yml
+++ b/projects/manuals-publisher/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   manuals-publisher-tmp:
   manuals-publisher-node-modules:

--- a/projects/maslow/docker-compose.yml
+++ b/projects/maslow/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   maslow-tmp:
   maslow-node-modules:

--- a/projects/publisher/docker-compose.yml
+++ b/projects/publisher/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   publisher-tmp:
   publisher-node-modules:

--- a/projects/publishing-api/docker-compose.yml
+++ b/projects/publishing-api/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   publishing-api-tmp:
 

--- a/projects/release/docker-compose.yml
+++ b/projects/release/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   release-tmp:
   release-node-modules:

--- a/projects/router-api/docker-compose.yml
+++ b/projects/router-api/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   router-api-tmp:
 

--- a/projects/router/docker-compose.yml
+++ b/projects/router/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 x-router: &router
   build:
     context: .

--- a/projects/search-admin/docker-compose.yml
+++ b/projects/search-admin/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   search-admin-tmp:
   search-admin-node-modules:

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 x-search-api: &search-api
   build:
     context: .

--- a/projects/service-manual-publisher/docker-compose.yml
+++ b/projects/service-manual-publisher/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   service-manual-publisher-tmp:
   service-manual-publisher-node-modules:

--- a/projects/short-url-manager/docker-compose.yml
+++ b/projects/short-url-manager/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   short-url-manager-tmp:
   short-url-manager-node-modules:

--- a/projects/signon/docker-compose.yml
+++ b/projects/signon/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   signon-tmp:
   signon-node-modules:

--- a/projects/smart-answers/docker-compose.yml
+++ b/projects/smart-answers/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   smart-answers-tmp:
   smart-answers-node-modules:

--- a/projects/special-route-publisher/docker-compose.yml
+++ b/projects/special-route-publisher/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 x-special-route-publisher: &special-route-publisher
   build:
     context: .

--- a/projects/specialist-publisher/docker-compose.yml
+++ b/projects/specialist-publisher/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   specialist-publisher-tmp:
   specialist-publisher-node-modules:

--- a/projects/static/docker-compose.yml
+++ b/projects/static/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   static-tmp:
   static-node-modules:

--- a/projects/support-api/docker-compose.yml
+++ b/projects/support-api/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   support-api-tmp:
 

--- a/projects/support/docker-compose.yml
+++ b/projects/support/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   support-tmp:
   support-node-modules:

--- a/projects/transition/docker-compose.yml
+++ b/projects/transition/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   transition-tmp:
 

--- a/projects/travel-advice-publisher/docker-compose.yml
+++ b/projects/travel-advice-publisher/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   travel-advice-publisher-tmp:
   travel-advice-publisher-node-modules:

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 volumes:
   whitehall-tmp:
   whitehall-node-modules:


### PR DESCRIPTION
This has been [deprecated] for a while and as of a recent Docker Compose upgrade is causing a flood of deprecation messages when running any command.

<img width="523" alt="image" src="https://github.com/alphagov/govuk-docker/assets/72141/a7b35b25-6bba-4f37-9b0f-9f2a3b260dfe">

[deprecated]: https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-top-level-element-obsolete