### PR TITLE
Add a draft content store

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -149,6 +149,7 @@ services:
           - content-data-admin.dev.gov.uk
           - content-store.dev.gov.uk
           - content-tagger.dev.gov.uk
+          - draft-content-store.dev.gov.uk
           - draft-origin.dev.gov.uk
           - draft-router.dev.gov.uk
           - email-alert-api.dev.gov.uk

--- a/projects/content-store/docker-compose.yml
+++ b/projects/content-store/docker-compose.yml
@@ -35,3 +35,10 @@ services:
     expose:
       - "3000"
     command: bin/rails s --restart
+
+  content-store-app-draft:
+    <<: *content-store-app
+    environment:
+      VIRTUAL_HOST: draft-content-store.dev.gov.uk
+      DATABASE_URL: "postgresql://postgres@postgres-13/draft-content-store"
+      BINDING: 0.0.0.0


### PR DESCRIPTION
This will allow us to easily run a draft version of the content store locally, so we can test out the publishing flow more easily end-to-end