### PR TITLE
Use a separate redis instance for each project

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,9 +84,6 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
 
-  redis:
-    image: redis
-
   rabbitmq:
     image: rabbitmq:management
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,9 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: root
 
+  redis:
+    image: redis
+
   rabbitmq:
     image: rabbitmq:management
     ports:
@@ -99,6 +102,9 @@ services:
       ES_JAVA_OPTS: -Xms1g -Xmx1g
     volumes:
       - elasticsearch-6:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+      - "9300:9300"
 
   elasticsearch-7:
     image: elasticsearch:7.9.3

--- a/projects/account-api/docker-compose.yml
+++ b/projects/account-api/docker-compose.yml
@@ -24,12 +24,12 @@ services:
       #
       # https://trello.com/c/ZMFOPaCl/1176-upgrade-our-app-databases
       - postgres-13
-      - redis
+      - account-api-redis
     environment:
       MEMCACHE_SERVERS: memcached
       DATABASE_URL: "postgresql://postgres@postgres-13/account-api"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/account-api-test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://account-api-redis
 
   account-api-app:
     <<: *account-api
@@ -38,7 +38,7 @@ services:
       - memcached
       - nginx-proxy
       - postgres-13
-      - redis
+      - account-api-redis
     environment:
       MEMCACHE_SERVERS: memcached
       DATABASE_URL: "postgresql://postgres@postgres-13/account-api"
@@ -46,7 +46,7 @@ services:
       BINDING: 0.0.0.0
       GOVUK_ACCOUNT_OAUTH_CLIENT_ID: client-id
       GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: client-secret
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://account-api-redis
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -57,11 +57,11 @@ services:
       - memcached
       - nginx-proxy
       - postgres-13
-      - redis
+      - account-api-redis
     environment:
       BINDING: 0.0.0.0
       DATABASE_URL: "postgresql://postgres@postgres-13/account-api"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://account-api-redis
       GOVUK_ACCOUNT_OAUTH_CLIENT_ID: client-id
       GOVUK_ACCOUNT_OAUTH_CLIENT_SECRET: client-secret
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
@@ -72,3 +72,6 @@ services:
     expose:
       - "3000"
     command: bin/rails s --restart
+
+  account-api-redis:
+    image: redis

--- a/projects/asset-manager/docker-compose.yml
+++ b/projects/asset-manager/docker-compose.yml
@@ -22,24 +22,24 @@ services:
     <<: *asset-manager
     depends_on:
       - mongo-3.6
-      - redis
+      - asset-manager-redis
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/asset-manager"
       FAKE_S3_HOST: "http://asset-manager.dev.gov.uk"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/asset-manager-test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://asset-manager-redis
 
   asset-manager-app: &asset-manager-app
     <<: *asset-manager
     depends_on:
       - mongo-3.6
-      - redis
+      - asset-manager-redis
       - nginx-proxy
       - asset-manager-worker
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/asset-manager"
       FAKE_S3_HOST: "http://asset-manager.dev.gov.uk"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://asset-manager-redis
       VIRTUAL_HOST: asset-manager.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -50,11 +50,14 @@ services:
     <<: *asset-manager
     depends_on:
       - mongo-3.6
-      - redis
+      - asset-manager-redis
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/asset-manager"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://asset-manager-redis
       ASSET_MANAGER_CLAMSCAN_PATH: /bin/true
       FAKE_S3_HOST: "http://asset-manager.dev.gov.uk"
       ALLOW_FAKE_S3_IN_PRODUCTION_FOR_PUBLISHING_E2E_TESTS: "true"
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  asset-manager-redis:
+    image: redis

--- a/projects/collections-publisher/docker-compose.yml
+++ b/projects/collections-publisher/docker-compose.yml
@@ -22,18 +22,18 @@ services:
     shm_size: 512mb
     depends_on:
       - mysql-8
-      - redis
+      - collections-publisher-redis
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/collections_publisher_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-8/collections_publisher_test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://collections-publisher-redis
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
 
   collections-publisher-app: &collections-publisher-app
     <<: *collections-publisher
     depends_on:
       - mysql-8
-      - redis
+      - collections-publisher-redis
       - content-store-app
       - link-checker-api-app
       - nginx-proxy
@@ -41,7 +41,7 @@ services:
       - collections-publisher-worker
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/collections_publisher_development"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://collections-publisher-redis
       VIRTUAL_HOST: collections-publisher.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -51,10 +51,13 @@ services:
   collections-publisher-worker:
     <<: *collections-publisher
     depends_on:
-      - redis
+      - collections-publisher-redis
       - mysql-8
       - publishing-api-app
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/collections_publisher_development"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://collections-publisher-redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  collections-publisher-redis:
+    image: redis

--- a/projects/contacts-admin/docker-compose.yml
+++ b/projects/contacts-admin/docker-compose.yml
@@ -22,17 +22,17 @@ services:
     shm_size: 512mb
     depends_on:
       - mysql-8
-      - redis
+      - contacts-admin-redis
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/contacts_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-8/contacts_test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://contacts-admin-redis
 
   contacts-admin-app: &contacts-admin-app
     <<: *contacts-admin
     depends_on:
       - mysql-8
-      - redis
+      - contacts-admin-redis
       - publishing-api-app
       - nginx-proxy
       - content-store-app
@@ -40,9 +40,12 @@ services:
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/contacts_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-8/contacts_test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://contacts-admin-redis
       VIRTUAL_HOST: contacts-admin.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart
+
+  contacts-admin-redis:
+    image: redis

--- a/projects/content-publisher/docker-compose.yml
+++ b/projects/content-publisher/docker-compose.yml
@@ -25,17 +25,17 @@ services:
     shm_size: 512mb
     depends_on:
       - postgres-13
-      - redis
+      - content-publisher-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/content-publisher"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/content-publisher-test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://content-publisher-redis
 
   content-publisher-app: &content-publisher-app
     <<: *content-publisher
     depends_on:
       - postgres-13
-      - redis
+      - content-publisher-redis
       - content-publisher-worker
       - publishing-api-app
       - asset-manager-app
@@ -43,7 +43,7 @@ services:
       - content-store-app
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/content-publisher"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://content-publisher-redis
       VIRTUAL_HOST: content-publisher.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -54,10 +54,13 @@ services:
     <<: *content-publisher
     depends_on:
       - postgres-13
-      - redis
+      - content-publisher-redis
       - publishing-api-app
       - asset-manager-app
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/content-publisher"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://content-publisher-redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  content-publisher-redis:
+    image: redis

--- a/projects/content-tagger/docker-compose.yml
+++ b/projects/content-tagger/docker-compose.yml
@@ -33,12 +33,15 @@ services:
       - postgres-13
       - publishing-api-app
       - nginx-proxy
-      - redis
+      - content-tagger-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/content-tagger"
       VIRTUAL_HOST: content-tagger.dev.gov.uk
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://content-tagger-redis
       BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/dev
+
+  content-tagger-redis:
+    image: redis

--- a/projects/email-alert-api/docker-compose.yml
+++ b/projects/email-alert-api/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     <<: *email-alert-api
     depends_on:
       - postgres-13-email-alert-api
-      - reemail-alert-api-redisdis
+      - email-alert-api-redis
     environment:
       DATABASE_URL: "postgresql://email-alert-api@postgres-13-email-alert-api/email-alert-api"
       TEST_DATABASE_URL: "postgresql://email-alert-api@postgres-13-email-alert-api/email-alert-api-test"

--- a/projects/email-alert-api/docker-compose.yml
+++ b/projects/email-alert-api/docker-compose.yml
@@ -19,21 +19,21 @@ services:
     <<: *email-alert-api
     depends_on:
       - postgres-13-email-alert-api
-      - redis
+      - reemail-alert-api-redisdis
     environment:
       DATABASE_URL: "postgresql://email-alert-api@postgres-13-email-alert-api/email-alert-api"
       TEST_DATABASE_URL: "postgresql://email-alert-api@postgres-13-email-alert-api/email-alert-api-test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://email-alert-api-redis
 
   email-alert-api-app: &email-alert-api-app
     <<: *email-alert-api
     depends_on:
       - nginx-proxy
       - postgres-13-email-alert-api
-      - redis
+      - email-alert-api-redis
     environment:
       DATABASE_URL: "postgresql://email-alert-api@postgres-13-email-alert-api/email-alert-api"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://email-alert-api-redis
       VIRTUAL_HOST: email-alert-api.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -44,8 +44,11 @@ services:
     <<: *email-alert-api
     depends_on:
       - postgres-13-email-alert-api
-      - redis
+      - email-alert-api-redis
     environment:
       DATABASE_URL: "postgresql://email-alert-api@postgres-13-email-alert-api/email-alert-api"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://email-alert-api-redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  email-alert-api-redis:
+    image: redis

--- a/projects/email-alert-frontend/docker-compose.yml
+++ b/projects/email-alert-frontend/docker-compose.yml
@@ -20,14 +20,14 @@ services:
   email-alert-frontend-lite:
     <<: *email-alert-frontend
     depends_on:
-      - redis
+      - email-alert-frontend-redis
     environment:
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://email-alert-frontend-redis
 
   email-alert-frontend-app: &email-alert-frontend-app
     <<: *email-alert-frontend
     depends_on:
-      - redis
+      - email-alert-frontend-redis
       - router-app
       - content-store-app
       - static-app
@@ -35,7 +35,7 @@ services:
       - nginx-proxy
     environment:
       GOVUK_PROXY_STATIC_ENABLED: "true"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://email-alert-frontend-redis
       VIRTUAL_HOST: email-alert-frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -45,14 +45,17 @@ services:
   email-alert-frontend-app-live:
     <<: *email-alert-frontend-app
     depends_on:
-      - redis
+      - email-alert-frontend-redis
       - email-alert-api-app
       - nginx-proxy
     environment:
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://email-alert-frontend-redis
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       GOVUK_PROXY_STATIC_ENABLED: "true"
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       PLEK_SERVICE_STATIC_URI: https://assets.publishing.service.gov.uk
       VIRTUAL_HOST: email-alert-frontend.dev.gov.uk
       BINDING: 0.0.0.0
+
+  email-alert-frontend-redis:
+    image: redis

--- a/projects/email-alert-service/docker-compose.yml
+++ b/projects/email-alert-service/docker-compose.yml
@@ -14,6 +14,9 @@ services:
   email-alert-service-lite:
     <<: *email-alert-service
     depends_on:
-      - redis
+      - email-alert-service-redis
     environment:
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://email-alert-service-redis
+
+  email-alert-service-redis:
+    image: redis

--- a/projects/feedback/docker-compose.yml
+++ b/projects/feedback/docker-compose.yml
@@ -24,7 +24,7 @@ services:
   feedback-app: &feedback-app
     <<: *feedback
     depends_on:
-      - redis
+      - feedback-redis
       - router-app
       - static-app
       - nginx-proxy
@@ -32,7 +32,7 @@ services:
       - support-app
     environment:
       GOVUK_PROXY_STATIC_ENABLED: "true"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://feedback-redis
       VIRTUAL_HOST: feedback.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -42,7 +42,7 @@ services:
   feedback-app-live:
     <<: *feedback-app
     depends_on:
-      - redis
+      - feedback-redis
       - nginx-proxy
     environment:
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
@@ -51,4 +51,7 @@ services:
       PLEK_SERVICE_STATIC_URI: https://assets.publishing.service.gov.uk
       VIRTUAL_HOST: feedback.dev.gov.uk
       BINDING: 0.0.0.0
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://feedback-redis
+
+  feedback-redis:
+    image: redis

--- a/projects/govuk-chat/docker-compose.yml
+++ b/projects/govuk-chat/docker-compose.yml
@@ -23,12 +23,12 @@ services:
       - opensearch-2
       - postgres-16
       - rabbitmq
-      - redis
+      - govuk-chat-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-16/govuk-chat"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-16/govuk-chat-test"
       RABBITMQ_URL: amqp://guest:guest@rabbitmq
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://govuk-chat-redis
       OPENSEARCH_URL: http://opensearch-2:9200
 
   govuk-chat-app:
@@ -38,10 +38,10 @@ services:
       - govuk-chat-worker
       - nginx-proxy
       - postgres-16
-      - redis
+      - govuk-chat-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-16/govuk-chat"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://govuk-chat-redis
       OPENSEARCH_URL: http://opensearch-2:9200
       VIRTUAL_HOST: govuk-chat.dev.gov.uk
       BINDING: 0.0.0.0
@@ -57,10 +57,10 @@ services:
     <<: *govuk-chat
     depends_on:
       - opensearch-2
-      - redis
+      - govuk-chat-redis
       - postgres-16
     environment:
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://govuk-chat-redis
       DATABASE_URL: "postgresql://postgres@postgres-16/govuk-chat"
       OPENSEARCH_URL: http://opensearch-2:9200
     command: bin/dev worker
@@ -76,3 +76,6 @@ services:
       RABBITMQ_URL: amqp://guest:guest@rabbitmq
       OPENSEARCH_URL: http://opensearch-2:9200
     command: bin/dev queue_consumer
+
+  govuk-chat-redis:
+    image: redis

--- a/projects/govuk_crawler_worker/docker-compose.yml
+++ b/projects/govuk_crawler_worker/docker-compose.yml
@@ -13,7 +13,10 @@ services:
     <<: *govuk_crawler_worker
     depends_on:
       - rabbitmq
-      - redis
+      - govuk_crawler_worker-redis
     environment:
       AMQP_ADDRESS: amqp://guest:guest@rabbitmq:5672
-      REDIS_ADDRESS: redis:6379
+      REDIS_ADDRESS: govuk_crawler_worker-redis:6379
+
+  govuk_crawler_worker-redis:
+    image: redis

--- a/projects/link-checker-api/docker-compose.yml
+++ b/projects/link-checker-api/docker-compose.yml
@@ -19,12 +19,12 @@ services:
     <<: *link-checker-api
     depends_on:
       - postgres-13
-      - redis
+      - link-checker-api-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/link-checker-api"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/link-checker-api-test"
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://link-checker-api-redis
 
   link-checker-api-app: &link-checker-api-app
     <<: *link-checker-api
@@ -32,10 +32,10 @@ services:
       - link-checker-api-worker
       - nginx-proxy
       - postgres-13
-      - redis
+      - link-checker-api-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/link-checker-api"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://link-checker-api-redis
       VIRTUAL_HOST: link-checker-api.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -46,9 +46,12 @@ services:
     <<: *link-checker-api
     depends_on:
       - postgres-13
-      - redis
+      - link-checker-api-redis
       - nginx-proxy
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/link-checker-api"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://link-checker-api-redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  link-checker-api-redis:
+    image: redis

--- a/projects/local-links-manager/docker-compose.yml
+++ b/projects/local-links-manager/docker-compose.yml
@@ -22,23 +22,26 @@ services:
     shm_size: 512mb
     depends_on:
       - postgres-13
-      - redis
+      - local-links-manager-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/local-links-manager"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/local-links-manager-test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://local-links-manager-redis
 
   local-links-manager-app:
     <<: *local-links-manager
     depends_on:
       - postgres-13
       - nginx-proxy
-      - redis
+      - local-links-manager-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/local-links-manager"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://local-links-manager-redis
       VIRTUAL_HOST: local-links-manager.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart
+
+  local-links-manager-redis:
+    image: redis

--- a/projects/locations-api/docker-compose.yml
+++ b/projects/locations-api/docker-compose.yml
@@ -19,10 +19,10 @@ services:
     <<: *locations-api
     depends_on:
       - postgres-13
-      - redis
+      - locations-api-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/locations-api"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://locations-api-redis
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/locations-api-test"
 
   locations-api-app: &locations-api-app
@@ -30,10 +30,10 @@ services:
     depends_on:
       - nginx-proxy
       - postgres-13
-      - redis
+      - locations-api-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/locations-api"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://locations-api-redis
       VIRTUAL_HOST: locations-api.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -44,8 +44,11 @@ services:
     <<: *locations-api
     depends_on:
       - postgres-13
-      - redis
+      - locations-api-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/locations-api"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://locations-api-redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  locations-api-redis:
+    image: redis

--- a/projects/manuals-publisher/docker-compose.yml
+++ b/projects/manuals-publisher/docker-compose.yml
@@ -21,17 +21,17 @@ services:
     <<: *manuals-publisher
     shm_size: 512mb
     depends_on:
-      - redis
+      - manuals-publisher-redis
       - mongo-3.6
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/manuals-publisher"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/manuals-publisher-test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://manuals-publisher-redis
 
   manuals-publisher-app: &manuals-publisher-app
     <<: *manuals-publisher
     depends_on:
-      - redis
+      - manuals-publisher-redis
       - mongo-3.6
       - asset-manager-app
       - publishing-api-app
@@ -41,7 +41,7 @@ services:
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/manuals-publisher"
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://manuals-publisher-redis
       VIRTUAL_HOST: manuals-publisher.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -51,11 +51,14 @@ services:
   manuals-publisher-worker:
     <<: *manuals-publisher
     depends_on:
-      - redis
+      - manuals-publisher-redis
       - mongo-3.6
       - asset-manager-app
       - publishing-api-app
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/manuals-publisher"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://manuals-publisher-redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  manuals-publisher-redis:
+    image: redis

--- a/projects/places-manager/docker-compose.yml
+++ b/projects/places-manager/docker-compose.yml
@@ -19,11 +19,11 @@ services:
     <<: *places-manager
     depends_on:
       - postgres-14-postgis
-      - redis
+      - places-manager-redis
     environment:
       DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/places-manager"
       TEST_DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/places-manager-test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://places-manager-redis
 
   places-manager-app: &places-manager-app
     <<: *places-manager
@@ -32,13 +32,13 @@ services:
       - local-links-manager-app
       - locations-api-app
       - nginx-proxy
-      - redis
+      - places-manager-redis
       - places-manager-worker
     environment:
       DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/places-manager"
       VIRTUAL_HOST: places-manager.dev.gov.uk
       BINDING: 0.0.0.0
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://places-manager-redis
     expose:
       - "3000"
     command: bin/rails s --restart
@@ -50,8 +50,11 @@ services:
       - local-links-manager-app
       - locations-api-app
       - nginx-proxy
-      - redis
+      - places-manager-redis
     environment:
       DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/places-manager"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://places-manager-redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  places-manager-redis:
+    image: redis

--- a/projects/publisher/docker-compose.yml
+++ b/projects/publisher/docker-compose.yml
@@ -21,17 +21,17 @@ services:
     <<: *publisher
     shm_size: 512mb
     depends_on:
-      - redis
+      - publisher-redis
       - mongo-3.6
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/publisher"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/publisher-test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://publisher-redis
 
   publisher-app: &publisher-app
     <<: *publisher
     depends_on:
-      - redis
+      - publisher-redis
       - mongo-3.6
       - nginx-proxy
       - publishing-api-app
@@ -40,7 +40,7 @@ services:
       - publisher-css
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/publisher"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://publisher-redis
       VIRTUAL_HOST: publisher.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -54,11 +54,14 @@ services:
   publisher-worker:
     <<: *publisher
     depends_on:
-      - redis
+      - publisher-redis
       - mongo-3.6
       - nginx-proxy
       - publishing-api-app
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/publisher"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://publisher-redis
     command: bin/dev worker
+
+  publisher-redis:
+    image: redis

--- a/projects/publishing-api/docker-compose.yml
+++ b/projects/publishing-api/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     <<: *publishing-api
     depends_on:
       - postgres-16
-      - redis
+      - publishing-api-redis
       - rabbitmq
     environment:
       RABBITMQ_EXCHANGE: published_documents
@@ -27,20 +27,20 @@ services:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api-test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://publishing-api-redis
 
   publishing-api-app: &publishing-api-app
     <<: *publishing-api
     depends_on:
       - postgres-16
       - publishing-api-worker
-      - redis
+      - publishing-api-redis
       - nginx-proxy
     environment:
       RABBITMQ_EXCHANGE: published_documents
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
       DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://publishing-api-redis
       VIRTUAL_HOST: publishing-api.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -51,11 +51,14 @@ services:
     <<: *publishing-api
     depends_on:
       - postgres-16
-      - redis
+      - publishing-api-redis
       - rabbitmq
     environment:
       RABBITMQ_EXCHANGE: published_documents
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
       DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://publishing-api-redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  publishing-api-redis:
+    image: redis

--- a/projects/release/docker-compose.yml
+++ b/projects/release/docker-compose.yml
@@ -21,24 +21,27 @@ services:
     <<: *release
     depends_on:
       - mysql-8
-      - redis
+      - release-redis
     environment:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       DATABASE_URL: "mysql2://root:root@mysql-8/release_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-8/release_test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://release-redi
 
   release-app:
     <<: *release
     depends_on:
       - mysql-8
       - nginx-proxy
-      - redis
+      - release-redis
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/release_development"
       BINDING: 0.0.0.0
       VIRTUAL_HOST: release.dev.gov.uk
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://release-redi
     expose:
       - "3000"
     command: ./bin/dev
+
+  release-redis:
+    image: redis

--- a/projects/search-api-v2/docker-compose.yml
+++ b/projects/search-api-v2/docker-compose.yml
@@ -22,10 +22,10 @@ services:
     <<: *search-api-v2
     depends_on:
       - rabbitmq
-      - redis
+      - search-api-v2-redis
     environment:
       RABBITMQ_URL: amqp://guest:guest@rabbitmq
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://search-api-v2-redis
       PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: search_api_v2_published_documents
       DISCOVERY_ENGINE_DATASTORE: none
       DISCOVERY_ENGINE_DATASTORE_BRANCH: none
@@ -36,11 +36,11 @@ services:
     depends_on:
       - nginx-proxy
       - rabbitmq
-      - redis
+      - search-api-v2-redis
       - search-api-v2-document-sync-worker
     environment:
       RABBITMQ_URL: "amqp://guest:guest@rabbitmq"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://search-api-v2-redis
       PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: "search_api_v2_published_documents"
       RAILS_DEVELOPMENT_HOSTS: "search-api-v2.dev.gov.uk,search-api-v2-app"
       VIRTUAL_HOST: "search-api-v2.dev.gov.uk"
@@ -59,10 +59,10 @@ services:
     <<: *search-api-v2
     depends_on:
       - rabbitmq
-      - redis
+      - search-api-v2-redis
     environment:
       RABBITMQ_URL: "amqp://guest:guest@rabbitmq"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://search-api-v2-redis
       PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: "search_api_v2_published_documents"
       # The fully qualified ID of the datastore, branch and serving config on the Discovery Engine
       # integration environment (required to use Discovery Engine locally).
@@ -71,3 +71,6 @@ services:
       DISCOVERY_ENGINE_DATASTORE_BRANCH: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/branches/default_branch"
       DISCOVERY_ENGINE_SERVING_CONFIG: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/servingConfigs/default_search"
     command: bin/rake document_sync_worker:run
+
+  search-api-v2-redis:
+    image: redis

--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -11,14 +11,14 @@ x-search-api: &search-api
   working_dir: /govuk/search-api
   environment:
     RABBITMQ_URL: amqp://guest:guest@rabbitmq
-    REDIS_URL: redis://redis
+    REDIS_URL: redis://search-api-redis
     ELASTICSEARCH_URI: http://elasticsearch-6:9200
 
 services:
   search-api-lite:
     <<: *search-api
     depends_on:
-      - redis
+      - search-api-redis
       - rabbitmq
       - elasticsearch-6
 
@@ -26,7 +26,7 @@ services:
     <<: *search-api
     depends_on:
       - nginx-proxy
-      - redis
+      - search-api-redis
       - elasticsearch-6
       - search-api-worker
       - search-api-listener-publishing-queue
@@ -34,7 +34,7 @@ services:
       - search-api-listener-bulk-insert-data
     environment:
       RABBITMQ_URL: amqp://guest:guest@rabbitmq
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://search-api-redis
       ELASTICSEARCH_URI: http://elasticsearch-6:9200
       VIRTUAL_HOST: search-api.dev.gov.uk, search.dev.gov.uk
       BINDING: 0.0.0.0
@@ -45,7 +45,7 @@ services:
   search-api-worker:
     <<: *search-api
     depends_on:
-      - redis
+      - search-api-redis
       - rabbitmq
       - elasticsearch-6
     command: bundle exec sidekiq -C ./config/sidekiq.yml
@@ -67,3 +67,6 @@ services:
     depends_on:
       - rabbitmq
     command: bundle exec rake message_queue:bulk_insert_data_into_govuk
+
+  search-api-redis:
+    image: redis

--- a/projects/short-url-manager/docker-compose.yml
+++ b/projects/short-url-manager/docker-compose.yml
@@ -22,21 +22,21 @@ services:
     shm_size: 512mb
     depends_on:
       - short-url-manager-redis
-      - mongo-3
+      - mongo-3.6
     environment:
-      MONGODB_URI: "mongodb://mongo-3/short-url-manager"
-      TEST_MONGODB_URI: "mongodb://mongo-3/short-url-manager-test"
+      MONGODB_URI: "mongodb://mongo-3.6/short-url-manager"
+      TEST_MONGODB_URI: "mongodb://mongo-3.6/short-url-manager-test"
       REDIS_URL: redis://short-url-manager-redis
 
   short-url-manager-app: &short-url-manager-app
     <<: *short-url-manager
     depends_on:
       - short-url-manager-redis
-      - mongo-3
+      - mongo-3.6
       - nginx-proxy
       - publishing-api-app
     environment:
-      MONGODB_URI: "mongodb://mongo-3/short-url-manager"
+      MONGODB_URI: "mongodb://mongo-3.6/short-url-manager"
       REDIS_URL: redis://short-url-manager-redis
       VIRTUAL_HOST: short-url-manager.dev.gov.uk
       BINDING: 0.0.0.0

--- a/projects/short-url-manager/docker-compose.yml
+++ b/projects/short-url-manager/docker-compose.yml
@@ -21,25 +21,28 @@ services:
     <<: *short-url-manager
     shm_size: 512mb
     depends_on:
-      - redis
-      - mongo-3.6
+      - short-url-manager-redis
+      - mongo-3
     environment:
-      MONGODB_URI: "mongodb://mongo-3.6/short-url-manager"
-      TEST_MONGODB_URI: "mongodb://mongo-3.6/short-url-manager-test"
-      REDIS_URL: redis://redis
+      MONGODB_URI: "mongodb://mongo-3/short-url-manager"
+      TEST_MONGODB_URI: "mongodb://mongo-3/short-url-manager-test"
+      REDIS_URL: redis://short-url-manager-redis
 
   short-url-manager-app: &short-url-manager-app
     <<: *short-url-manager
     depends_on:
-      - redis
-      - mongo-3.6
+      - short-url-manager-redis
+      - mongo-3
       - nginx-proxy
       - publishing-api-app
     environment:
-      MONGODB_URI: "mongodb://mongo-3.6/short-url-manager"
-      REDIS_URL: redis://redis
+      MONGODB_URI: "mongodb://mongo-3/short-url-manager"
+      REDIS_URL: redis://short-url-manager-redis
       VIRTUAL_HOST: short-url-manager.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart
+
+  short-url-manager-redis:
+    image: redis

--- a/projects/signon/docker-compose.yml
+++ b/projects/signon/docker-compose.yml
@@ -22,24 +22,24 @@ services:
     shm_size: 512mb
     depends_on:
       - mysql-8
-      - redis
+      - signon-redis
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/signon_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-8/signon_test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://signon-redis
 
   signon-app:
     <<: *signon
     depends_on:
       - mysql-8
       - nginx-proxy
-      - redis
+      - signon-redis
       - signon-worker
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/signon_development"
       VIRTUAL_HOST: signon.dev.gov.uk
       BINDING: 0.0.0.0
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://signon-redis
     expose:
       - "3000"
     command: ./bin/dev
@@ -48,9 +48,12 @@ services:
     <<: *signon
     depends_on:
       - mysql-8
-      - redis
+      - signon-redis
       - nginx-proxy
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/signon_development"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://signon-redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  signon-redis:
+    image: redis

--- a/projects/specialist-publisher/docker-compose.yml
+++ b/projects/specialist-publisher/docker-compose.yml
@@ -22,17 +22,17 @@ services:
     shm_size: 512mb
     depends_on:
       - mongo-3.6
-      - redis
+      - specialist-publisher-redis
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/specialist-publisher"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/specialist-publisher-test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://specialist-publisher-redis
 
   specialist-publisher-app: &specialist-publisher-app
     <<: *specialist-publisher
     depends_on:
       - mongo-3.6
-      - redis
+      - specialist-publisher-redis
       - nginx-proxy
       - publishing-api-app
       - asset-manager-app
@@ -40,7 +40,7 @@ services:
       - specialist-publisher-worker
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/specialist-publisher"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://specialist-publisher-redis
       VIRTUAL_HOST: specialist-publisher.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -51,10 +51,13 @@ services:
     <<: *specialist-publisher
     depends_on:
       - mongo-3.6
-      - redis
+      - specialist-publisher-redis
       - publishing-api-app
       - asset-manager-app
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/specialist-publisher"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://specialist-publisher-redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  specialist-publisher-redis:
+    image: redis

--- a/projects/support-api/docker-compose.yml
+++ b/projects/support-api/docker-compose.yml
@@ -19,23 +19,26 @@ services:
     <<: *support-api
     depends_on:
       - postgres-13
-      - redis
+      - support-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/support-api"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/support-api-test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://support-redis
 
   support-api-app: &support-api-app
     <<: *support-api
     depends_on:
       - postgres-13
-      - redis
+      - support-redis
       - nginx-proxy
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/support-api"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://support-redis
       VIRTUAL_HOST: support-api.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart
+
+  support-redis:
+    image: redis

--- a/projects/support-api/docker-compose.yml
+++ b/projects/support-api/docker-compose.yml
@@ -19,7 +19,7 @@ services:
     <<: *support-api
     depends_on:
       - postgres-13
-      - support-redis
+      - support-api-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/support-api"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/support-api-test"
@@ -29,16 +29,16 @@ services:
     <<: *support-api
     depends_on:
       - postgres-13
-      - support-redis
+      - support-api-redis
       - nginx-proxy
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/support-api"
-      REDIS_URL: redis://support-redis
+      REDIS_URL: redis://support-api-redis
       VIRTUAL_HOST: support-api.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/rails s --restart
 
-  support-redis:
+  support-api-redis:
     image: redis

--- a/projects/support/docker-compose.yml
+++ b/projects/support/docker-compose.yml
@@ -20,20 +20,23 @@ services:
   support-lite:
     <<: *support
     depends_on:
-      - redis
+      - support-redis
     environment:
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://support-redis
 
   support-app: &support-app
     <<: *support
     depends_on:
-      - redis
+      - support-redis
       - nginx-proxy
       - support-api-app
     environment:
       VIRTUAL_HOST: support.dev.gov.uk
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://support-redis
       BINDING: 0.0.0.0
     expose:
       - "3000"
     command: ./bin/dev
+
+  support-redis:
+    image: redis

--- a/projects/transition/docker-compose.yml
+++ b/projects/transition/docker-compose.yml
@@ -20,24 +20,27 @@ services:
     shm_size: 512mb
     depends_on:
       - postgres-13
-      - redis
+      - transition-redis
     environment:
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       DATABASE_URL: "postgresql://postgres@postgres-13/transition"
       TEST_DATABASE_URL: "postgresql://postgres@postgres-13/transition-test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://transition-redis
 
   transition-app: &transition-app
     <<: *transition
     depends_on:
       - nginx-proxy
       - postgres-13
-      - redis
+      - transition-redis
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-13/transition"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://transition-redis
       VIRTUAL_HOST: transition.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
       - "3000"
     command: bin/dev
+
+  transition-redis:
+    image: redis

--- a/projects/travel-advice-publisher/docker-compose.yml
+++ b/projects/travel-advice-publisher/docker-compose.yml
@@ -22,24 +22,24 @@ services:
     shm_size: 512mb
     depends_on:
       - mongo-3.6
-      - redis
+      - travel-advice-publisher-redis
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/travel-advice-publisher"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/travel-advice-publisher-test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://travel-advice-publisher-redis
 
   travel-advice-publisher-app: &travel-advice-publisher-app
     <<: *travel-advice-publisher
     depends_on:
       - mongo-3.6
-      - redis
+      - travel-advice-publisher-redis
       - publishing-api-app
       - asset-manager-app
       - content-store-app
       - nginx-proxy
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/travel-advice-publisher"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://travel-advice-publisher-redis
       VIRTUAL_HOST: travel-advice-publisher.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -50,9 +50,12 @@ services:
     <<: *travel-advice-publisher
     depends_on:
       - mongo-3.6
-      - redis
+      - travel-advice-publisher-redis
       - publishing-api-app
       - asset-manager-app
     environment:
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://travel-advice-publisher-redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  travel-advice-publisher-redis:
+    image: redis

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       GOVUK_ASSET_ROOT: "http://asset-manager.dev.gov.uk"
       DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://whitehall-redis
 
   whitehall-app: &whitehall-app
     <<: *whitehall
@@ -46,7 +46,7 @@ services:
       GOVUK_PROXY_STATIC_ENABLED: "true"
       GOVUK_ASSET_ROOT: "http://asset-manager.dev.gov.uk"
       DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_development"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://whitehall-redis
       VIRTUAL_HOST: whitehall-admin.dev.gov.uk, whitehall-frontend.dev.gov.uk
       BINDING: 0.0.0.0
       DISABLE_ASSETS_DEBUG:
@@ -64,5 +64,8 @@ services:
       - publishing-api-app
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_development"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://whitehall-redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  whitehall-redis:
+    image: redis

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     shm_size: 512mb
     depends_on:
       - mysql-8
-      - redis
+      - whitehall-redis
     environment:
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
       GOVUK_ASSET_ROOT: "http://asset-manager.dev.gov.uk"
@@ -37,7 +37,7 @@ services:
     <<: *whitehall
     depends_on:
       - mysql-8
-      - redis
+      - whitehall-redis
       - nginx-proxy
       - asset-manager-app
       - publishing-api-app
@@ -58,7 +58,7 @@ services:
     <<: *whitehall
     depends_on:
       - mysql-8
-      - redis
+      - whitehall-redis
       - nginx-proxy
       - asset-manager-app
       - publishing-api-app

--- a/spec/integration/compose/expected_volumes_spec.rb
+++ b/spec/integration/compose/expected_volumes_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe "Expected volumes" do
   end
 
   rails_projects.each do |project_name|
-    ComposeHelper.services(project_name).each_pair do |service_name, service|
+    ComposeHelper.services(project_name)
+                 .reject { |service_name| service_name.end_with? "redis" }
+                 .each_pair do |service_name, service|
       it "configures #{service_name} with a govuk delegated volume" do
         expect(service.fetch("volumes", []))
           .to include("${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated")
@@ -36,7 +38,9 @@ RSpec.describe "Expected volumes" do
   end
 
   node_projects.each do |project_name|
-    ComposeHelper.services(project_name).each_pair do |service_name, service|
+    ComposeHelper.services(project_name)
+                 .reject { |service_name| service_name.end_with? "redis" }
+                 .each_pair do |service_name, service|
       it "configures #{service_name} with a node modules volume" do
         expect(service.fetch("volumes", []))
           .to include("#{project_name}-node-modules:/govuk/#{project_name}/node_modules")


### PR DESCRIPTION
Sidekiq queues no longer use Redis namespaces with a shared Redis instance in production. Instead, each project has a dedicated Redis instance.

We are therefore unable to share a Redis instance in GOV.UK docker. This commit adds a redis service for each individual project.

The shared redis instance is maintained as some non-Sidekiq use cases rely on it (e.g. the emergency banner)