### PR TITLE
Add 12349 as debug port for places-manager

### DIFF
--- a/projects/places-manager/docker-compose.yml
+++ b/projects/places-manager/docker-compose.yml
@@ -37,11 +37,15 @@ services:
     environment:
       DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/places-manager"
       VIRTUAL_HOST: places-manager.dev.gov.uk
+      VIRTUAL_PORT: 3000
       BINDING: 0.0.0.0
       REDIS_URL: redis://places-manager-redis
+      WEB_CONCURRENCY: 0
     expose:
       - "3000"
     command: bin/rails s --restart
+    ports:
+      - "12349:12345"
 
   places-manager-worker:
     <<: *places-manager


### PR DESCRIPTION
This enables VS code debugging for places-manager (see https://github.com/alphagov/places-manager/pull/1675)