### PR TITLE
(CM-414) Add a service to run “full” Content Block Manager

### DIFF
--- a/projects/content-block-manager/Makefile
+++ b/projects/content-block-manager/Makefile
@@ -1,4 +1,4 @@
-content-block-manager: bundle-content-block-manager publishing-api signon
+content-block-manager: bundle-content-block-manager publishing-api signon frontend government-frontend whitehall publisher
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/content-block-manager/docker-compose.yml
+++ b/projects/content-block-manager/docker-compose.yml
@@ -52,6 +52,21 @@ services:
       - "3000"
     command: bin/dev
 
+  # Run the app with Whitehall, Mainstream and both frontend apps running
+  content-block-manager-full:
+    <<: *content-block-manager-app
+    depends_on:
+      - postgres-16
+      - content-block-manager-redis
+      - nginx-proxy
+      - publishing-api-app
+      - content-block-manager-worker
+      - signon-app
+      - whitehall-app
+      - publisher-app
+      - frontend-app
+      - government-frontend-app
+
   content-block-manager-worker:
     <<: *content-block-manager
     depends_on:


### PR DESCRIPTION
This spins up Content Block Manager with both frontend apps enabled, as well as Mainstream and Publisher, allowing us to test the whole journey of a content block, as well as the inline preview functionality.