### PR TITLE
Search API v2: Add datastore env config

### DIFF
--- a/projects/search-api-v2/docker-compose.yml
+++ b/projects/search-api-v2/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       RABBITMQ_URL: amqp://guest:guest@rabbitmq
       REDIS_URL: redis://redis
       PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: search_api_v2_published_documents
+      DISCOVERY_ENGINE_DATASTORE: none
       DISCOVERY_ENGINE_DATASTORE_BRANCH: none
       DISCOVERY_ENGINE_SERVING_CONFIG: none
 
@@ -44,9 +45,10 @@ services:
       RAILS_DEVELOPMENT_HOSTS: "search-api-v2.dev.gov.uk,search-api-v2-app"
       VIRTUAL_HOST: "search-api-v2.dev.gov.uk"
       BINDING: "0.0.0.0"
-      # The fully qualified ID of the datastore branch and engine on the Discovery Engine integration
+      # The fully qualified ID of the datastore, branch and engine on the Discovery Engine integration
       # environment (required to use Discovery Engine locally).
       #
+      DISCOVERY_ENGINE_DATASTORE: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content"
       DISCOVERY_ENGINE_DATASTORE_BRANCH: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/branches/default_branch"
       DISCOVERY_ENGINE_SERVING_CONFIG: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/servingConfigs/default_search"
     expose:
@@ -62,9 +64,10 @@ services:
       RABBITMQ_URL: "amqp://guest:guest@rabbitmq"
       REDIS_URL: redis://redis
       PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: "search_api_v2_published_documents"
-      # The fully qualified ID of the datastore branch and serving config on the Discovery Engine
+      # The fully qualified ID of the datastore, branch and serving config on the Discovery Engine
       # integration environment (required to use Discovery Engine locally).
       #
+      DISCOVERY_ENGINE_DATASTORE: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content"
       DISCOVERY_ENGINE_DATASTORE_BRANCH: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/branches/default_branch"
       DISCOVERY_ENGINE_SERVING_CONFIG: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/servingConfigs/default_search"
     command: bin/rake document_sync_worker:run


### PR DESCRIPTION
For autocomplete requests, we need to make requests against a datastore directly, not a branch. This adds the required configuration variable to the app's environment.