### PR TITLE
Add option to skip branch checks on `make`

### DIFF
--- a/bin/branch_checks.sh
+++ b/bin/branch_checks.sh
@@ -7,6 +7,11 @@ if [[ "$#" == "0" ]]; then
   exit 1
 fi
 
+if [[ -n "${SKIP_BRANCH_CHECKS:-}" ]]; then
+  echo "SKIP_BRANCH_CHECKS set, skipping branch checks."
+  exit 0
+fi
+
 bold=$(tput bold)
 end_bold=$(tput sgr0)
 ul=$(tput smul)

--- a/docs/how-tos.md
+++ b/docs/how-tos.md
@@ -101,3 +101,12 @@ GOV.UK Docker should respect the following environment variables:
 ## How to: publish a finder and specialist documents to test finders end-to-end locally
 
 See [How to Publish Content to a Finder in GOV.UK Docker](./how-tos/finder-setup.md)
+
+## How to: Re-run `make` without branch checks
+
+If you have already run `make` for a project recently, and just want to re-run it without it
+checking for updates to all dependent repositories (for example if you do not have a stable internet
+connection), you can set the `SKIP_BRANCH_CHECKS` environment variable:
+```bash
+SKIP_BRANCH_CHECKS=1 make my-app
+```


### PR DESCRIPTION
Sometimes I just want to quickly rebuild a project (for example if things have gotten into a bad state somehow) without the build scripts obsessively checking for updates to dependent repositories. This is especially useful when I have several dependent repositories intentionally checked out to a different branch and don't want to have to confirm that each time, or when I am on a train and the internet connection is too spotty to reliably update local repositories.

This adds an environment variable flag `SKIP_BRANCH_CHECKS` that when set will skip the branch checks on `make` invocations.