### PR TITLE
Search API v2: Add `GOOGLE_CLOUD_PROJECT_ID`

### DIFF
--- a/projects/search-api-v2/docker-compose.yml
+++ b/projects/search-api-v2/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       # The fully qualified ID of the datastore, branch and engine on the Discovery Engine integration
       # environment (required to use Discovery Engine locally).
       #
+      GOOGLE_CLOUD_PROJECT_ID: "search-api-v2-integration"
       DISCOVERY_ENGINE_DATASTORE: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content"
       DISCOVERY_ENGINE_DATASTORE_BRANCH: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/branches/default_branch"
       DISCOVERY_ENGINE_SERVING_CONFIG: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/servingConfigs/default_search"


### PR DESCRIPTION
This environment variable is now available on the deployed environments, adding it here as well.

see https://github.com/alphagov/govuk-helm-charts/pull/2802