### PR TITLE
Run Publishing API alongside Frontend

### DIFF
--- a/projects/frontend/Makefile
+++ b/projects/frontend/Makefile
@@ -1,2 +1,2 @@
-frontend: bundle-frontend account-api content-store router search-api static
+frontend: bundle-frontend account-api content-store publishing-api router search-api static
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - account-api-app
       - content-store-app
       - nginx-proxy
+      - publishing-api-app
       - router-app
       - search-api-app
       - static-app


### PR DESCRIPTION
We did similar for Collections in d6b7b30f53967ce126c495f2268fa6317594fa60. Like with Collections, we conditionally run GraphQL queries in Frontend. These queries are made directly to Publishing API from the Frontend app, so we need to run Publishing API at the same time as Frontend when developing locally

[Trello](https://trello.com/c/wZY6HFxy/1673-make-graphql-version-of-news-articles-reference-the-same-image-src-as-regular-version)