### PR TITLE
Move dnsmasq to port 533

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -12,10 +12,15 @@ echo -e "✅ Starting Docker...\n"
 echo "✅ Configuring dnsmasq [/etc/resolver/dev/gov.uk]"
 echo -e "You may need to enter your root password...\n"
 sudo mkdir -p /etc/resolver
-echo -e "nameserver 127.0.0.1\nport 53" | sudo tee /etc/resolver/dev.gov.uk >/dev/null
+echo -e "nameserver 127.0.0.1\nport 533" | sudo tee /etc/resolver/dev.gov.uk >/dev/null
 
 echo -e "✅ Configuring dnsmasq [$brew_root/etc/dnsmasq.conf]\n"
-echo "conf-dir=$brew_root/etc/dnsmasq.d,*.conf" >> $brew_root/etc/dnsmasq.conf
+echo """
+conf-dir=$brew_root/etc/dnsmasq.d,*.conf
+port=533
+domain-needed
+bogus-priv
+""" >> $brew_root/etc/dnsmasq.conf
 
 echo -e "✅ Configuring dnsmasq [$brew_root/etc/dnsmasq.d/development.conf]\n"
 mkdir -p $brew_root/etc/dnsmasq.d

--- a/lib/govuk_docker/doctor/checkup.rb
+++ b/lib/govuk_docker/doctor/checkup.rb
@@ -103,7 +103,7 @@ module GovukDocker::Doctor
     end
 
     def dnsmasq_resolver?
-      File.read("/etc/resolver/dev.gov.uk").strip == "nameserver 127.0.0.1\nport 53"
+      File.read("/etc/resolver/dev.gov.uk").strip == "nameserver 127.0.0.1\nport 533"
     end
 
     def dnsmasq_resolver_message
@@ -115,7 +115,7 @@ module GovukDocker::Doctor
     end
 
     def dnsmasq_resolving?
-      `dig +short +time=1 +tries=1 app.dev.gov.uk @127.0.0.1`.strip == "127.0.0.1"
+      `dig -p 533 +short +time=1 +tries=1 app.dev.gov.uk @127.0.0.1`.strip == "127.0.0.1"
     end
 
     def dnsmasq_resolving_message

--- a/spec/govuk_docker/doctor/checkup_spec.rb
+++ b/spec/govuk_docker/doctor/checkup_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe GovukDocker::Doctor::Checkup do
     end
 
     it "should report success if dnsmasq conf matches the one in govuk-docker" do
-      dns_config = "nameserver 127.0.0.1\nport 53"
+      dns_config = "nameserver 127.0.0.1\nport 533"
       allow(File).to receive(:read).and_call_original
       allow(File).to receive(:read).with("/etc/resolver/dev.gov.uk").and_return(dns_config)
 


### PR DESCRIPTION
Which enables GOV.UK dnsmasq to run on devices that have ZScaler ZIA running on them (which exposes a DNS resolver on port 53).