### PR TITLE
Remove `content-block-manager-full`

### DIFF
--- a/projects/content-block-manager/Makefile
+++ b/projects/content-block-manager/Makefile
@@ -1,4 +1,4 @@
-content-block-manager: bundle-content-block-manager publishing-api signon frontend government-frontend whitehall publisher
+content-block-manager: bundle-content-block-manager publishing-api signon
 	$(GOVUK_DOCKER) run $@-lite bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite env RAILS_ENV=test bin/rake db:prepare
 	$(GOVUK_DOCKER) run $@-lite yarn

--- a/projects/content-block-manager/docker-compose.yml
+++ b/projects/content-block-manager/docker-compose.yml
@@ -51,21 +51,6 @@ services:
       - "3000"
     command: bin/dev
 
-  # Run the app with Whitehall, Mainstream and both frontend apps running
-  content-block-manager-full:
-    <<: *content-block-manager-app
-    depends_on:
-      - postgres-17
-      - content-block-manager-redis
-      - nginx-proxy
-      - publishing-api-app
-      - content-block-manager-worker
-      - signon-app
-      - whitehall-app
-      - publisher-app
-      - frontend-app
-      - government-frontend-app
-
   content-block-manager-worker:
     <<: *content-block-manager
     depends_on:


### PR DESCRIPTION
This was always a convenience service to run all services needed to run the whole stack, but caused some issues when using RubyMine and Docker together, so let’s bin it off (I think it’s only me that uses it anyway!)

I’ll update the app itself to add a convenience script to run the full stack.