### PR TITLE
Set `GOVUK_WEBSITE_ROOT` for publisher

### DIFF
--- a/projects/publisher/docker-compose.yml
+++ b/projects/publisher/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-17/publisher"
       REDIS_URL: redis://publisher-redis
+      GOVUK_WEBSITE_ROOT: https://www.gov.uk
       VIRTUAL_HOST: publisher.dev.gov.uk
       BINDING: 0.0.0.0
     expose:
@@ -62,6 +63,7 @@ services:
     environment:
       DATABASE_URL: "postgresql://postgres@postgres-17/publisher"
       REDIS_URL: redis://publisher-redis
+      GOVUK_WEBSITE_ROOT: https://www.gov.uk
     command: bin/dev worker
 
   publisher-redis:


### PR DESCRIPTION
[Mainstream Jira ticket](https://gov-uk.atlassian.net/jira/software/c/projects/MAIN/boards/1555?selectedIssue=MAIN-1323)

Publisher's WorkingDaysCalculator calls GdsApi.calendars.bank_holidays, which builds its URL from Plek.new.website_root. When running publisher, this resolves to http://www.dev.gov.uk, which would require router, frontend, and content-store to be running to return the bank holiday data so the lookup fails.

This change points publisher-app and publisher-worker at https://www.gov.uk so the bank holidays are fetched from production.