### PR TITLE
Add `content-block-manager` app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,7 @@ services:
           - bouncer-redirect.dev.gov.uk
           - collections-publisher.dev.gov.uk
           - collections.dev.gov.uk
+          - content-block-manager.dev.gov.uk
           - content-publisher.dev.gov.uk
           - content-data-api.dev.gov.uk
           - content-data-admin.dev.gov.uk

--- a/projects/content-block-manager/Dockerfile
+++ b/projects/content-block-manager/Dockerfile
@@ -1,0 +1,25 @@
+# Install packages for building ruby
+FROM buildpack-deps:bookworm
+
+# Install chromium browser and its webdriver
+RUN apt-get update -qq && apt-get install -y chromium chromium-driver
+
+# Enable no-sandbox for chrome so that it can run as a root user
+ENV GOVUK_TEST_CHROME_NO_SANDBOX 1
+
+# Install node / yarn
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN apt-get update -qq && apt-get install -y yarn nodejs
+RUN yarn config set cache-folder /root/.yarn/
+
+# Install rbenv to manage ruby versions
+RUN git clone https://github.com/rbenv/rbenv.git /rbenv
+RUN git clone https://github.com/rbenv/ruby-build.git /rbenv/plugins/ruby-build
+RUN /rbenv/plugins/ruby-build/install.sh
+ENV PATH /root/.rbenv/shims:/rbenv/bin:$PATH
+ENV BUNDLE_SILENCE_ROOT_WARNING 1
+
+# Install `less` for paginated output in 'rails console' and 'binding.pry'
+RUN apt-get update -qq && apt-get install -y less

--- a/projects/content-block-manager/Makefile
+++ b/projects/content-block-manager/Makefile
@@ -1,0 +1,5 @@
+content-block-manager: bundle-content-block-manager publishing-api signon
+	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
+	$(GOVUK_DOCKER) run $@-lite yarn
+	$(GOVUK_DOCKER) run $@-lite yarn playwright install --with-deps

--- a/projects/content-block-manager/docker-compose.yml
+++ b/projects/content-block-manager/docker-compose.yml
@@ -1,0 +1,68 @@
+volumes:
+  content-block-manager-tmp:
+  content-block-manager-node-modules:
+
+x-content-block-manager: &content-block-manager
+  build:
+    context: .
+    dockerfile: projects/content-block-manager/Dockerfile
+  image: content-block-manager
+  stdin_open: true
+  tty: true
+  volumes:
+    - ${GOVUK_ROOT_DIR:-~/govuk}:/govuk:delegated
+    - root-home:/root
+    - content-block-manager-tmp:/govuk/content-block-manager/tmp
+    - content-block-manager-node-modules:/govuk/content-block-manager/node_modules
+  working_dir: /govuk/content-block-manager
+  # Mount /tmp as a tmpfs volume. This is a workaround until docker/for-linux#1015 is resolved.
+  # See alphagov/govuk-docker#537 for more info.
+  tmpfs: /tmp:exec
+
+services:
+  content-block-manager-lite:
+    <<: *content-block-manager
+    shm_size: 512mb
+    depends_on:
+      - postgres-16
+      - content-block-manager-redis
+      - publishing-api-app
+    environment:
+      DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
+      DATABASE_URL: "postgresql://postgres@postgres-16/content-block-manager_development"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-16/content-block-manager_test"
+      REDIS_URL: redis://content-block-manager-redis
+
+  content-block-manager-app: &content-block-manager-app
+    <<: *content-block-manager
+    depends_on:
+      - postgres-16
+      - content-block-manager-redis
+      - nginx-proxy
+      - publishing-api-app
+      - content-block-manager-worker
+      - signon-app
+    environment:
+      GOVUK_PROXY_STATIC_ENABLED: "true"
+      DATABASE_URL: "postgresql://postgres@postgres-16/content-block-manager_development"
+      REDIS_URL: redis://content-block-manager-redis
+      VIRTUAL_HOST: content-block-manager.dev.gov.uk
+      BINDING: 0.0.0.0
+    expose:
+      - "3000"
+    command: bin/dev
+
+  content-block-manager-worker:
+    <<: *content-block-manager
+    depends_on:
+      - postgres-16
+      - content-block-manager-redis
+      - nginx-proxy
+      - publishing-api-app
+    environment:
+      DATABASE_URL: "postgresql://root:root@postgres-16/content-block-manager_development"
+      REDIS_URL: redis://content-block-manager-redis
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
+
+  content-block-manager-redis:
+    image: redis


### PR DESCRIPTION
This adds the in-progress [`content-block-manager`](https://github.com/alphagov/content-block-manager) app to govuk-docker. The app is currently running as an engine in Whitehall, but we’re in the process of moving it to it’s own app.