### PR TITLE
Fix replication issues for Content Store and Publishing API

### DIFF
--- a/projects/content-store/docker-compose.yml
+++ b/projects/content-store/docker-compose.yml
@@ -18,18 +18,18 @@ services:
   content-store-lite:
     <<: *content-store
     depends_on:
-      - postgres-13
+      - postgres-16
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/content-store"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/content-store-test"
+      DATABASE_URL: "postgresql://postgres@postgres-16/content-store"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-16/content-store-test"
   content-store-app: &content-store-app
     <<: *content-store
     depends_on:
-      - postgres-13
+      - postgres-16
       - router-api-app
       - nginx-proxy
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/content-store"
+      DATABASE_URL: "postgresql://postgres@postgres-16/content-store"
       VIRTUAL_HOST: content-store.dev.gov.uk
       BINDING: 0.0.0.0
     expose:

--- a/projects/publishing-api/docker-compose.yml
+++ b/projects/publishing-api/docker-compose.yml
@@ -18,28 +18,28 @@ services:
   publishing-api-lite:
     <<: *publishing-api
     depends_on:
-      - postgres-13
+      - postgres-16
       - redis
       - rabbitmq
     environment:
       RABBITMQ_EXCHANGE: published_documents
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
-      DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api-test"
+      DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api-test"
       REDIS_URL: redis://redis
 
   publishing-api-app: &publishing-api-app
     <<: *publishing-api
     depends_on:
-      - postgres-13
+      - postgres-16
       - publishing-api-worker
       - redis
       - nginx-proxy
     environment:
       RABBITMQ_EXCHANGE: published_documents
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
-      DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api"
+      DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: publishing-api.dev.gov.uk
       BINDING: 0.0.0.0
@@ -50,12 +50,12 @@ services:
   publishing-api-worker:
     <<: *publishing-api
     depends_on:
-      - postgres-13
+      - postgres-16
       - redis
       - rabbitmq
     environment:
       RABBITMQ_EXCHANGE: published_documents
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
-      DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api"
+      DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
Running these tools locally works fine, but if you wish to replicate the database from the AWS server, said database wouldn't build due to a Postgres version mismatch. Essentially, the Docker environment version of Postgres is too old.

```
docker compose -f [...] run --rm -T postgres-13 /usr/bin/pg_restore -h postgres-13 -U postgres -d content-store --no-owner --no-privileges
pg_restore: error: unsupported version (1.15) in file header                                                                                                                                ]   0% ETA 14:28:41
3.06MiB 0:00:03 [ 819KiB/s] [>                                                                                                                                                              ]   0%             
docker compose -f [...] down
[+] Running 2/2
 ✔ Container govuk-docker-postgres-13-1  Removed                                                                                                                                                          0.1s 
 ✔ Network govuk-docker_default          Removed  
```

This commit modifies the Docker environment for both Content Store and Publishing API so that they now use Postgres-16 rather than -13, allowing compatibility with the databases found on production.

Publishing API and Content Store have both had their envrioments tested locally and pass with flying colours with this change.