### PR TITLE
Add OpenSearch as a govuk-chat-app dependency

### DIFF
--- a/projects/govuk-chat/docker-compose.yml
+++ b/projects/govuk-chat/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-16/govuk-chat"
       REDIS_URL: redis://redis
+      OPENSEARCH_URL: http://opensearch-2:9200
       VIRTUAL_HOST: govuk-chat.dev.gov.uk
       BINDING: 0.0.0.0
     expose:


### PR DESCRIPTION
Not sure how we've gone so long without this being set.