### PR TITLE
Automatically run taxonomy building rake task

### DIFF
--- a/projects/whitehall/Makefile
+++ b/projects/whitehall/Makefile
@@ -2,3 +2,6 @@ whitehall: bundle-whitehall asset-manager link-checker-api publishing-api signon
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn
+	$(GOVUK_DOCKER) run $@-lite yarn
+	$(GOVUK_DOCKER) run $@-lite rails taxonomy:populate_end_to_end_test_data
+	$(GOVUK_DOCKER) run $@-lite rails taxonomy:rebuild_cache


### PR DESCRIPTION
Whitehall expects this task to have been run, otherwise when you try to publish a document locally, you will be told you need to add a topic, and when you try to add a topic, there are no topics to choose from.