### PR TITLE
Add `signon-app` to Whitehall/Mainstream

### DIFF
--- a/projects/publisher/Makefile
+++ b/projects/publisher/Makefile
@@ -1,4 +1,4 @@
-publisher: bundle-publisher publishing-api link-checker-api
+publisher: bundle-publisher publishing-api link-checker-api signon
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:setup
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/publisher/docker-compose.yml
+++ b/projects/publisher/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - link-checker-api-app
       - publisher-worker
       - publisher-css
+      - signon-app
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/publisher"
       REDIS_URL: redis://publisher-redis

--- a/projects/whitehall/Makefile
+++ b/projects/whitehall/Makefile
@@ -1,4 +1,4 @@
-whitehall: bundle-whitehall asset-manager publishing-api
+whitehall: bundle-whitehall asset-manager publishing-api signon
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - asset-manager-app
       - publishing-api-app
       - whitehall-worker
+      - signon-app
     environment:
       GOVUK_PROXY_STATIC_ENABLED: "true"
       GOVUK_ASSET_ROOT: "http://asset-manager.dev.gov.uk"


### PR DESCRIPTION
Whitehall (and Mainstream shortly) will soon need access to Signon to fetch user information about updated content blocks (see https://github.com/alphagov/publisher/pull/2513 and https://github.com/alphagov/whitehall/pull/9754)