### PR TITLE
Fix example command for replicating data locally in how-to docs

### DIFF
--- a/docs/how-tos.md
+++ b/docs/how-tos.md
@@ -54,7 +54,7 @@ There may be times when a full database is required locally.  The following scri
 You will need to assume-role into AWS using the [gds-cli](https://docs.publishing.service.gov.uk/manual/access-aws-console.html) before running the scripts. For example, to replicate data for Collections Publisher, run:
 
 ```
-gds aws govuk-integration-developer --assume-role-ttl 3h ./bin/replicate-postgresql.sh collections-publisher
+gds aws govuk-integration-developer --assume-role-ttl 3h ./bin/replicate-mysql.sh collections-publisher
 ```
 
 > The `readonly` role does not provide access to S3, so cannot be used to replicate data locally.


### PR DESCRIPTION
Prior to this change I was seeing the following error when running the example command:

    gds aws govuk-integration-developer --assume-role-ttl 3h ./bin/replicate-postgresql.sh collections-publisher

    Replicating postgres for collections-publisher
    couldn't figure out backup filename in S3 - if you're sure the app uses PostgreSQL, file an issue in alphagov/govuk-docker.

This was because collections-publisher [has a MySQL database][1] and not a PostgreSQL database.

[1]: https://github.com/alphagov/collections-publisher/blob/8decf3647508319789df6ce1fd42a7b097530a6d/config/database.yml#L2