### PR TITLE
Add ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE=true to all frontend apps except -lite

### DIFF
--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - router-app
       - static-app
     environment:
+      ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE: "true"
       VIRTUAL_HOST: frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -41,6 +42,7 @@ services:
       - account-api-app-live
       - nginx-proxy
     environment:
+      ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE: "true"
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       GOVUK_PROXY_STATIC_ENABLED: "true"
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
@@ -54,6 +56,7 @@ services:
       - account-api-app-live
       - nginx-proxy
     environment:
+      ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE: "true"
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       GOVUK_PROXY_STATIC_ENABLED: "true"
       #ASSET_MANAGER_BEARER_TOKEN: <get an asset manager token from https://signon.integration.publishing.service.gov.uk/api_users>


### PR DESCRIPTION
Adds support for local content items to be loaded from a file in Frontend, an aid for developers and preview apps. Here we add support for the standard, -live, and, -integration versions of the app. We don't add it to -lite, which is the basis for tests. Unfortunately that's also the basis for the console, so if you want to test local content item loading on the command line you'll need to explicitly run the console with the environment variable.

https://trello.com/c/FytCkByy/383-improve-contentitem-offline-loading

See also: https://github.com/alphagov/frontend/pull/4366