### PR TITLE
Document the database creation/seed steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,26 @@ make [app-name]
 make collections-publisher
 ```
 
+You'll also need to set up the database and seed data:
+
+```
+# enter the app directory, e.g. ~/govuk/whitehall
+cd ~/govuk/app-name
+
+# create development database (used locally when running `govuk-docker-up`)
+govuk-docker-run rails db:create
+
+# create test database (used locally when running tests)
+govuk-docker-run rails db:create RAILS_ENV=test
+
+# Seed the database(s)
+govuk-docker-run rails db:seed
+govuk-docker-run rails db:seed RAILS_ENV=test
+```
+
 👉 [Check the troubleshooting guide if you have a problem.](docs/troubleshooting.md)
+
+## Stacks
 
 Each project provides a number of 'stacks' for different use cases. You can see the stacks for a project in its [config file](projects/content-publisher/docker-compose.yml). To provide consistency, all projects should follow these conventions for stacks:
 


### PR DESCRIPTION
PLACEHOLDER: this may just have been needed for Whitehall, in which case a tweak to the Whitehall Makefile is probably the solution.

---

I had to run these steps manually when making Whitehall. I can't find anywhere else where we've documented these steps, and it took me a little while to figure out the `RAILS_ENV` dependency for getting tests working.

I did consider documenting this elsewhere (https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html) but given govuk-docker is all about setting up a working local environment, and given govuk-docker handles everything but db creation/seeding for you, then this it seems reasonable to document this gotcha here, where it's more likely to be seen at point of need.