### PR TITLE
Fix broken Elasticsearch 6 container

### DIFF
--- a/services/elasticsearch-6/Dockerfile
+++ b/services/elasticsearch-6/Dockerfile
@@ -10,13 +10,9 @@ FROM eclipse-temurin:8-jre
 
 ARG ELASTICSEARCH_VERSION=6.7.2
 
-ARG USERNAME=elastic
-ARG USER_UID=1000
-ARG USER_GID=${USER_UID}
-
-# Set up unprivileged local user
-RUN groupadd --gid ${USER_GID} ${USERNAME} \
-    && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME}
+# As of Ubuntu 24.04, the official Docker image (which the Eclipse Temurin one is based on) ships
+# with an existing non-root user called "ubuntu"
+ARG USERNAME=ubuntu
 
 # Install required tooling
 RUN apt update && apt install -y curl


### PR DESCRIPTION
The underlying version of Ubuntu for our custom ES6 container has changed, and it now includes a non-root user by default, with the same ID as the one which we were previously creating. This was causing the image build to fail.

- Remove custom non-root user setup and replace with default non-root user