### PR TITLE
[SCH-1792] Update ELASTICSEARCH_VERSION to 6.8.23

### DIFF
--- a/services/elasticsearch-6/Dockerfile
+++ b/services/elasticsearch-6/Dockerfile
@@ -8,7 +8,7 @@
 
 FROM eclipse-temurin:8-jre
 
-ARG ELASTICSEARCH_VERSION=6.7.2
+ARG ELASTICSEARCH_VERSION=6.8.23
 
 # As of Ubuntu 24.04, the official Docker image (which the Eclipse Temurin one is based on) ships
 # with an existing non-root user called "ubuntu"


### PR DESCRIPTION
We upgraded to elasticsearch 6.8.23 on search-api in November 2025, but hadn't yet updated the elasticsearch version used in this docker service. Updating the version here too so that we can use snapshots created using version 6.8.

See error message when trying to restore from snapshot created with a later version of elasticsearch:
```
{"error":{"root_cause":[{"type":"snapshot_restore_exception","reason":"[snapshots:2026-04-2005:37:02-elasticsearch6/4wl0BS-VSNiWILSEoXVavw] the snapshot was created with Elasticsearch version [6.8.0] which is higher than the version of this node [6.7.2]"}],"type":"snapshot_restore_exception","reason":"[snapshots:2026-04-2005:37:02-elasticsearch6/4wl0BS-VSNiWILSEoXVavw] the snapshot was created with Elasticsearch version [6.8.0] which is higher than the version of this node [6.7.2]"},"status":500}01946b366aa0a393ad4343100f31196fee308850a6d29f7e7c672a8eafbb43ec
```