### PR TITLE
`finder-frontend`: Remove separate v2 search stack

### DIFF
--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -47,15 +47,6 @@ services:
       - "3000"
     command: bin/rails s --restart
 
-  finder-frontend-search-v2: &finder-frontend-search-v2
-    <<: *finder-frontend-app
-    environment:
-      PLEK_SERVICE_SEARCH_API_URI: http://search-api-v2-app:3000
-      GOVUK_PROXY_STATIC_ENABLED: "true"
-      VIRTUAL_HOST: finder-frontend.dev.gov.uk
-      BINDING: 0.0.0.0
-      MEMCACHE_SERVERS: memcached
-
   finder-frontend-app-live:
     <<: *finder-frontend-app
     depends_on:


### PR DESCRIPTION
This was helpful back when `search-api-v2` wasn't live yet, but now we can just rely on the regular v1/v2 switching logic in the Finder Frontend app.