### PR TITLE
Increase shared memory for government-frontend

### DIFF
--- a/projects/government-frontend/docker-compose.yml
+++ b/projects/government-frontend/docker-compose.yml
@@ -19,6 +19,7 @@ x-government-frontend: &government-frontend
 services:
   government-frontend-lite:
     <<: *government-frontend
+    shm_size: 512mb
 
   government-frontend-app: &government-frontend-app
     <<: *government-frontend


### PR DESCRIPTION
## What

Too little shared memory causes some tests that use Selenium to fail when running locally in the development environment. This change fixes that. For consistency, the amount chosen (512MB) is the same amount as used by other applications for similar purpose.

## Why

The problem was noticed when working on https://trello.com/c/IKHEtABq/p This change also allows for correct calculation of test coverage.