### PR TITLE
Add app-ports port forwarding support for Frontend

### DIFF
--- a/bin/port-forward
+++ b/bin/port-forward
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# **************************************************************
+# DO NOT ADD NEW STUFF IN HERE
+#
+# This is meant to be a simple wrapper script to reduce typing
+# for day-to-day commands. Its behaviour should not depend on
+# its arguments. We do not want our own bespoke CLI, as this can
+# only lead to complexity, performance and maintenance overheads
+# on top of docker and docker-compose.
+# **************************************************************
+
+appname="$(basename $(pwd))"
+script_dir="$(dirname "$(readlink -f "$0")")"
+source "${script_dir}/../projects/${appname}/port-forward.sh"

--- a/docs/how-tos/frontend-ports.md
+++ b/docs/how-tos/frontend-ports.md
@@ -1,0 +1,29 @@
+# Local Frontend with port-forwarded supporting apps
+
+Frontend has the app-live, app-integration and app-draft options, but they are increasingly complicated to maintain and have generally exluded postcode searches
+and licences. To develop against integration or live (or even staging) versions
+of these backend services we can now use kubernetes port forwarding.
+
+From the app directory (~/govuk/frontend):
+
+1) Log in to the appropriate AWS environment (we'll use integration as an example)
+
+```eval $(gds aws govuk-$1-developer -e --art 8h)```
+
+1) Use the appropriate context
+
+```kubectl config use-context integration```
+
+1) Run the port forward command
+
+```../govuk-docker/bin/port-forward```
+
+1) Run govuk-docker against the ports app
+
+```../govuk-docker-run app-ports```
+
+You should now be able to locally view postcode and licence pages as they appear in integration.
+
+When you're finished, stop the port-forwarding with:
+
+```pkill -f "kubectl port-forward"```

--- a/projects/frontend/docker-compose.yml
+++ b/projects/frontend/docker-compose.yml
@@ -41,6 +41,35 @@ services:
       - "3005"
     command: bin/dev
 
+  frontend-app-ports:
+    <<: *frontend-app
+    depends_on:
+      - nginx-proxy
+    environment:
+      ALLOW_LOCAL_CONTENT_ITEM_OVERRIDE: "true"
+      BINDING: 0.0.0.0
+      GOVUK_WEBSITE_ROOT: https://www.gov.uk
+      PLEK_SERVICE_CONTENT_STORE_URI: http://content-store:8080
+      PLEK_SERVICE_LICENSIFY_URI: http://licensify:8081
+      PLEK_SERVICE_LOCAL_LINKS_MANAGER_URI: http://local-links-manager:8082
+      PLEK_SERVICE_LOCATIONS_API_URI: http://locations-api:8083
+      PLEK_SERVICE_PLACES_MANAGER_URI: http://places-manager:8084
+      PLEK_SERVICE_PUBLISHING_API_URI: http://publishing-api:8085
+      PLEK_SERVICE_SEARCH_API_URI: http://search-api:8086
+      VIRTUAL_HOST: frontend.dev.gov.uk
+      VIRTUAL_PORT: 3005
+      WEB_CONCURRENCY: 0
+    ports:
+      - "12345:12345"
+    extra_hosts:
+      "content-store": host-gateway
+      "licensify": host-gateway
+      "local-links-manager": host-gateway
+      "locations-api": host-gateway
+      "places-manager": host-gateway
+      "publishing-api": host-gateway
+      "search-api": host-gateway
+
   frontend-app-live:
     <<: *frontend-app
     depends_on:
@@ -77,6 +106,7 @@ services:
       WEB_CONCURRENCY: 0
     ports:
       - "12345:12345"
+
   frontend-app-draft:
     <<: *frontend-app
     depends_on:

--- a/projects/frontend/port-forward.sh
+++ b/projects/frontend/port-forward.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+kubectl port-forward -n apps deploy/content-store 8080:8080 &
+kubectl port-forward -n licensify deploy/licensify-frontend 8081:8080 &
+kubectl port-forward -n apps deploy/local-links-manager 8082:8080 &
+kubectl port-forward -n apps deploy/locations-api 8083:8080 &
+kubectl port-forward -n apps deploy/places-manager 8084:8080 &
+kubectl port-forward -n apps deploy/publishing-api 8085:8080 &
+kubectl port-forward -n apps deploy/search-api 8086:8080 &


### PR DESCRIPTION
- This allows us to run local frontend against all the backing services in any environment, based on port forwarding, improving dev feedback loop for postcode lookup pages, licences, etc.