### PR TITLE
Add redis under govuk-chat-lite

### DIFF
--- a/projects/govuk-chat/docker-compose.yml
+++ b/projects/govuk-chat/docker-compose.yml
@@ -23,10 +23,12 @@ services:
       - opensearch-2
       - postgres-13
       - rabbitmq
+      - redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat-test"
       RABBITMQ_URL: amqp://guest:guest@rabbitmq
+      REDIS_URL: redis://redis
       OPENSEARCH_URL: http://opensearch-2:9200
 
   govuk-chat-app:


### PR DESCRIPTION
- Govuk chat needs direct connection to redis for some tests, this config adds the redis connection details.

Trello card: https://trello.com/c/LPJKEiIA/1351-configure-gds-sso-to-allow-govuk-signon-authentication