### PR TITLE
Fix Elasticsearch restore script to support repositories containing multiple indices

### DIFF
--- a/bin/replicate-elasticsearch.sh
+++ b/bin/replicate-elasticsearch.sh
@@ -64,7 +64,7 @@ sleep 5
 
 snapshot_name=$(curl "http://127.0.0.1:9200/_snapshot/snapshots/_all" | jq -r ".snapshots | map(.snapshot) | sort | last")
 
-indices=$(curl "http://127.0.0.1:9200/_snapshot/snapshots/_all" | jq -r '
+indices=$(curl "http://127.0.0.1:9200/_snapshot/snapshots/$snapshot_name" | jq -r '
 .snapshots[].indices
 | [
     (map(select(startswith("detailed-"))) | sort | last),


### PR DESCRIPTION
Previously, the restore script assumed that a snapshot repository contained only a single index. When multiple indices were present, the script failed due to incorrect handling of the index list.

This update corrects the logic so that repositories with multiple indices are processed correctly, ensuring Elasticsearch restores function reliably regardless of the number of indices stored.

https://gov-uk.atlassian.net/browse/SCH-1620