### PR TITLE
Upgrade version of PostgreSQL used by Publishing API

### DIFF
--- a/projects/publishing-api/docker-compose.yml
+++ b/projects/publishing-api/docker-compose.yml
@@ -18,28 +18,28 @@ services:
   publishing-api-lite:
     <<: *publishing-api
     depends_on:
-      - postgres-13
+      - postgres-16
       - redis
       - rabbitmq
     environment:
       RABBITMQ_EXCHANGE: published_documents
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
-      DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api-test"
+      DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api-test"
       REDIS_URL: redis://redis
 
   publishing-api-app: &publishing-api-app
     <<: *publishing-api
     depends_on:
-      - postgres-13
+      - postgres-16
       - publishing-api-worker
       - redis
       - nginx-proxy
     environment:
       RABBITMQ_EXCHANGE: published_documents
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
-      DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api"
+      DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api"
       REDIS_URL: redis://redis
       VIRTUAL_HOST: publishing-api.dev.gov.uk
       BINDING: 0.0.0.0
@@ -50,12 +50,12 @@ services:
   publishing-api-worker:
     <<: *publishing-api
     depends_on:
-      - postgres-13
+      - postgres-16
       - redis
       - rabbitmq
     environment:
       RABBITMQ_EXCHANGE: published_documents
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
-      DATABASE_URL: "postgresql://postgres@postgres-13/publishing-api"
+      DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api"
       REDIS_URL: redis://redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml


### PR DESCRIPTION
We were using an outdated image, which contained a version of `pg_restore` that was not compatible with the dumps of production data.

Therefore upgrading the version of PostgreSQL image we are using to allow replication of real data.