### PR TITLE
Amend replicate elasticsearch script

### DIFF
--- a/bin/replicate-elasticsearch.sh
+++ b/bin/replicate-elasticsearch.sh
@@ -23,7 +23,7 @@ fi
 
 # temporary config file because ES needs to be configured in advance
 # for filesystem-based snapshots
-cfg_path=$(mktemp '/tmp/govuk-docker-data-sync.XXXXX')
+cfg_path=$(mktemp -d -t govuk-docker-data-sync)
 echo "
   cluster.name: 'docker-cluster'
   network.host: 0.0.0.0


### PR DESCRIPTION
The Santa policies on the new DSIT technologist laptops block virtual machines from accessing certain directories. Changing the replicate-elasticsearch.sh script to use a local `/tmp` directory rather than system one.

I've run the amended script locally with this change and managed to restore the elasticsearch data.