### PR TITLE
Finder Frontend: Increase `shm_size`

### DIFF
--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -8,6 +8,7 @@ x-finder-frontend: &finder-frontend
     dockerfile: Dockerfile.govuk-base
   image: finder-frontend
   stdin_open: true
+  shm_size: 512mb
   tty: true
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated


### PR DESCRIPTION
This fixes out of memory issues with running the Cucumber test suite through GOV.UK Docker by increasing shared memory size in line with some of the publishing apps.

See e.g. https://github.com/alphagov/govuk-docker/blob/5b643fea60fa6359f307b04293f37e5e79f6937c/projects/publisher/docker-compose.yml#L22