### PR TITLE
Fix debugging in finder-frontend

### DIFF
--- a/projects/finder-frontend/docker-compose.yml
+++ b/projects/finder-frontend/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       WEB_CONCURRENCY: 0
     expose:
       - "3000"
-    command: bin/rails s --restart
+    command: bin/dev
     ports:
       - "12347:12345"
 
@@ -63,6 +63,7 @@ services:
       VIRTUAL_HOST: finder-frontend.dev.gov.uk
       VIRTUAL_PORT: 3000
       BINDING: 0.0.0.0
+      WEB_CONCURRENCY: 0
 
   finder-frontend-app-integration:
     <<: *finder-frontend-app


### PR DESCRIPTION
- needs bin/dev to use the procfile which controls debugging
- needs web concurrency 0 set on all environments so that two processes don't start up and clash when they create debug ports.