### PR TITLE
Add the Zscaler root CA certificate to containers

### DIFF
--- a/Dockerfile.govuk-base
+++ b/Dockerfile.govuk-base
@@ -5,6 +5,11 @@
 # Install packages for building ruby
 FROM buildpack-deps:trixie
 
+# Trust the ZScaler root CA so HTTPS URLs work behing the corporate proxy
+RUN curl -fsSL -o /usr/local/share/ca-certificates/zscaler-root-ca.crt \
+  https://raw.githubusercontent.com/alphagov/govuk-infrastructure/refs/heads/main/cacerts/zscaler-root-ca.pem \
+  && update-ca-certificates
+
 # Install chromium browser and its webdriver
 RUN apt-get update -qq && \
   apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Any encrypted requests that get intercepted by and proxied through Zscaler fail because Zscaler terminates and re-encrypts TLS connections, and because Zscaler's root CA certificate isn't part of the container's trust store, these requests fail.

This change, adding Zscaler's root CA certificate into the base container's trust store, means we accept Zscaler acting as man in the middle, intercepting, inspecting and re-encrypting select SSL connections, and ensuring these connections don't break when Zscaler does it.

The missing root CA certificate and consequential error prevents, e.g., running Pact tests, which are trying to access our Pact broker (https://govuk-pact-broker-6991351eca05.herokuapp.com). The following apps have Pact tests are directly affected by this:

- Asset Manager
- Content Store
- Link Checker API
- Publishing API
- Signon
- Support API
