### PR TITLE
Add exceptional case for GOV.UK Chat

### DIFF
--- a/bin/replicate-postgresql.sh
+++ b/bin/replicate-postgresql.sh
@@ -9,6 +9,10 @@ function try_find_file {
       # Bouncer and Transition share a database with a non-standard hostname (ending with "postgresql" not "postgres")
       db_hostname="transition-postgresql"
       ;;
+    "govuk-chat")
+      # We drop the govuk- prefix from the product name on our infrastructure.
+      db_hostname="chat-postgres"
+      ;;
     "content-data-api")
       # Content Data API has a non-standard hostname (ending with "postgresql" not "postgres")
       db_hostname="content-data-api-postgresql"


### PR DESCRIPTION
GOV.UK Chat doesn't use the "govuk" prefix in the db name for the database on GOV.UK infrastructure. This change allows the DB to be cloned locally.