### PR TITLE
Change to transition for dart-sass

### DIFF
--- a/projects/transition/docker-compose.yml
+++ b/projects/transition/docker-compose.yml
@@ -40,4 +40,4 @@ services:
       BINDING: 0.0.0.0
     expose:
       - "3000"
-    command: bin/rails s --restart
+    command: bin/dev


### PR DESCRIPTION
## What
Change docker compose for `transition` to match compilation of CSS using dart-sass, needed to support the switch to dart-sass for Sass compilation in https://github.com/alphagov/transition/pull/1661

## Why
We're switching these apps from libsass to dart-sass, and this change is needed to support that.

Trello card: https://trello.com/c/gW2NW1sB/239-fix-sass-compilation-warnings

