### PR TITLE
Add playwright browser install to Whitehall makefile

### DIFF
--- a/projects/whitehall/Makefile
+++ b/projects/whitehall/Makefile
@@ -4,3 +4,4 @@ whitehall: bundle-whitehall asset-manager link-checker-api publishing-api signon
 	$(GOVUK_DOCKER) run $@-lite yarn
 	$(GOVUK_DOCKER) run $@-lite rails taxonomy:populate_end_to_end_test_data
 	$(GOVUK_DOCKER) run $@-lite rails taxonomy:rebuild_cache
+	$(GOVUK_DOCKER) run $@-lite yarn playwright install --with-deps


### PR DESCRIPTION
Without this, all of the cucumber features requiring Javascript will fail with no error output explaining what the problem is.