### PR TITLE
Use dartsass for apps CSS compilation

### DIFF
--- a/projects/collections-publisher/docker-compose.yml
+++ b/projects/collections-publisher/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       BINDING: 0.0.0.0
     expose:
       - "3000"
-    command: bin/rails s --restart
+    command: bin/dev
 
   collections-publisher-worker:
     <<: *collections-publisher

--- a/projects/content-tagger/docker-compose.yml
+++ b/projects/content-tagger/docker-compose.yml
@@ -41,4 +41,4 @@ services:
       BINDING: 0.0.0.0
     expose:
       - "3000"
-    command: bin/rails s --restart
+    command: bin/dev


### PR DESCRIPTION
## What
Change docker compose for some applications to match compilation of CSS using dart-sass. Specifically:

- `content-tagger` see https://github.com/alphagov/content-tagger/pull/1763
- `collections-publisher` see https://github.com/alphagov/collections-publisher/pull/2230

## Why
We're switching these apps from libsass to dart-sass, and this change is needed to support that.

Trello card: https://trello.com/c/gW2NW1sB/239-fix-sass-compilation-warnings