### PR TITLE
Static: Ensure `EMERGENCY_BANNER_REDIS_URL` is defined

### DIFF
--- a/projects/static/docker-compose.yml
+++ b/projects/static/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - nginx-proxy
     environment:
       ASSET_HOST: static.dev.gov.uk
+      EMERGENCY_BANNER_REDIS_URL: redis://redis
       REDIS_URL: redis://redis
       VIRTUAL_HOST: static.dev.gov.uk
       BINDING: 0.0.0.0


### PR DESCRIPTION
This was missing from the config, and a recent change in static (https://github.com/alphagov/static/pull/3447) means the app will spend ages waiting for a Redis request to this URL to succeed (and ultimately fail) and no longer fall back on `REDIS_URL` as it did before - causing downstream local apps to fail to load when depending on static.