### PR TITLE
Run Publishing API alongside Collections

### DIFF
--- a/projects/collections/Makefile
+++ b/projects/collections/Makefile
@@ -1,2 +1,2 @@
-collections: bundle-collections content-store router static
+collections: bundle-collections content-store publishing-api router static
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/collections/docker-compose.yml
+++ b/projects/collections/docker-compose.yml
@@ -26,6 +26,7 @@ services:
     depends_on:
       - router-app
       - content-store-app
+      - publishing-api-app
       - static-app
       - nginx-proxy
     environment:


### PR DESCRIPTION
We are adding GraphQL queries into Collections, which are made directly to Publishing API.

Therefore we need to run Publishing API at the same time as Collections when developing locally.

[Trello card](https://trello.com/c/jDF1nSQ0)