### PR TITLE
Add `docker build prune` step to the "clean slate" instruction

### DIFF
--- a/docs/how-tos.md
+++ b/docs/how-tos.md
@@ -7,7 +7,7 @@
 If you encounter an issue with your Docker setup and you've already exhausted all other ideas, here's a quick one-liner that stops and removes absolutely everything. You can then follow the govuk-docker README instructions for `make`-ing your app again.
 
 ```
-docker stop $(docker ps -a -q) && docker rm $(docker ps -a -q) && docker rmi $(docker images -q) -f && docker volume prune && docker container prune && docker image prune && docker network prune && docker system prune --all --volumes
+docker stop $(docker ps -a -q) && docker rm $(docker ps -a -q) && docker rmi $(docker images -q) -f && docker volume prune && docker container prune && docker image prune && docker network prune && docker build prune -f && docker system prune --all --volumes
 ```
 
 ## How to: reduce typing with shortcuts


### PR DESCRIPTION
[Two hours later](https://gds.slack.com/archives/CAB4Q3QBW/p1750750044363409) and my local setup issue turned out to be a caching issue, fixed by

```
govuk-docker down
docker builder prune -f
govuk-docker build publishing-api-lite --no-cache
```

Let's avoid anyone else having to go through that headache.