### PR TITLE
Reconfigure frontend to not use static

### DIFF
--- a/projects/frontend/Makefile
+++ b/projects/frontend/Makefile
@@ -1,2 +1,2 @@
-frontend: bundle-frontend account-api content-store publishing-api router search-api static
+frontend: bundle-frontend account-api content-store publishing-api router search-api
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -29,12 +29,10 @@ services:
       - publishing-api-app
       - router-app
       - search-api-app
-      - static-app
     environment:
       ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE: "true"
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
-      GOVUK_PROXY_STATIC_ENABLED: "true"
-      PLEK_SERVICE_STATIC_URI: http://static.dev.gov.uk
+      GOVUK_PROXY_STATIC_ENABLED: "false"
       PLEK_SERVICE_CONTENT_STORE_URI: http://content-store.dev.gov.uk
       VIRTUAL_HOST: frontend.dev.gov.uk
       BINDING: 0.0.0.0
@@ -50,10 +48,9 @@ services:
     environment:
       ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE: "true"
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
-      GOVUK_PROXY_STATIC_ENABLED: "true"
+      GOVUK_PROXY_STATIC_ENABLED: "false"
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
       PLEK_SERVICE_SEARCH_API_URI: https://www.gov.uk/api
-      PLEK_SERVICE_STATIC_URI: https://assets.publishing.service.gov.uk
       VIRTUAL_HOST: frontend.dev.gov.uk
       BINDING: 0.0.0.0
 
@@ -65,11 +62,10 @@ services:
     environment:
       ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE: "true"
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
-      GOVUK_PROXY_STATIC_ENABLED: "true"
+      GOVUK_PROXY_STATIC_ENABLED: "false"
       #ASSET_MANAGER_BEARER_TOKEN: <get an asset manager token from https://signon.integration.publishing.service.gov.uk/api_users>
       PLEK_SERVICE_ASSET_MANAGER_URI: https://assets-origin.eks.integration.govuk.digital
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.integration.publishing.service.gov.uk/api
       PLEK_SERVICE_SEARCH_API_URI: https://www.integration.publishing.service.gov.uk/api
-      PLEK_SERVICE_STATIC_URI: https://assets-origin.eks.integration.govuk.digital
       VIRTUAL_HOST: frontend.dev.gov.uk
       BINDING: 0.0.0.0


### PR DESCRIPTION
## What / why
Change `frontend` to not rely on `static` anymore.

- app was modified to not use static in October: https://github.com/alphagov/frontend/pull/4928
- updating the config here to reflect that
