### PR TITLE
Upate Go version to 1.24

### DIFF
--- a/projects/router/Dockerfile
+++ b/projects/router/Dockerfile
@@ -1,1 +1,1 @@
-FROM golang:1.23
+FROM golang:1.24


### PR DESCRIPTION
The required version in Router itself was updated but it wasn't reflected in the docker file, causing failures when attempting to build anything that relies on it e.g. content-store locally.