### PR TITLE
Update content store postgres

### DIFF
--- a/projects/content-store/docker-compose.yml
+++ b/projects/content-store/docker-compose.yml
@@ -18,18 +18,18 @@ services:
   content-store-lite:
     <<: *content-store
     depends_on:
-      - postgres-13
+      - postgres-16
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/content-store"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/content-store-test"
+      DATABASE_URL: "postgresql://postgres@postgres-16/content-store"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-16/content-store-test"
   content-store-app: &content-store-app
     <<: *content-store
     depends_on:
-      - postgres-13
+      - postgres-16
       - router-api-app
       - nginx-proxy
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/content-store"
+      DATABASE_URL: "postgresql://postgres@postgres-16/content-store"
       VIRTUAL_HOST: content-store.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -40,5 +40,5 @@ services:
     <<: *content-store-app
     environment:
       VIRTUAL_HOST: draft-content-store.dev.gov.uk
-      DATABASE_URL: "postgresql://postgres@postgres-13/draft-content-store"
+      DATABASE_URL: "postgresql://postgres@postgres-16/draft-content-store"
       BINDING: 0.0.0.0


### PR DESCRIPTION
Updating image version of Postgres for content store

Was giving a `pg_restore: error: unsupported version (1.15) in file header` when trying to replicate data.

Prior art: https://github.com/alphagov/govuk-docker/pull/794