### PR TITLE
Reconfigure email-alert-frontend to not use static

### DIFF
--- a/projects/email-alert-frontend/Makefile
+++ b/projects/email-alert-frontend/Makefile
@@ -1,2 +1,2 @@
-email-alert-frontend: bundle-email-alert-frontend email-alert-api content-store static router
+email-alert-frontend: bundle-email-alert-frontend email-alert-api content-store router
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/email-alert-frontend/docker-compose.yml
+++ b/projects/email-alert-frontend/docker-compose.yml
@@ -30,11 +30,10 @@ services:
       - email-alert-frontend-redis
       - router-app
       - content-store-app
-      - static-app
       - email-alert-api-app
       - nginx-proxy
     environment:
-      GOVUK_PROXY_STATIC_ENABLED: "true"
+      GOVUK_PROXY_STATIC_ENABLED: "false"
       REDIS_URL: redis://email-alert-frontend-redis
       VIRTUAL_HOST: email-alert-frontend.dev.gov.uk
       BINDING: 0.0.0.0
@@ -51,9 +50,8 @@ services:
     environment:
       REDIS_URL: redis://email-alert-frontend-redis
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
-      GOVUK_PROXY_STATIC_ENABLED: "true"
+      GOVUK_PROXY_STATIC_ENABLED: "false"
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
-      PLEK_SERVICE_STATIC_URI: https://assets.publishing.service.gov.uk
       VIRTUAL_HOST: email-alert-frontend.dev.gov.uk
       BINDING: 0.0.0.0
 


### PR DESCRIPTION
## What / why
Change `email-alert-frontend` to not rely on `static` anymore.

- app was modified to not use static in March: https://github.com/alphagov/email-alert-frontend/pull/1890
- updating the config here to reflect that