### PR TITLE
Sch 1991 update govuk docker to remove government index

### DIFF
--- a/bin/replicate-elasticsearch.sh
+++ b/bin/replicate-elasticsearch.sh
@@ -70,7 +70,6 @@ indices=$(curl "http://127.0.0.1:9200/_snapshot/snapshots/$snapshot_name" | jq -
     (map(select(startswith("page-traffic-"))) | sort | last),
     (map(select(startswith("metasearch-"))) | sort | last),
     (map(select(startswith("govuk-"))) | sort | last),
-    (map(select(startswith("government-"))) | sort | last),
     ".kibana_1",
     ".tasks",
     "licence-finder"

--- a/projects/search-api/Makefile
+++ b/projects/search-api/Makefile
@@ -7,7 +7,7 @@ wait-for-elasticsearch:
 	@echo "Elasticsearch is up!"
 
 search-api: bundle-search-api wait-for-elasticsearch
-	@if curl -s "http://localhost:9200/_cat/indices" | grep -q "government-"; then \
+	@if curl -s "http://localhost:9200/_cat/indices" | grep -q "govuk-"; then \
       echo "Indices found, skipping index creation."; \
     else \
       echo "No indices found, creating all indices..."; \


### PR DESCRIPTION
The government index has been decommissioned.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-1991