### PR TITLE
Update postgres in several images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ volumes:
   postgres-14:
   postgres-14-postgis:
   postgres-16:
+  postgres-17:
   mysql-8:
   mongo-3.6:
   go:
@@ -63,6 +64,13 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
     volumes:
       - postgres-16:/var/lib/postgresql/data
+
+  postgres-17:
+    image: postgres:17
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+    volumes:
+      - postgres-17:/var/lib/postgresql/data
 
   memcached:
     image: memcached

--- a/projects/content-store/docker-compose.yml
+++ b/projects/content-store/docker-compose.yml
@@ -18,18 +18,18 @@ services:
   content-store-lite:
     <<: *content-store
     depends_on:
-      - postgres-13
+      - postgres-17
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/content-store"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/content-store-test"
+      DATABASE_URL: "postgresql://postgres@postgres-17/content-store"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-17/content-store-test"
   content-store-app: &content-store-app
     <<: *content-store
     depends_on:
-      - postgres-13
+      - postgres-17
       - router-api-app
       - nginx-proxy
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/content-store"
+      DATABASE_URL: "postgresql://postgres@postgres-17/content-store"
       VIRTUAL_HOST: content-store.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -40,5 +40,5 @@ services:
     <<: *content-store-app
     environment:
       VIRTUAL_HOST: draft-content-store.dev.gov.uk
-      DATABASE_URL: "postgresql://postgres@postgres-13/draft-content-store"
+      DATABASE_URL: "postgresql://postgres@postgres-17/draft-content-store"
       BINDING: 0.0.0.0

--- a/projects/publisher/docker-compose.yml
+++ b/projects/publisher/docker-compose.yml
@@ -22,20 +22,20 @@ services:
     shm_size: 512mb
     depends_on:
       - publisher-redis
-      - postgres-16
+      - postgres-17
       - mongo-3.6
     environment:
       MONGODB_URI: "mongodb://mongo-3.6/publisher"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/publisher-test"
-      DATABASE_URL: "postgresql://postgres@postgres-16/publisher"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-16/publisher_test"
+      DATABASE_URL: "postgresql://postgres@postgres-17/publisher"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-17/publisher_test"
       REDIS_URL: redis://publisher-redis
 
   publisher-app: &publisher-app
     <<: *publisher
     depends_on:
       - publisher-redis
-      - postgres-16
+      - postgres-17
       - mongo-3.6
       - nginx-proxy
       - publishing-api-app
@@ -44,7 +44,7 @@ services:
       - publisher-css
       - signon-app
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-16/publisher"
+      DATABASE_URL: "postgresql://postgres@postgres-17/publisher"
       MONGODB_URI: "mongodb://mongo-3.6/publisher"
       REDIS_URL: redis://publisher-redis
       VIRTUAL_HOST: publisher.dev.gov.uk
@@ -62,11 +62,11 @@ services:
     depends_on:
       - publisher-redis
       - mongo-3.6
-      - postgres-16
+      - postgres-17
       - nginx-proxy
       - publishing-api-app
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-16/publisher"
+      DATABASE_URL: "postgresql://postgres@postgres-17/publisher"
       MONGODB_URI: "mongodb://mongo-3.6/publisher"
       REDIS_URL: redis://publisher-redis
     command: bin/dev worker

--- a/projects/publishing-api/docker-compose.yml
+++ b/projects/publishing-api/docker-compose.yml
@@ -18,28 +18,28 @@ services:
   publishing-api-lite:
     <<: *publishing-api
     depends_on:
-      - postgres-16
+      - postgres-17
       - publishing-api-redis
       - rabbitmq
     environment:
       RABBITMQ_EXCHANGE: published_documents
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
       DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: "true"
-      DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api-test"
+      DATABASE_URL: "postgresql://postgres@postgres-17/publishing-api"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-17/publishing-api-test"
       REDIS_URL: redis://publishing-api-redis
 
   publishing-api-app: &publishing-api-app
     <<: *publishing-api
     depends_on:
-      - postgres-16
+      - postgres-17
       - publishing-api-worker
       - publishing-api-redis
       - nginx-proxy
     environment:
       RABBITMQ_EXCHANGE: published_documents
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
-      DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api"
+      DATABASE_URL: "postgresql://postgres@postgres-17/publishing-api"
       REDIS_URL: redis://publishing-api-redis
       VIRTUAL_HOST: publishing-api.dev.gov.uk
       BINDING: 0.0.0.0
@@ -50,13 +50,13 @@ services:
   publishing-api-worker:
     <<: *publishing-api
     depends_on:
-      - postgres-16
+      - postgres-17
       - publishing-api-redis
       - rabbitmq
     environment:
       RABBITMQ_EXCHANGE: published_documents
       RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672
-      DATABASE_URL: "postgresql://postgres@postgres-16/publishing-api"
+      DATABASE_URL: "postgresql://postgres@postgres-17/publishing-api"
       REDIS_URL: redis://publishing-api-redis
     command: bundle exec sidekiq -C ./config/sidekiq.yml
 

--- a/projects/support-api/docker-compose.yml
+++ b/projects/support-api/docker-compose.yml
@@ -18,21 +18,21 @@ services:
   support-api-lite:
     <<: *support-api
     depends_on:
-      - postgres-13
+      - postgres-17
       - support-api-redis
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/support-api"
-      TEST_DATABASE_URL: "postgresql://postgres@postgres-13/support-api-test"
+      DATABASE_URL: "postgresql://postgres@postgres-17/support-api"
+      TEST_DATABASE_URL: "postgresql://postgres@postgres-17/support-api-test"
       REDIS_URL: redis://support-redis
 
   support-api-app: &support-api-app
     <<: *support-api
     depends_on:
-      - postgres-13
+      - postgres-17
       - support-api-redis
       - nginx-proxy
     environment:
-      DATABASE_URL: "postgresql://postgres@postgres-13/support-api"
+      DATABASE_URL: "postgresql://postgres@postgres-17/support-api"
       REDIS_URL: redis://support-api-redis
       VIRTUAL_HOST: support-api.dev.gov.uk
       BINDING: 0.0.0.0


### PR DESCRIPTION
Update the image version of postgres in several places, to fix data replication.

Currently we get `pg_restore: error: unsupported version (...) in file header)`, which is because `pg_dump` has been upgraded somewhere.

Prior art: #794 #885
