### PR TITLE
Remove search-api-URI in government-frontend

### DIFF
--- a/projects/government-frontend/docker-compose.yml
+++ b/projects/government-frontend/docker-compose.yml
@@ -45,7 +45,6 @@ services:
       GOVUK_PROXY_STATIC_ENABLED: "true"
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       PLEK_SERVICE_STATIC_URI: https://assets.publishing.service.gov.uk
-      PLEK_SERVICE_SEARCH_API_URI: https://www.gov.uk/api
       VIRTUAL_HOST: government-frontend.dev.gov.uk
       BINDING: 0.0.0.0
 
@@ -58,6 +57,5 @@ services:
       GOVUK_PROXY_STATIC_ENABLED: "true"
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.integration.publishing.service.gov.uk/api
       PLEK_SERVICE_STATIC_URI: https://assets.integration.publishing.service.gov.uk
-      PLEK_SERVICE_SEARCH_API_URI: https://www.integration.publishing.service.gov.uk/api
       VIRTUAL_HOST: government-frontend.dev.gov.uk
       BINDING: 0.0.0.0


### PR DESCRIPTION
- Removed search-api-URI from government-frontend as get-involved document_type is now rendered by frontend

Trello card: https://trello.com/c/mXj8oTI3/349-move-document-type-getinvolved-from-government-frontend-to-frontend