### PR TITLE
Ignore cert errors when installing elastic

### DIFF
--- a/services/elasticsearch-6/Dockerfile
+++ b/services/elasticsearch-6/Dockerfile
@@ -19,7 +19,7 @@ RUN apt update && apt install -y curl
 
 # Get Elasticsearch
 WORKDIR /usr
-RUN curl -L -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
+RUN curl -L -O --insecure https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
 RUN tar -xvf elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
 RUN mv elasticsearch-${ELASTICSEARCH_VERSION} elasticsearch
 


### PR DESCRIPTION
When running `make search-api` I was getting an error on the line where we fetch elastic. Possibly introduced as part of a recent upgrade to the elastic version, or just a change on the vendor side? Curl is failing on fetching the tarball with this error:
```
curl: (60) SSL certificate problem: unable to get local issuer certificate 
```

I assume this is fine to ignore for the purposes of installing elastic in docker.