### PR TITLE
Add an app-live to docker compose for smart answers

### DIFF
--- a/projects/smart-answers/docker-compose.yml
+++ b/projects/smart-answers/docker-compose.yml
@@ -35,3 +35,23 @@ services:
     expose:
       - "3000"
     command: bin/rails s --restart
+
+  smart-answers-app-live:
+    <<: *smart-answers
+    depends_on:
+      - nginx-proxy
+      - publishing-api-app
+      - static-app
+      - content-store-app
+      - whitehall-app
+    environment:
+      GOVUK_PROXY_STATIC_ENABLED: "true"
+      VIRTUAL_HOST: smart-answers.dev.gov.uk
+      GOVUK_APP_DOMAIN: www.gov.uk
+      GOVUK_WEBSITE_ROOT: https://www.gov.uk
+      PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
+      PLEK_SERVICE_STATIC_URI: https://assets.publishing.service.gov.uk
+      BINDING: 0.0.0.0
+    expose:
+      - "3000"
+    command: bin/rails s --restart


### PR DESCRIPTION
Some of the dev urls that are required to run smart answers locally don't work and we would need to configure live urls hence with this PR we have added an app-live to docker compose to allow us to run locally using some live urls.