### PR TITLE
Content Store: Use `db:prepare` instead of `db:setup`

### DIFF
--- a/projects/content-store/Makefile
+++ b/projects/content-store/Makefile
@@ -1,2 +1,2 @@
 content-store: bundle-content-store router-api publishing-api
-	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare


### PR DESCRIPTION
We probably don't want to nuke existing databases anyway, and the new SQL-instead-of-Ruby based schema in Content Store won't apply cleanly to an existing database (where this will just make it run migrations instead).