### PR TITLE
Add places-manager-app-ports service

### DIFF
--- a/projects/places-manager/docker-compose.yml
+++ b/projects/places-manager/docker-compose.yml
@@ -47,6 +47,51 @@ services:
     ports:
       - "12349:12345"
 
+  places-manager-app-ports: &places-manager-app
+    <<: *places-manager
+    depends_on:
+      - postgres-14-postgis
+      - nginx-proxy
+      - places-manager-redis
+      - places-manager-worker-ports
+    environment:
+      DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/places-manager"
+      PLEK_SERVICE_CONTENT_STORE_URI: http://content-store:8080
+      PLEK_SERVICE_LOCATIONS_API_URI: http://locations-api:8081
+      PLEK_SERVICE_SEARCH_API_URI: http://search-api:8082
+      VIRTUAL_HOST: places-manager.dev.gov.uk
+      VIRTUAL_PORT: 3000
+      BINDING: 0.0.0.0
+      REDIS_URL: redis://places-manager-redis
+      WEB_CONCURRENCY: 0
+    expose:
+      - "3000"
+    command: bin/rails s --restart
+    ports:
+      - "12349:12345"
+    extra_hosts:
+      "content-store": host-gateway
+      "locations-api": host-gateway
+      "search-api": host-gateway
+
+  places-manager-worker-ports:
+    <<: *places-manager
+    depends_on:
+      - postgres-14-postgis
+      - nginx-proxy
+      - places-manager-redis
+    environment:
+      DATABASE_URL: "postgis://postgres:password@postgres-14-postgis/places-manager"
+      PLEK_SERVICE_CONTENT_STORE_URI: http://content-store:8080
+      PLEK_SERVICE_LOCATIONS_API_URI: http://locations-api:8081
+      PLEK_SERVICE_SEARCH_API_URI: http://search-api:8082
+      REDIS_URL: redis://places-manager-redis
+    command: bundle exec sidekiq -C ./config/sidekiq.yml
+    extra_hosts:
+      "content-store": host-gateway
+      "locations-api": host-gateway
+      "search-api": host-gateway
+
   places-manager-worker:
     <<: *places-manager
     depends_on:

--- a/projects/places-manager/port-forward.sh
+++ b/projects/places-manager/port-forward.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+kubectl port-forward -n apps deploy/content-store 8080:8080 &
+kubectl port-forward -n apps deploy/locations-api 8081:8080 &
+kubectl port-forward -n apps deploy/search-api 8082:8080 &


### PR DESCRIPTION
This allows us to run a version of places-manager against backing services in any environment by using port forwarding. It also reduces the need to have replicated data locally.