### PR TITLE
Update developer docs config

### DIFF
--- a/projects/govuk-developer-docs/Makefile
+++ b/projects/govuk-developer-docs/Makefile
@@ -1,1 +1,2 @@
 govuk-developer-docs: bundle-govuk-developer-docs
+	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/govuk-developer-docs/docker-compose.yml
+++ b/projects/govuk-developer-docs/docker-compose.yml
@@ -1,3 +1,6 @@
+volumes:
+  govuk-developer-docs-node-modules:
+
 x-govuk-developer-docs: &govuk-developer-docs
   build:
     context: .
@@ -6,6 +9,7 @@ x-govuk-developer-docs: &govuk-developer-docs
   volumes:
     - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
     - root-home:/root
+    - govuk-developer-docs-node-modules:/govuk/govuk-developer-docs/node_modules
   working_dir: /govuk/govuk-developer-docs
 
 services:
@@ -22,4 +26,4 @@ services:
       VIRTUAL_HOST: govuk-developer-docs.dev.gov.uk
     expose:
       - "4567"
-    command: bundle exec middleman server --bind-address 0.0.0.0
+    command: bash -c "yarn && bundle exec middleman server --bind-address 0.0.0.0"

--- a/projects/govuk-developer-docs/docker-compose.yml
+++ b/projects/govuk-developer-docs/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     <<: *govuk-developer-docs
     environment:
       LANG: "C.UTF-8"
+      NO_CONTRACTS: true
 
   govuk-developer-docs-app:
     <<: *govuk-developer-docs


### PR DESCRIPTION
This adds a `yarn` step to Developer Docs now we have JS dependencies (see https://github.com/alphagov/govuk-developer-docs/pull/5019), as well as adding a `NO_CONTRACTS` env var to skip some of Middleman's magic typechecking, which slows the build down.