### PR TITLE
Revert "[Draft] Fix Elasticsearch data path"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
     environment:
       ES_JAVA_OPTS: -Xms1g -Xmx1g
     volumes:
-      - elasticsearch-6:/usr/elasticsearch/data
+      - elasticsearch-6:/usr/share/elasticsearch/data
     ports:
       - "9200:9200"
       - "9300:9300"


### PR DESCRIPTION
Reverts alphagov/govuk-docker#867

This has broken our local builds of search api as the codebase has moved on since the PR was opened. See https://github.com/alphagov/govuk-docker/pull/905