### PR TITLE
Bump Go version for Router to 1.26

### DIFF
--- a/projects/router/Dockerfile
+++ b/projects/router/Dockerfile
@@ -1,1 +1,1 @@
-FROM golang:1.25
+FROM golang:1.26


### PR DESCRIPTION
Much like here I think: https://github.com/alphagov/govuk-docker/pull/869

These versions get out of sync over time. The router repo is using 1.26.2 already but just needs to be bumped here.

This is currently failing to build when using govuk-docker (at least when I build projects that depend on router)