### PR TITLE
Revert "Add `draft-frontend`" and replace functionality.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,7 +170,6 @@ services:
           - draft-content-store.dev.gov.uk
           - draft-origin.dev.gov.uk
           - draft-router.dev.gov.uk
-          - draft-frontend.dev.gov.uk
           - email-alert-api.dev.gov.uk
           - email-alert-frontend.dev.gov.uk
           - fact-check-manager.dev.gov.uk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,6 +168,7 @@ services:
           - content-store.dev.gov.uk
           - content-tagger.dev.gov.uk
           - draft-content-store.dev.gov.uk
+          - draft-frontend.dev.gov.uk
           - draft-origin.dev.gov.uk
           - draft-router.dev.gov.uk
           - email-alert-api.dev.gov.uk

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -40,8 +40,6 @@ services:
     expose:
       - "3005"
     command: bin/dev
-    ports:
-      - "12345:12345"
 
   frontend-app-live:
     <<: *frontend-app
@@ -57,6 +55,8 @@ services:
       VIRTUAL_PORT: 3005
       BINDING: 0.0.0.0
       WEB_CONCURRENCY: 0
+    ports:
+      - "12345:12345"
 
   frontend-app-integration:
     <<: *frontend-app
@@ -75,3 +75,23 @@ services:
       VIRTUAL_PORT: 3005
       BINDING: 0.0.0.0
       WEB_CONCURRENCY: 0
+    ports:
+      - "12345:12345"
+  frontend-app-draft:
+    <<: *frontend-app
+    depends_on:
+      - account-api-app-live
+      - nginx-proxy
+    environment:
+      GOVUK_RAILS_JSON_LOGGING: "false"
+      ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE: "true"
+      GOVUK_WEBSITE_ROOT: https://www.gov.uk
+      PLEK_SERVICE_CONTENT_STORE_URI: http://draft-content-store.dev.gov.uk
+      VIRTUAL_HOST: draft-frontend.dev.gov.uk
+      VIRTUAL_PORT: 3005
+      BINDING: 0.0.0.0
+      WEB_CONCURRENCY: 0
+      PIDFILE: ./tmp/pids/server-draft.pid
+      RAILS_DEVELOPMENT_HOSTS: draft-frontend.dev.gov.uk
+    ports:
+      - "12346:12345"

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -6,13 +6,6 @@ x-frontend: &frontend
   build:
     context: .
     dockerfile: Dockerfile.govuk-base
-  depends_on:
-    - account-api-app
-    - content-store-app
-    - nginx-proxy
-    - publishing-api-app
-    - router-app
-    - search-api-app
   image: frontend
   stdin_open: true
   tty: true
@@ -29,6 +22,13 @@ services:
 
   frontend-app: &frontend-app
     <<: *frontend
+    depends_on:
+      - account-api-app
+      - content-store-app
+      - nginx-proxy
+      - publishing-api-app
+      - router-app
+      - search-api-app
     environment:
       ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE: "true"
       GOVUK_WEBSITE_ROOT: https://www.gov.uk
@@ -37,14 +37,14 @@ services:
       VIRTUAL_PORT: 3005
       BINDING: 0.0.0.0
       WEB_CONCURRENCY: 0
-    ports:
-      - "12345:12345"
     expose:
       - "3005"
     command: bin/dev
+    ports:
+      - "12345:12345"
 
   frontend-app-live:
-    <<: *frontend
+    <<: *frontend-app
     depends_on:
       - account-api-app-live
       - nginx-proxy
@@ -57,12 +57,9 @@ services:
       VIRTUAL_PORT: 3005
       BINDING: 0.0.0.0
       WEB_CONCURRENCY: 0
-    expose:
-      - "3005"
-    command: bin/dev
 
   frontend-app-integration:
-    <<: *frontend
+    <<: *frontend-app
     depends_on:
       - account-api-app-live
       - nginx-proxy
@@ -78,30 +75,3 @@ services:
       VIRTUAL_PORT: 3005
       BINDING: 0.0.0.0
       WEB_CONCURRENCY: 0
-    expose:
-      - "3005"
-    command: bin/dev
-
-  frontend-app-draft:
-    <<: *frontend
-    depends_on:
-      - account-api-app
-      - content-store-app-draft
-      - nginx-proxy
-      - publishing-api-app
-      - router-app
-      - search-api-app
-    environment:
-      GOVUK_RAILS_JSON_LOGGING: "false"
-      ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE: "true"
-      GOVUK_WEBSITE_ROOT: https://www.gov.uk
-      PLEK_SERVICE_CONTENT_STORE_URI: http://draft-content-store.dev.gov.uk
-      VIRTUAL_HOST: draft-frontend.dev.gov.uk
-      VIRTUAL_PORT: 3005
-      BINDING: 0.0.0.0
-      WEB_CONCURRENCY: 0
-      PIDFILE: ./tmp/pids/server-draft.pid
-      RAILS_DEVELOPMENT_HOSTS: draft-frontend.dev.gov.uk
-    expose:
-      - "3005"
-    command: bin/dev


### PR DESCRIPTION
Reverts alphagov/govuk-docker#974, then reinstates the functionality (with a slight change to app name).

974 adds the ability to access the local draft stack through govuk-docker, but introduces two problems:
- it adds a number of dependencies to the "-lite" version of the service, which should be kept dependency free (in particular, this seems to make build times worse)
- it breaks debugging on app-live and app-integration by removing the exposed debugging port. This is to allow the live and draft containers to be run at the same time, but it's a bit of a drastic solution to the problem and essentially disabled a useful feature with no notice. Here we alter the exposed port so that the app-draft stack can still be debugged, but doesn't clash with the port used by app/live/integration. It's assumed here that people probably aren't running live and integration versions at the same time (but they might want local and local draft together) 