### PR TITLE
Add the Zscaler root CA cert to asset-manager

### DIFF
--- a/projects/asset-manager/Dockerfile
+++ b/projects/asset-manager/Dockerfile
@@ -1,6 +1,11 @@
 # Install packages for building ruby
 FROM buildpack-deps:trixie
 
+# Trust the ZScaler root CA so HTTPS URLs work behing the corporate proxy
+RUN curl -fsSL -o /usr/local/share/ca-certificates/zscaler-root-ca.crt \
+  https://raw.githubusercontent.com/alphagov/govuk-infrastructure/refs/heads/main/cacerts/zscaler-root-ca.pem \
+  && update-ca-certificates
+
 # Install chromium browser and its webdriver
 RUN apt-get update -qq && apt-get install -y chromium chromium-driver
 


### PR DESCRIPTION
As a follow up to 054da93, adding the root CA cert to the base Dockerfile, this change ensures asset-manager also gets the cert, because it doesn't use the base Dockerfile but has its own.

The same is true for the following four projects, but I'll skip them as they don't have any Pact tests that need to make HTTPS requests:

- content-block-manager
- govuk_crawler_worker
- router
- whitehall