### PR TITLE
Define shared WHITEHALL_ASSET_MANAGER_SHARED_API_KEY [WHIT-3751]

### DIFF
--- a/projects/asset-manager/docker-compose.yml
+++ b/projects/asset-manager/docker-compose.yml
@@ -28,6 +28,7 @@ services:
       FAKE_S3_HOST: "http://asset-manager.dev.gov.uk"
       TEST_MONGODB_URI: "mongodb://mongo-3.6/asset-manager-test"
       REDIS_URL: redis://asset-manager-redis
+      WHITEHALL_ASSET_MANAGER_SHARED_API_KEY: "secret-whitehall-asset-manager-shared-api-key"
 
   asset-manager-app: &asset-manager-app
     <<: *asset-manager
@@ -42,6 +43,7 @@ services:
       REDIS_URL: redis://asset-manager-redis
       VIRTUAL_HOST: asset-manager.dev.gov.uk
       BINDING: 0.0.0.0
+      WHITEHALL_ASSET_MANAGER_SHARED_API_KEY: "secret-whitehall-asset-manager-shared-api-key"
     expose:
       - "3000"
     command: bin/rails s --restart

--- a/projects/whitehall/docker-compose.yml
+++ b/projects/whitehall/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_development"
       TEST_DATABASE_URL: "mysql2://root:root@mysql-8/whitehall_test"
       REDIS_URL: redis://whitehall-redis
+      WHITEHALL_ASSET_MANAGER_SHARED_API_KEY: "secret-whitehall-asset-manager-shared-api-key"
 
   whitehall-app: &whitehall-app
     <<: *whitehall
@@ -54,6 +55,7 @@ services:
       VIRTUAL_HOST: whitehall-admin.dev.gov.uk, whitehall-frontend.dev.gov.uk
       BINDING: 0.0.0.0
       DISABLE_ASSETS_DEBUG:
+      WHITEHALL_ASSET_MANAGER_SHARED_API_KEY: "secret-whitehall-asset-manager-shared-api-key"
     expose:
       - "3000"
     command: bin/dev


### PR DESCRIPTION
We need to set up a shared key so that some requests from Whitehall can bypass the usual access-limiting checks on assets. See https://github.com/alphagov/asset-manager/pull/2039

Jira: https://gov-uk.atlassian.net/browse/WHIT-3751