### PR TITLE
Fix: add --rm to govuk-docker-run

### DIFF
--- a/exe/govuk-docker-run
+++ b/exe/govuk-docker-run
@@ -10,4 +10,4 @@
 # on top of docker and docker-compose.
 # **************************************************************
 
-"$(dirname "$0")"/govuk-docker run "$(basename "$(pwd)")-lite" "$@"
+"$(dirname "$0")"/govuk-docker run --rm "$(basename "$(pwd)")-lite" "$@"


### PR DESCRIPTION
govuk-docker-run is usually used for short-lived tasks like rake tasks, test suites, bundle installs, etc. Without the --rm (delete container after it exits) flag, it tends to leave lots of orphan containers, which subsequent runs complain about.