### PR TITLE
Rename imminence to places-manager

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,12 +159,12 @@ services:
           - govuk-developer-docs.dev.gov.uk
           - govuk-publishing-components.dev.gov.uk
           - hmrc-manuals-api.dev.gov.uk
-          - imminence.dev.gov.uk
           - link-checker-api.dev.gov.uk
           - local-links-manager.dev.gov.uk
           - locations-api.dev.gov.uk
           - manuals-publisher.dev.gov.uk
           - maslow.dev.gov.uk
+          - places-manager.dev.gov.uk
           - publisher.dev.gov.uk
           - publishing-api.dev.gov.uk
           - release.dev.gov.uk

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -42,7 +42,6 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ govuk-developer-docs
    - ✅ govuk-chat
    - ✅ hmrc-manuals-api
-   - ✅ imminence
    - ❌ licensify
       * Has a [separate](https://github.com/alphagov/licensify/blob/master/DOCKER.md) Docker project.
    - ✅ link-checker-api
@@ -50,6 +49,7 @@ These are repos that can be started as a some kind of process, such as a web app
    - ✅ locations-api
    - ✅ manuals-publisher
    - ✅ maslow
+   - ✅ places-manager
    - ✅ publisher
    - ✅ publishing-api
    - ✅ release

--- a/projects/places-manager/Makefile
+++ b/projects/places-manager/Makefile
@@ -1,3 +1,3 @@
-imminence: bundle-imminence local-links-manager locations-api
+places-manager: bundle-places-manager local-links-manager locations-api
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup

--- a/projects/places-manager/docker-compose.yml
+++ b/projects/places-manager/docker-compose.yml
@@ -1,50 +1,50 @@
 volumes:
-  imminence-tmp:
+  places-manager-tmp:
 
-x-imminence: &imminence
+x-places-manager: &places-manager
   build:
     context: .
     dockerfile: Dockerfile.govuk-base
-  image: imminence
+  image: places-manager
   stdin_open: true
   tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
-    - imminence-tmp:/govuk/imminence/tmp
-  working_dir: /govuk/imminence
+    - places-manager-tmp:/govuk/places-manager/tmp
+  working_dir: /govuk/places-manager
 
 services:
-  imminence-lite:
-    <<: *imminence
+  places-manager-lite:
+    <<: *places-manager
     depends_on:
       - postgres-14-postgis
       - redis
     environment:
-      DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/imminence"
-      TEST_DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/imminence-test"
+      DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/places-manager"
+      TEST_DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/places-manager-test"
       REDIS_URL: redis://redis
 
-  imminence-app: &imminence-app
-    <<: *imminence
+  places-manager-app: &places-manager-app
+    <<: *places-manager
     depends_on:
       - postgres-14-postgis
       - local-links-manager-app
       - locations-api-app
       - nginx-proxy
       - redis
-      - imminence-worker
+      - places-manager-worker
     environment:
-      DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/imminence"
-      VIRTUAL_HOST: imminence.dev.gov.uk
+      DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/places-manager"
+      VIRTUAL_HOST: places-manager.dev.gov.uk
       BINDING: 0.0.0.0
       REDIS_URL: redis://redis
     expose:
       - "3000"
     command: bin/rails s --restart
 
-  imminence-worker:
-    <<: *imminence
+  places-manager-worker:
+    <<: *places-manager
     depends_on:
       - postgres-14-postgis
       - local-links-manager-app
@@ -52,6 +52,6 @@ services:
       - nginx-proxy
       - redis
     environment:
-      DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/imminence"
+      DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/places-manager"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
Imminence is now Places Manager, rename govuk-docker's internal references.

https://trello.com/c/HAEH2bVF/4-rename-imminence

