### PR TITLE
Remove slimmer reference from compatibility

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -84,5 +84,4 @@ These repos are used as part of running the live GOV.UK site. Since all of them 
    - ❌ govuk_sidekiq
    - ❌ govuk_taxonomy_helpers
    - ✅ plek
-   - ❌ slimmer
    - ✅ smokey


### PR DESCRIPTION
- Slimmer is now retired

[JIRA Card](https://gov-uk.atlassian.net/browse/PNP-9782)