### PR TITLE
Run `bundle install` when gems are missing

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -33,6 +33,9 @@ RUN /rbenv/plugins/ruby-build/install.sh
 ENV PATH /root/.rbenv/shims:/rbenv/bin:$PATH
 ENV BUNDLE_SILENCE_ROOT_WARNING 1
 
+# Automatically run `bundle install` when gems are missing
+ENV BUNDLE_AUTO_INSTALL 1
+
 # Install `psql` and `mysql` for 'rails dbconsole'
 # and `less` for paginated output in 'rails console' and 'binding.pry'
 RUN apt-get update -qq && apt-get install -y postgresql-client default-mysql-client less


### PR DESCRIPTION
This adds the `BUNDLE_AUTO_INSTALL` env var, which tells bundler to run `bundle install` when gems are missing.

See https://blog.rubygems.org/2024/05/30/bundler-auto-install-just-got-a-whole-lot-better.html