### PR TITLE
Stop using Yarn APT repo and install Yarn via Corepack

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -10,6 +10,7 @@ RUN apt-get update -qq && \
   apt-get install -y --no-install-recommends \
   build-essential \
   autoconf bison \
+  clang \
   libssl-dev  \
   libreadline-dev \
   zlib1g-dev \
@@ -18,14 +19,14 @@ RUN apt-get update -qq && \
 
 # Enable no-sandbox for chrome so that it can run as a root user
 ENV GOVUK_TEST_CHROME_NO_SANDBOX 1
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 
-# Install node / yarn
-RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
-RUN mkdir -p /etc/apt/keyrings && \
-  curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /etc/apt/keyrings/yarn-archive-keyring.gpg && \
-  chmod a+r /etc/apt/keyrings/yarn-archive-keyring.gpg
-RUN echo "deb [signed-by=/etc/apt/keyrings/yarn-archive-keyring.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update -qq && apt-get install -y yarn nodejs
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+ && apt-get update -qq  \
+ && apt-get install -y nodejs \
+ && corepack enable \
+ && corepack prepare yarn@1.22.22 --activate
+
 RUN yarn config set cache-folder /root/.yarn/
 
 # Install rbenv to manage ruby versions


### PR DESCRIPTION
The Yarn Debian APT repository is signed with an expired GPG key, which now causes builds to fail on recent versions of APT.

The error is:

0.571 W: https://dl.yarnpkg.com/debian/dists/stable/InRelease: Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details.
0.571 W: GPG error: https://dl.yarnpkg.com/debian stable InRelease: The following signatures were invalid: EXPKEYSIG 23E7166788B63E1E Yarn Packaging <yarn@dan.cx>
0.571 E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.

Rather than relying on the deprecated Yarn APT repo, install Yarn via Corepack, which is bundled with Node.js and is the recommended way to manage Yarn going forward.
(https://www.docs4dev.com/docs/yarn/berry/getting-started/install.html)

This avoids GPG key expiry issues and makes the build more robust to future APT security changes.