### PR TITLE
Use postgres-16 for govuk-chat

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ volumes:
   postgres-13-email-alert-api:
   postgres-14:
   postgres-14-postgis:
+  postgres-16:
   mysql-8:
   mongo-3.6:
   go:
@@ -55,6 +56,13 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - postgres-14-postgis:/var/lib/postgresql/data
+
+  postgres-16:
+    image: postgres:16
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - postgres-16:/var/lib/postgresql/data
 
   memcached:
     image: memcached

--- a/projects/govuk-chat/docker-compose.yml
+++ b/projects/govuk-chat/docker-compose.yml
@@ -21,12 +21,12 @@ services:
     <<: *govuk-chat
     depends_on:
       - opensearch-2
-      - postgres-13
+      - postgres-16
       - rabbitmq
       - redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat-test"
+      DATABASE_URL: "postgresql://postgres@postgres-16/govuk-chat"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-16/govuk-chat-test"
       RABBITMQ_URL: amqp://guest:guest@rabbitmq
       REDIS_URL: redis://redis
       OPENSEARCH_URL: http://opensearch-2:9200
@@ -37,10 +37,10 @@ services:
       - govuk-chat-css
       - govuk-chat-worker
       - nginx-proxy
-      - postgres-13
+      - postgres-16
       - redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
+      DATABASE_URL: "postgresql://postgres@postgres-16/govuk-chat"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: govuk-chat.dev.gov.uk
       BINDING: 0.0.0.0
@@ -56,20 +56,20 @@ services:
     <<: *govuk-chat
     depends_on:
       - redis
-      - postgres-13
+      - postgres-16
     environment:
       REDIS_URL: redis://redis
-      DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
+      DATABASE_URL: "postgresql://postgres@postgres-16/govuk-chat"
     command: bin/dev worker
 
   govuk-chat-queue-consumer:
     <<: *govuk-chat
     depends_on:
       - opensearch-2
-      - postgres-13
+      - postgres-16
       - rabbitmq
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/govuk-chat"
+      DATABASE_URL: "postgresql://postgres@postgres-16/govuk-chat"
       RABBITMQ_URL: amqp://guest:guest@rabbitmq
       OPENSEARCH_URL: http://opensearch-2:9200
     command: bin/dev queue_consumer


### PR DESCRIPTION
- Adds postgres-16 in the list of databases.
- Govuk-chat will be using postgres-16 in all the environments (integration, staging, prod). Updated the dev environment to reflect that.

Trello Card: https://trello.com/c/ewV5ilJ6/1229-initial-terraform-for-integration-environment