### PR TITLE
Reconfigure feedback without static

### DIFF
--- a/projects/feedback/Makefile
+++ b/projects/feedback/Makefile
@@ -1,2 +1,2 @@
-feedback: bundle-feedback router static support-api support
+feedback: bundle-feedback router support-api support
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/feedback/docker-compose.yml
+++ b/projects/feedback/docker-compose.yml
@@ -26,12 +26,11 @@ services:
     depends_on:
       - feedback-redis
       - router-app
-      - static-app
       - nginx-proxy
       - support-api-app
       - support-app
     environment:
-      GOVUK_PROXY_STATIC_ENABLED: "true"
+      GOVUK_PROXY_STATIC_ENABLED: "false"
       REDIS_URL: redis://feedback-redis
       VIRTUAL_HOST: feedback.dev.gov.uk
       BINDING: 0.0.0.0
@@ -46,9 +45,8 @@ services:
       - nginx-proxy
     environment:
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
-      GOVUK_PROXY_STATIC_ENABLED: "true"
+      GOVUK_PROXY_STATIC_ENABLED: "false"
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
-      PLEK_SERVICE_STATIC_URI: https://assets.publishing.service.gov.uk
       VIRTUAL_HOST: feedback.dev.gov.uk
       BINDING: 0.0.0.0
       REDIS_URL: redis://feedback-redis


### PR DESCRIPTION
## What / why
Change `feedback` to not rely on `static` anymore.

- feedback was modified to not use static in June: https://github.com/alphagov/feedback/pull/2108
- updating the config here to reflect that
