### PR TITLE
Add Link Checker API dependency to Whitehall

### DIFF
--- a/projects/whitehall/Makefile
+++ b/projects/whitehall/Makefile
@@ -1,4 +1,4 @@
-whitehall: bundle-whitehall asset-manager publishing-api signon
+whitehall: bundle-whitehall asset-manager link-checker-api publishing-api signon
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - whitehall-redis
       - nginx-proxy
       - asset-manager-app
+      - link-checker-api-app
       - publishing-api-app
       - whitehall-worker
       - signon-app
@@ -62,6 +63,7 @@ services:
       - whitehall-redis
       - nginx-proxy
       - asset-manager-app
+      - link-checker-api-app
       - publishing-api-app
     environment:
       DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_development"


### PR DESCRIPTION
Whitehall has a 'broken links checker' feature that needs Link Checker API to be running in order to work.

Trello: https://trello.com/c/tmnht4P1