### PR TITLE
Router: Update Go to 1.23

### DIFF
--- a/projects/router/Dockerfile
+++ b/projects/router/Dockerfile
@@ -1,1 +1,1 @@
-FROM golang:1.22
+FROM golang:1.23


### PR DESCRIPTION
This was updated recently in https://github.com/alphagov/router/pull/518