### PR TITLE
Reconfigure smart-answers to not use static

### DIFF
--- a/projects/smart-answers/Makefile
+++ b/projects/smart-answers/Makefile
@@ -1,2 +1,2 @@
-smart-answers: bundle-smart-answers publishing-api content-store static
+smart-answers: bundle-smart-answers publishing-api content-store
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/smart-answers/docker-compose.yml
+++ b/projects/smart-answers/docker-compose.yml
@@ -25,10 +25,9 @@ services:
     depends_on:
       - nginx-proxy
       - publishing-api-app
-      - static-app
       - content-store-app
     environment:
-      GOVUK_PROXY_STATIC_ENABLED: "true"
+      GOVUK_PROXY_STATIC_ENABLED: "false"
       VIRTUAL_HOST: smart-answers.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -40,15 +39,13 @@ services:
     depends_on:
       - nginx-proxy
       - publishing-api-app
-      - static-app
       - content-store-app
     environment:
-      GOVUK_PROXY_STATIC_ENABLED: "true"
+      GOVUK_PROXY_STATIC_ENABLED: "false"
       VIRTUAL_HOST: smart-answers.dev.gov.uk
       GOVUK_APP_DOMAIN: www.gov.uk
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
       PLEK_SERVICE_CONTENT_STORE_URI: https://www.gov.uk/api
-      PLEK_SERVICE_STATIC_URI: https://assets.publishing.service.gov.uk
       BINDING: 0.0.0.0
     expose:
       - "3000"


### PR DESCRIPTION
## What / why
Change `smart-answers` to not rely on `static` anymore.

- app was modified to not use static in August: https://github.com/alphagov/smart-answers/pull/7304
- updating the config here to reflect that