### PR TITLE
Fix elasticsearch replication script

### DIFF
--- a/bin/replicate-elasticsearch.sh
+++ b/bin/replicate-elasticsearch.sh
@@ -23,7 +23,8 @@ fi
 
 # temporary config file because ES needs to be configured in advance
 # for filesystem-based snapshots
-cfg_path=$(mktemp -d -t govuk-docker-data-sync)
+mkdir -p -v './tmp'
+cfg_path=$(mktemp './tmp/govuk-docker-data-sync.XXXXX')
 echo "
   cluster.name: 'docker-cluster'
   network.host: 0.0.0.0


### PR DESCRIPTION
Two changes:
1. Change cfg_path back to a file, instead of a directory, so that text can be redirected.
2. Use local directory rather than system directory.

Santa policies on the new DSIT machines don't allow virtual machines to access certain directories [1]. "mktemp -d -t" generates a temporary directory relative to the TMPDIR environment variable. By default, this is under /var/folders, which is symlink to /host_mnt/private/var/folders. Virtual Machines are not allowed to access these directories, so a local one must be used instead.

[1] https://github.com/alphagov/dev-euc-santa-policies/blob/main/santa-policies/file_access_policy/ics_protections/enforcing/virtual_machines.rb#L2

This is a follow up from https://github.com/alphagov/govuk-docker/pull/1008