### PR TITLE
Added note about preventing unexpected DB schema diffs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -205,3 +205,19 @@ This may resolve by removing orphan containers which were created in a previous 
 ```
 docker-compose down -v --rmi all --remove-orphans
 ```
+
+
+## Rails database schema changed unexpectedly when running `rake db:migrate`
+
+It is common to find that running `rake db:migrate` results in unexpected changes to the `schema.rb` file. This is caused by slight differences between databases running in GOV.UK Docker and the production databases on AWS.
+
+Unfortunately, to resolve the issue, the only solution is to drop the database in GOV.UK docker and create a new one.
+
+Once you have taken a backup, you can remove and re-create your local database using the following commands:
+
+```bash
+rake db:drop
+rake db:create
+rake db:schema:load
+rake db:schema:migrate // optional, but if you are adding a new migration this will now update the schema without creating a horrible diff
+```


### PR DESCRIPTION
This has become a bit of an annoying issue for the Whitehall team over time, and has sometimes led to changes to the schema.rb file not being committed when they should have been.

Trello: https://trello.com/c/Ai59Yd1F