### PR TITLE
Update Search API v2/Search Admin env and Redis 

### DIFF
--- a/projects/search-admin/docker-compose.yml
+++ b/projects/search-admin/docker-compose.yml
@@ -27,9 +27,8 @@ services:
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/search_admin_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-8/search_admin_test"
-      REDIS_URL: redis://redis
-      DISCOVERY_ENGINE_ENGINE: none
-      DISCOVERY_ENGINE_SERVING_CONFIG: none
+      REDIS_URL: redis://search-admin-redis
+      DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME: none
 
   search-admin-app: &search-admin-app
     <<: *search-admin-base
@@ -40,12 +39,14 @@ services:
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/search_admin_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-8/search_admin_test"
-      REDIS_URL: redis://redis
+      REDIS_URL: redis://search-admin-redis
       VIRTUAL_HOST: search-admin.dev.gov.uk
       BINDING: 0.0.0.0
       PORT: 3000
-      DISCOVERY_ENGINE_ENGINE: projects/search-api-v2-integration/locations/global/collections/default_collection/engines/govuk
-      DISCOVERY_ENGINE_SERVING_CONFIG: projects/search-api-v2-integration/locations/global/collections/default_collection/engines/govuk/servingConfigs/default_search
+      DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME: "projects/780375417592/locations/global/collections/default_collection"
     expose:
       - "3000"
     command: bin/dev
+
+  search-admin-redis:
+    image: redis

--- a/projects/search-api-v2/docker-compose.yml
+++ b/projects/search-api-v2/docker-compose.yml
@@ -28,9 +28,7 @@ services:
       REDIS_URL: redis://search-api-v2-redis
       PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: search_api_v2_published_documents
       GOOGLE_CLOUD_PROJECT_ID: none
-      DISCOVERY_ENGINE_DATASTORE: none
-      DISCOVERY_ENGINE_DATASTORE_BRANCH: none
-      DISCOVERY_ENGINE_SERVING_CONFIG: none
+      DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME: none
 
   search-api-v2-app:
     <<: *search-api-v2
@@ -46,13 +44,8 @@ services:
       RAILS_DEVELOPMENT_HOSTS: "search-api-v2.dev.gov.uk,search-api-v2-app"
       VIRTUAL_HOST: "search-api-v2.dev.gov.uk"
       BINDING: "0.0.0.0"
-      # The fully qualified ID of the datastore, branch and engine on the Discovery Engine integration
-      # environment (required to use Discovery Engine locally).
-      #
-      GOOGLE_CLOUD_PROJECT_ID: "search-api-v2-integration"
-      DISCOVERY_ENGINE_DATASTORE: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content"
-      DISCOVERY_ENGINE_DATASTORE_BRANCH: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/branches/default_branch"
-      DISCOVERY_ENGINE_SERVING_CONFIG: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/servingConfigs/default_search"
+      GOOGLE_CLOUD_PROJECT_ID: "780375417592"
+      DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME: "projects/780375417592/locations/global/collections/default_collection"
     expose:
       - "3000"
     command: bin/rails server --restart
@@ -66,13 +59,8 @@ services:
       RABBITMQ_URL: "amqp://guest:guest@rabbitmq"
       REDIS_URL: redis://search-api-v2-redis
       PUBLISHED_DOCUMENTS_MESSAGE_QUEUE_NAME: "search_api_v2_published_documents"
-      # The fully qualified ID of the datastore, branch and serving config on the Discovery Engine
-      # integration environment (required to use Discovery Engine locally).
-      #
-      GOOGLE_CLOUD_PROJECT_ID: "search-api-v2-integration"
-      DISCOVERY_ENGINE_DATASTORE: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content"
-      DISCOVERY_ENGINE_DATASTORE_BRANCH: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/branches/default_branch"
-      DISCOVERY_ENGINE_SERVING_CONFIG: "projects/search-api-v2-integration/locations/global/collections/default_collection/dataStores/govuk_content/servingConfigs/default_search"
+      GOOGLE_CLOUD_PROJECT_ID: "780375417592"
+      DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME: "projects/780375417592/locations/global/collections/default_collection"
     command: bin/rake document_sync_worker:run
 
   search-api-v2-redis:


### PR DESCRIPTION
- Set the new `DISCOVERY_ENGINE_DEFAULT_COLLECTION_NAME` environment
  variable for Search API v2 and Search Admin
- Remove the legacy Discovery Engine environment variables from Search
  Admin
- Replace the human-readable GCP project ID with the numeric form in all
  env vars for consistency (sadly _some_ API calls only accept the
  numeric form, so we might as well use it everywhere)
- Add a dedicated Redis instance for Search Admin (which will be using
  Sidekiq again)
