### PR TITLE
Content Block Manager set default JWT_AUTH_SECRET

### DIFF
--- a/projects/content-block-manager/docker-compose.yml
+++ b/projects/content-block-manager/docker-compose.yml
@@ -47,6 +47,7 @@ services:
       REDIS_URL: redis://content-block-manager-redis
       VIRTUAL_HOST: content-block-manager.dev.gov.uk
       BINDING: 0.0.0.0
+      JWT_AUTH_SECRET: secret
     expose:
       - "3000"
     command: bin/dev


### PR DESCRIPTION
When running locally in Docker, the app requires this value to be set to something.