### PR TITLE
Finder Frontend: Add public Search API v2 URL

### DIFF
--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - nginx-proxy
     environment:
       PLEK_SERVICE_SEARCH_API_URI: https://www.gov.uk/api
+      PLEK_SERVICE_SEARCH_API_V2_URI: https://search.publishing.service.gov.uk/v0_1
       PLEK_SERVICE_WHITEHALL_FRONTEND_URI: https://www.gov.uk
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       GOVUK_PROXY_STATIC_ENABLED: "true"
@@ -69,6 +70,7 @@ services:
       - nginx-proxy
     environment:
       PLEK_SERVICE_SEARCH_API_URI: https://www.integration.publishing.service.gov.uk/api
+      PLEK_SERVICE_SEARCH_API_V2_URI: https://search.integration.publishing.service.gov.uk/v0_1
       PLEK_SERVICE_WHITEHALL_FRONTEND_URI: https://www.integration.publishing.service.gov.uk
       GOVUK_WEBSITE_ROOT: https://www.integration.publishing.service.gov.uk
       GOVUK_PROXY_STATIC_ENABLED: "true"


### PR DESCRIPTION
This adds the new semi-public Search API v2 URL to the `live` and `integration` stacks, allowing local development against Search API v2.