### PR TITLE
Allow user to pass extra args for govuk-docker-up

### DIFF
--- a/exe/govuk-docker-up
+++ b/exe/govuk-docker-up
@@ -11,4 +11,4 @@
 # **************************************************************
 
 STACK=${1:-app}
-"$(dirname "$0")"/govuk-docker up "$(basename "$(pwd)")-$STACK"
+"$(dirname "$0")"/govuk-docker up "$(basename "$(pwd)")-$STACK" "${@:2}"


### PR DESCRIPTION
This change should allow the govuk-docker-up command to pass through any extra arguments to the underlying govuk-docker command, as provided by the user. For example, a user could run this from their app's repo:

```sh
  govuk-docker-up app -d # Detached mode: Run containers in the background
```

The govuk-docker command already applies all extra arguments to docker compose.