### PR TITLE
Remove search-api-listener-publishing-queue queue creation

### DIFF
--- a/projects/search-api/docker-compose.yml
+++ b/projects/search-api/docker-compose.yml
@@ -29,7 +29,6 @@ services:
       - search-api-redis
       - elasticsearch-6
       - search-api-worker
-      - search-api-listener-publishing-queue
       - search-api-listener-insert-data
       - search-api-listener-bulk-insert-data
     environment:
@@ -49,12 +48,6 @@ services:
       - rabbitmq
       - elasticsearch-6
     command: bundle exec sidekiq -C ./config/sidekiq.yml
-
-  search-api-listener-publishing-queue:
-    <<: *search-api
-    depends_on:
-      - rabbitmq
-    command: bundle exec rake message_queue:listen_to_publishing_queue
 
   search-api-listener-insert-data:
     <<: *search-api


### PR DESCRIPTION
As part of the work to remove the government index, this queue is no longer used and is removed

Jira: https://gov-uk.atlassian.net/browse/SCH-1985
github: https://github.com/alphagov/search-api/pull/3589