### PR TITLE
Get Frontend apps working using govuk-docker

### DIFF
--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -32,11 +32,15 @@ services:
       - static-app
     environment:
       ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE: "true"
+      GOVUK_WEBSITE_ROOT: https://www.gov.uk
+      GOVUK_PROXY_STATIC_ENABLED: "true"
+      PLEK_SERVICE_STATIC_URI: http://static.dev.gov.uk
+      PLEK_SERVICE_CONTENT_STORE_URI: http://content-store.dev.gov.uk
       VIRTUAL_HOST: frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
-      - "3000"
-    command: bin/rails s --restart
+      - "3005"
+    command: bin/dev
 
   frontend-app-live:
     <<: *frontend-app

--- a/projects/government-frontend/docker-compose.yml
+++ b/projects/government-frontend/docker-compose.yml
@@ -30,11 +30,13 @@ services:
       - nginx-proxy
     environment:
       GOVUK_PROXY_STATIC_ENABLED: "true"
+      PLEK_SERVICE_STATIC_URI: http://static.dev.gov.uk
+      PLEK_SERVICE_CONTENT_STORE_URI: http://content-store.dev.gov.uk
       VIRTUAL_HOST: government-frontend.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
-      - "3000"
-    command: bin/rails s --restart
+      - "3090"
+    command: bin/dev
 
   government-frontend-app-live:
     <<: *government-frontend-app


### PR DESCRIPTION
I had some problems running both `frontend` and `government-frontend` working with Docker. Looking at the docs and asking around, it doesn't seem like many people run the frontend apps in this way, which is why they're not working _quite_ as I'd expect.

This adds some environment variables so the frontend apps point to the development versions of static and content store, as well as running the `bin/dev` commands so we can watch the assets while running the app.

Both frontend apps also run on a non-standard port (see https://github.com/alphagov/frontend/blob/main/Procfile.dev and https://github.com/alphagov/government-frontend/blob/main/Procfile.dev) so we change the exposed ports too.