### PR TITLE
Fix elasticsearch config path

### DIFF
--- a/bin/replicate-elasticsearch.sh
+++ b/bin/replicate-elasticsearch.sh
@@ -34,7 +34,7 @@ echo "
 echo "stopping running govuk-docker containers..."
 govuk-docker down
 
-container=$(govuk-docker run -d --rm -v "$archive_path:/replication" -v "$cfg_path:/usr/share/elasticsearch/config/elasticsearch.yml" -p 9200:9200 elasticsearch-6 | tail -n1)
+container=$(govuk-docker run -d --rm -v "$archive_path:/replication" -v "$cfg_path:/usr/elasticsearch/config/elasticsearch.yml" -p 9200:9200 elasticsearch-6 | tail -n1)
 # we want $container and $cfg_path to be expanded now
 # shellcheck disable=SC2064
 trap "docker stop '$container'; rm '$cfg_path'" EXIT


### PR DESCRIPTION
While trying to run ES6 locally, I found that the configuration was not being read by the elasticsearch cluster.

>{"error":{"root_cause":[{"type":"repository_exception","reason":"[snapshots] location [/replication] doesn't match any of the locations specified by path.repo because this setting is empty"}],"type":"repository_exception","reason":"[snapshots] failed to create repository","caused_by":{"type":"repository_exception","reason":"[snapshots] location [/replication] doesn't match any of the locations specified by path.repo because this setting is empty"}},"status":500}

I confirmed this by spinning up the docker container with the config specified in the replication file, and querying it:

`govuk-docker run -d --rm -v "$archive_path:/replication" -v "$cfg_path:/usr/share/elasticsearch/config/elasticsearch.yml" -p 9200:9200 elasticsearch-6` 

`curl "localhost:9200/_nodes/settings?pretty"`

I then got an interactive terminal to the running container and verified the path where the config was expected:

`docker exec -it govuk-docker-elasticsearch-6-run-37256d47af96 sh`

`ps -aef | grep java`
>/opt/java/openjdk/bin/java ...(lots)...  -Des.path.conf=/usr/elasticsearch/config ...(lots)...

I removed `share` from the path in the config and the replication started working.