### PR TITLE
Prevent orphaned carrierwave files

### DIFF
--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -1,4 +1,5 @@
 volumes:
+  carrierwave-tmp:
   whitehall-tmp:
   whitehall-node-modules:
 
@@ -14,6 +15,7 @@ x-whitehall: &whitehall
     - root-home:/root
     - whitehall-tmp:/govuk/whitehall/tmp
     - whitehall-node-modules:/govuk/whitehall/node_modules
+    - carrierwave-tmp:/govuk/whitehall/carrierwave-tmp
   working_dir: /govuk/whitehall
   # Mount /tmp as a tmpfs volume. This is a workaround until docker/for-linux#1015 is resolved.
   # See alphagov/govuk-docker#537 for more info.


### PR DESCRIPTION
Over time, files would build up in the `carrierwave-tmp` directory when tests requiring carrierwave uploads were run.

These files were not required beyond the duration of the test.

Rubocop would become increasingly slow at scanning the project because it was not configured to ignore the carrierwave-tmp directory.

Adding a volume for the carrierwave-tmp directory enables the test process to delete the files once the tests have completed because they are not owned by the external user.